### PR TITLE
[Optimize] Remove importing CoreGraphics on Darwin for CGFloat

### DIFF
--- a/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/AlignmentID.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/AlignmentID.swift
@@ -5,11 +5,7 @@
 //  Audited for RELEASE_2021
 //  Status: Complete
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 /// A type that you use to create custom alignment guides.
 ///

--- a/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/HorizontalAlignment.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/HorizontalAlignment.swift
@@ -6,11 +6,7 @@
 //  Status: Complete
 //  ID: E20796D15DD3D417699102559E024115
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 /// An alignment position along the horizontal axis.
 ///

--- a/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/VerticalAlignment.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/VerticalAlignment.swift
@@ -6,11 +6,7 @@
 //  Status: Complete
 //  ID: E20796D15DD3D417699102559E024115
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 /// An alignment position along the vertical axis.
 ///

--- a/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/ViewDimensions.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Alignment/ViewDimensions.swift
@@ -5,11 +5,7 @@
 //  Audited for RELEASE_2021
 //  Status: Complete
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 /// A view's size and alignment guides in its own coordinate space.
 ///

--- a/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Edge/EdgeInsets.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutAdjustments/Edge/EdgeInsets.swift
@@ -5,11 +5,7 @@
 //  Audited for RELEASE_2021
 //  Status: Complete
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 /// The inset distances for the sides of a rectangle.
 @frozen

--- a/Sources/OpenSwiftUI/Layout/LayoutFundamentals/Stack/HStack.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutFundamentals/Stack/HStack.swift
@@ -1,8 +1,4 @@
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 @frozen
 public struct HStack<Content: View>: PrimitiveView {

--- a/Sources/OpenSwiftUI/Layout/LayoutFundamentals/Stack/_HStackLayout.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutFundamentals/Stack/_HStackLayout.swift
@@ -1,8 +1,4 @@
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 @frozen
 public struct _HStackLayout {

--- a/Sources/OpenSwiftUI/Layout/LayoutFundamentals/internal/LayoutComputer.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutFundamentals/internal/LayoutComputer.swift
@@ -5,11 +5,7 @@
 //  Audited for RELEASE_2021
 //  Status: WIP
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 // TODO:
 struct LayoutComputer: Equatable {

--- a/Sources/OpenSwiftUI/Layout/LayoutFundamentals/internal/Spacing.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutFundamentals/internal/Spacing.swift
@@ -6,11 +6,7 @@
 //  Status: TODO
 //  ID: 127A76D3C8081D0134153BE9AE746714
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 struct Spacing {
     // TODO

--- a/Sources/OpenSwiftUI/Layout/LayoutFundamentals/internal/_ProposedSize.swift
+++ b/Sources/OpenSwiftUI/Layout/LayoutFundamentals/internal/_ProposedSize.swift
@@ -5,11 +5,7 @@
 //  Audited for RELEASE_2021
 //  Status: Complete
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 struct _ProposedSize: Hashable {
     var width: CGFloat?

--- a/Sources/OpenSwiftUI/Test/_BenchmarkHost.swift
+++ b/Sources/OpenSwiftUI/Test/_BenchmarkHost.swift
@@ -6,11 +6,7 @@
 //  Status: Complete
 //  ID: 3E629D505F0A70F29ACFC010AA42C6E0
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 #if canImport(QuartzCore)
 import QuartzCore

--- a/Sources/OpenSwiftUI/View/Animation/TODO/Animatable.swift
+++ b/Sources/OpenSwiftUI/View/Animation/TODO/Animatable.swift
@@ -41,11 +41,7 @@ extension Animatable where AnimatableData == EmptyAnimatableData {
     }
 }
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 // MARK: - Animatable + CoreGraphics
 

--- a/Sources/OpenSwiftUI/View/Animation/VectorArithmetic.swift
+++ b/Sources/OpenSwiftUI/View/Animation/VectorArithmetic.swift
@@ -56,11 +56,7 @@ extension Double: VectorArithmetic {
     }
 }
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 extension CGFloat: VectorArithmetic {
     @_transparent

--- a/Sources/OpenSwiftUI/View/Core/IdentifiedViewProxy.swift
+++ b/Sources/OpenSwiftUI/View/Core/IdentifiedViewProxy.swift
@@ -1,8 +1,4 @@
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 public struct _IdentifiedViewProxy {
     var identifier: AnyHashable

--- a/Sources/OpenSwiftUI/View/Core/ViewTransform.swift
+++ b/Sources/OpenSwiftUI/View/Core/ViewTransform.swift
@@ -1,10 +1,6 @@
 //  ID: CE19A3CEA6B9730579C42CE4C3071E74
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 struct ViewTransform {
     private var chunks: ContiguousArray<Chunk>

--- a/Sources/OpenSwiftUI/View/Text/Font/TODO/Font.swift
+++ b/Sources/OpenSwiftUI/View/Text/Font/TODO/Font.swift
@@ -1,8 +1,4 @@
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 @frozen
 public struct Font: Hashable {

--- a/Sources/OpenSwiftUI/View/Text/Text/TODO/Text.swift
+++ b/Sources/OpenSwiftUI/View/Text/Text/TODO/Text.swift
@@ -5,11 +5,7 @@
 //  Audited for RELEASE_2021
 //  Status: Empty
 
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 @frozen
 public struct Text: Equatable {

--- a/Tests/OpenSwiftUITests/Layout/LayoutAdjustments/Alignment/AlignmentIDTests.swift
+++ b/Tests/OpenSwiftUITests/Layout/LayoutAdjustments/Alignment/AlignmentIDTests.swift
@@ -7,11 +7,7 @@
 
 @testable import OpenSwiftUI
 import Testing
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 struct AlignmentIDTests {
     private struct TestAlignment: AlignmentID {

--- a/Tests/OpenSwiftUITests/View/Core/Debug/ViewDebugTests.swift
+++ b/Tests/OpenSwiftUITests/View/Core/Debug/ViewDebugTests.swift
@@ -7,11 +7,7 @@
 
 @testable import OpenSwiftUI
 import Testing
-#if canImport(Darwin)
-import CoreGraphics
-#else
 import Foundation
-#endif
 
 struct ViewDebugTests {
     @Test(.disabled("Skip the test until we finish the implementation of _ViewDebug"))


### PR DESCRIPTION
Many CG related struct definition has moved from `CoreGraphics` to `CoreFoundation`.

So we can just use `import Foundation` for all platforms.