### PR TITLE
Add DisplayGamut API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "394fa589a5a76e3ceafd3f71df512dd61ef2dc543eeef5abf1308cd86bf625c8",
+  "originHash" : "0b4bd4c9fead87239ae31a73097366993adb4ca8c166658de631281043ce9936",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,8 @@ let openSwiftUISPITarget = Target.target(
     ],
     publicHeadersPath: ".",
     cSettings: sharedCSettings + [.define("_GNU_SOURCE", .when(platforms: .nonDarwinPlatforms))],
-    cxxSettings: sharedCxxSettings
+    cxxSettings: sharedCxxSettings,
+    linkerSettings: [.unsafeFlags(["-lMobileGestalt"], .when(platforms: .darwinPlatforms))] // For MGCopyAnswer API support
 )
 let coreGraphicsShims = Target.target(
     name: "CoreGraphicsShims",
@@ -423,6 +424,10 @@ if compatibilityTestCondition {
 }
 
 extension [Platform] {
+    static var darwinPlatforms: [Platform] {
+        [.macOS, .iOS, .macCatalyst, .tvOS, .watchOS, .visionOS]
+    }
+
     static var nonDarwinPlatforms: [Platform] {
         [.linux, .android, .wasi, .openbsd, .windows]
     }

--- a/Sources/OpenSwiftUICore/Graphic/Color/DisplayGamut.swift
+++ b/Sources/OpenSwiftUICore/Graphic/Color/DisplayGamut.swift
@@ -1,0 +1,30 @@
+//
+//  DisplayGamut.swift
+//  OpenSwiftUICore
+//
+//  Audited for iOS 18.0
+//  Status: Complete
+
+import OpenSwiftUI_SPI
+
+@_spi(Private)
+public enum DisplayGamut: Int {
+    case sRGB
+    case displayP3
+
+    package static var deviceDefault: DisplayGamut {
+        #if canImport(Darwin)
+        switch _CUIDefaultDisplayGamut() {
+        case .SRGB: .sRGB
+        case .P3: .displayP3
+        }
+        #else
+        return .sRGB
+        #endif
+    }
+}
+
+@available(*, unavailable)
+extension DisplayGamut: Sendable {}
+
+extension DisplayGamut: ProtobufEnum {}

--- a/Sources/OpenSwiftUI_SPI/Overlay/CoreUI/CUIDefaultDisplayGamut.h
+++ b/Sources/OpenSwiftUI_SPI/Overlay/CoreUI/CUIDefaultDisplayGamut.h
@@ -1,0 +1,24 @@
+//
+//  CUIDefaultDisplayGamut.h
+//  OpenSwiftUI_SPI
+//
+//  Audited for iOS 18.0
+//  Status: Complete
+
+#ifndef CUIDefaultDisplayGamut_h
+#define CUIDefaultDisplayGamut_h
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+typedef CF_CLOSED_ENUM(uint32_t, CUIDisplayGamut) {
+    CUIDisplayGamutSRGB = 0,
+    CUIDisplayGamutP3 = 1,
+};
+
+CUIDisplayGamut _CUIDefaultDisplayGamut();
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN */
+
+#endif /* CUIDefaultDisplayGamut_h */

--- a/Sources/OpenSwiftUI_SPI/Overlay/CoreUI/CUIDefaultDisplayGamut.m
+++ b/Sources/OpenSwiftUI_SPI/Overlay/CoreUI/CUIDefaultDisplayGamut.m
@@ -1,0 +1,28 @@
+//
+//  _CUIDefaultDisplayGamut.m
+//  OpenSwiftUI_SPI
+//
+//  Audited for iOS 18.0
+//  Status: Complete
+
+#include "CUIDefaultDisplayGamut.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#include "../../Shims/libMobileGestalt/MobileGestalt.h"
+
+CUIDisplayGamut _CUIDefaultDisplayGamut() {
+    static CUIDisplayGamut defaultGamut;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSString *answer = (__bridge NSString *)(MGCopyAnswer((__bridge CFStringRef)@"ArtworkTraitDisplayGamut", nil));
+        if ([answer isEqualToString:@"P3"]) {
+            defaultGamut = CUIDisplayGamutP3;
+        } else {
+            defaultGamut = CUIDisplayGamutSRGB;
+        }
+    });
+    return defaultGamut;
+}
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN */

--- a/Sources/OpenSwiftUI_SPI/Shims/libMobileGestalt/MobileGestalt.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/libMobileGestalt/MobileGestalt.h
@@ -1,0 +1,213 @@
+// https://github.com/davidmurray/ios-reversed-headers
+// LICENSE: GPL-3.0 license
+
+/*
+ * libMobileGestalt header.
+ * Mobile gestalt functions as a QA system. You ask it a question, and it gives you the answer! :)
+ *
+ * Copyright (c) 2013-2014 Cykey (David Murray)
+ * All rights reserved.
+ */
+
+#ifndef LIBMOBILEGESTALT_H_
+#define LIBMOBILEGESTALT_H_
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#include <sys/cdefs.h>
+
+typedef enum {
+    MGDeviceClassInvalid        = -1,
+    /* 0 is intentionally not in this enum */
+    MGDeviceClassiPhone         = 1,
+    MGDeviceClassiPod           = 2,
+    MGDeviceClassiPad           = 3,
+    MGDeviceClassAppleTV        = 4,
+    MGDeviceClassiFPGA           = 5,
+    MGDeviceClassWatch          = 6,
+    MGDeviceClassAudioAccessory = 7,
+    MGDeviceClassiBridge        = 8,
+    MGDeviceClassMac            = 9,
+    MGDeviceClassAppleDisplay   = 10,
+} MGDeviceClass;
+
+#pragma mark - API
+
+FOUNDATION_EXPORT CFTypeRef MGCopyAnswer(CFStringRef question, CFDictionaryRef options);
+FOUNDATION_EXPORT CFTypeRef MGCopyAnswerWithError(CFStringRef question, CFDictionaryRef options, int *error);
+
+FOUNDATION_EXPORT bool MGGetBoolAnswer(CFStringRef question);
+FOUNDATION_EXPORT bool MGIsQuestionValid(CFStringRef question);
+
+FOUNDATION_EXPORT SInt32 MGGetSInt32Answer(CFStringRef question, SInt32 defaultValue);
+FOUNDATION_EXPORT SInt64 MGGetSInt64Answer(CFStringRef question, SInt64 defaultValue);
+
+FOUNDATION_EXPORT Float32 MGGetFloat32Answer(CFStringRef question, Float32 defaultValue);
+
+FOUNDATION_EXPORT CFPropertyListRef MGCopyMultipleAnswers(CFArrayRef questions, CFDictionaryRef options);
+
+FOUNDATION_EXPORT CF_RETURNS_RETAINED CFStringRef MGGetStringAnswer(CFStringRef question);
+
+/*
+ * Not all questions are assignable.
+ * For example, kMGUserAssignedDeviceName is assignable but
+ * kMGProductType is not.
+ */
+FOUNDATION_EXPORT int MGSetAnswer(CFStringRef question, CFTypeRef answer);
+
+#pragma mark - Identifying Information
+
+static const CFStringRef kMGDiskUsage = CFSTR("DiskUsage");
+static const CFStringRef kMGModelNumber = CFSTR("ModelNumber");
+static const CFStringRef kMGSIMTrayStatus = CFSTR("SIMTrayStatus");
+static const CFStringRef kMGSerialNumber = CFSTR("SerialNumber");
+static const CFStringRef kMGMLBSerialNumber = CFSTR("MLBSerialNumber");
+static const CFStringRef kMGUniqueDeviceID = CFSTR("UniqueDeviceID");
+static const CFStringRef kMGUniqueDeviceIDData = CFSTR("UniqueDeviceIDData");
+static const CFStringRef kMGUniqueChipID = CFSTR("UniqueChipID");
+static const CFStringRef kMGInverseDeviceID = CFSTR("InverseDeviceID");
+static const CFStringRef kMGDiagnosticsData = CFSTR("DiagData");
+static const CFStringRef kMGDieID = CFSTR("DieId");
+static const CFStringRef kMGCPUArchitecture = CFSTR("CPUArchitecture");
+static const CFStringRef kMGPartitionType = CFSTR("PartitionType");
+static const CFStringRef kMGUserAssignedDeviceName = CFSTR("UserAssignedDeviceName");
+
+#pragma mark - Bluetooth Information
+
+static const CFStringRef kMGBluetoothAddress = CFSTR("BluetoothAddress");
+
+#pragma mark - Battery Information
+
+static const CFStringRef kMGRequiredBatteryLevelForSoftwareUpdate = CFSTR("RequiredBatteryLevelForSoftwareUpdate");
+static const CFStringRef kMGBatteryIsFullyCharged = CFSTR("BatteryIsFullyCharged");
+static const CFStringRef kMGBatteryIsCharging = CFSTR("BatteryIsCharging");
+static const CFStringRef kMGBatteryCurrentCapacity = CFSTR("BatteryCurrentCapacity");
+static const CFStringRef kMGExternalPowerSourceConnected = CFSTR("ExternalPowerSourceConnected");
+
+#pragma mark - Baseband Information
+
+static const CFStringRef kMGBasebandSerialNumber = CFSTR("BasebandSerialNumber");
+static const CFStringRef kMGBasebandCertId = CFSTR("BasebandCertId");
+static const CFStringRef kMGBasebandChipId = CFSTR("BasebandChipId");
+static const CFStringRef kMGBasebandFirmwareManifestData = CFSTR("BasebandFirmwareManifestData");
+static const CFStringRef kMGBasebandFirmwareVersion = CFSTR("BasebandFirmwareVersion");
+static const CFStringRef kMGBasebandKeyHashInformation = CFSTR("BasebandKeyHashInformation");
+
+#pragma mark - Telephony Information
+
+static const CFStringRef kMGCarrierBundleInfo = CFSTR("CarrierBundleInfoArray");
+static const CFStringRef kMGCarrierInstallCapability = CFSTR("CarrierInstallCapability");
+static const CFStringRef kMGInternationalMobileEquipmentIdentity = CFSTR("InternationalMobileEquipmentIdentity");
+static const CFStringRef kMGMobileSubscriberCountryCode = CFSTR("MobileSubscriberCountryCode");
+static const CFStringRef kMGMobileSubscriberNetworkCode = CFSTR("MobileSubscriberNetworkCode");
+
+#pragma mark - Device Information
+
+static const CFStringRef kMGChipID = CFSTR("ChipID");
+static const CFStringRef kMGComputerName = CFSTR("ComputerName");
+static const CFStringRef kMGDeviceVariant = CFSTR("DeviceVariant");
+static const CFStringRef kMGHWModel = CFSTR("HWModelStr");
+static const CFStringRef kMGBoardId = CFSTR("BoardId");
+static const CFStringRef kMGHardwarePlatform = CFSTR("HardwarePlatform");
+static const CFStringRef kMGDeviceName = CFSTR("DeviceName");
+static const CFStringRef kMGDeviceColor = CFSTR("DeviceColor");
+static const CFStringRef kMGDeviceClassNumber = CFSTR("DeviceClassNumber");
+static const CFStringRef kMGDeviceClass = CFSTR("DeviceClass");
+static const CFStringRef kMGBuildVersion = CFSTR("BuildVersion");
+static const CFStringRef kMGProductName = CFSTR("ProductName");
+static const CFStringRef kMGProductType = CFSTR("ProductType");
+static const CFStringRef kMGProductVersion = CFSTR("ProductVersion");
+static const CFStringRef kMGFirmwareNonce = CFSTR("FirmwareNonce");
+static const CFStringRef kMGFirmwareVersion = CFSTR("FirmwareVersion");
+static const CFStringRef kMGFirmwarePreflightInfo = CFSTR("FirmwarePreflightInfo");
+static const CFStringRef kMGIntegratedCircuitCardIdentifier = CFSTR("IntegratedCircuitCardIdentifier");
+static const CFStringRef kMGAirplaneMode = CFSTR("AirplaneMode");
+static const CFStringRef kMGAllowYouTube = CFSTR("AllowYouTube");
+static const CFStringRef kMGAllowYouTubePlugin = CFSTR("AllowYouTubePlugin");
+static const CFStringRef kMGMinimumSupportediTunesVersion = CFSTR("MinimumSupportediTunesVersion");
+static const CFStringRef kMGProximitySensorCalibration = CFSTR("ProximitySensorCalibration");
+static const CFStringRef kMGRegionCode = CFSTR("RegionCode");
+static const CFStringRef kMGRegionInfo = CFSTR("RegionInfo");
+static const CFStringRef kMGRegulatoryIdentifiers = CFSTR("RegulatoryIdentifiers");
+static const CFStringRef kMGSBAllowSensitiveUI = CFSTR("SBAllowSensitiveUI");
+static const CFStringRef kMGSBCanForceDebuggingInfo = CFSTR("SBCanForceDebuggingInfo");
+static const CFStringRef kMGSDIOManufacturerTuple = CFSTR("SDIOManufacturerTuple");
+static const CFStringRef kMGSDIOProductInfo = CFSTR("SDIOProductInfo");
+static const CFStringRef kMGShouldHactivate = CFSTR("ShouldHactivate");
+static const CFStringRef kMGSigningFuse = CFSTR("SigningFuse");
+static const CFStringRef kMGSoftwareBehavior = CFSTR("SoftwareBehavior");
+static const CFStringRef kMGSoftwareBundleVersion = CFSTR("SoftwareBundleVersion");
+static const CFStringRef kMGSupportedDeviceFamilies = CFSTR("SupportedDeviceFamilies");
+static const CFStringRef kMSupportedKeyboards = CFSTR("SupportedKeyboards");
+static const CFStringRef kMGTotalSystemAvailable = CFSTR("TotalSystemAvailable");
+
+#pragma mark - Capability Information
+
+static const CFStringRef kMGAllDeviceCapabilities = CFSTR("AllDeviceCapabilities");
+static const CFStringRef kMGAppleInternalInstallCapability = CFSTR("AppleInternalInstallCapability");
+static const CFStringRef kMGExternalChargeCapability = CFSTR("ExternalChargeCapability");
+static const CFStringRef kMGForwardCameraCapability = CFSTR("ForwardCameraCapability");
+static const CFStringRef kMGPanoramaCameraCapability = CFSTR("PanoramaCameraCapability");
+static const CFStringRef kMGRearCameraCapability = CFSTR("RearCameraCapability");
+static const CFStringRef kMGHasAllFeaturesCapability = CFSTR("HasAllFeaturesCapability");
+static const CFStringRef kMGHasBaseband = CFSTR("HasBaseband");
+static const CFStringRef kMGHasInternalSettingsBundle = CFSTR("HasInternalSettingsBundle");
+static const CFStringRef kMGHasSpringBoard = CFSTR("HasSpringBoard");
+static const CFStringRef kMGInternalBuild = CFSTR("InternalBuild");
+static const CFStringRef kMGIsSimulator = CFSTR("IsSimulator");
+static const CFStringRef kMGIsThereEnoughBatteryLevelForSoftwareUpdate = CFSTR("IsThereEnoughBatteryLevelForSoftwareUpdate");
+static const CFStringRef kMGIsUIBuild = CFSTR("IsUIBuild");
+
+#pragma mark - Regional Behaviour
+
+static const CFStringRef kMGRegionalBehaviorAll = CFSTR("RegionalBehaviorAll");
+static const CFStringRef kMGRegionalBehaviorChinaBrick = CFSTR("RegionalBehaviorChinaBrick");
+static const CFStringRef kMGRegionalBehaviorEUVolumeLimit = CFSTR("RegionalBehaviorEUVolumeLimit");
+static const CFStringRef kMGRegionalBehaviorGB18030 = CFSTR("RegionalBehaviorGB18030");
+static const CFStringRef kMGRegionalBehaviorGoogleMail = CFSTR("RegionalBehaviorGoogleMail");
+static const CFStringRef kMGRegionalBehaviorNTSC = CFSTR("RegionalBehaviorNTSC");
+static const CFStringRef kMGRegionalBehaviorNoPasscodeLocationTiles = CFSTR("RegionalBehaviorNoPasscodeLocationTiles");
+static const CFStringRef kMGRegionalBehaviorNoVOIP = CFSTR("RegionalBehaviorNoVOIP");
+static const CFStringRef kMGRegionalBehaviorNoWiFi = CFSTR("RegionalBehaviorNoWiFi");
+static const CFStringRef kMGRegionalBehaviorShutterClick = CFSTR("RegionalBehaviorShutterClick");
+static const CFStringRef kMGRegionalBehaviorVolumeLimit = CFSTR("RegionalBehaviorVolumeLimit");
+
+#pragma mark - Wireless Information
+
+static const CFStringRef kMGActiveWirelessTechnology = CFSTR("ActiveWirelessTechnology");
+static const CFStringRef kMGWifiAddress = CFSTR("WifiAddress");
+static const CFStringRef kMGWifiAddressData = CFSTR("WifiAddressData");
+static const CFStringRef kMGWifiVendor = CFSTR("WifiVendor");
+
+#pragma mark - FaceTime Information
+
+static const CFStringRef kMGFaceTimeBitRate2G = CFSTR("FaceTimeBitRate2G");
+static const CFStringRef kMGFaceTimeBitRate3G = CFSTR("FaceTimeBitRate3G");
+static const CFStringRef kMGFaceTimeBitRateLTE = CFSTR("FaceTimeBitRateLTE");
+static const CFStringRef kMGFaceTimeBitRateWiFi = CFSTR("FaceTimeBitRateWiFi");
+static const CFStringRef kMGFaceTimeDecodings = CFSTR("FaceTimeDecodings");
+static const CFStringRef kMGFaceTimeEncodings = CFSTR("FaceTimeEncodings");
+static const CFStringRef kMGFaceTimePreferredDecoding = CFSTR("FaceTimePreferredDecoding");
+static const CFStringRef kMGFaceTimePreferredEncoding = CFSTR("FaceTimePreferredEncoding");
+
+#pragma mark - More Device Capabilities
+
+static const CFStringRef kMGDeviceSupportsFaceTime = CFSTR("DeviceSupportsFaceTime");
+static const CFStringRef kMGDeviceSupportsTethering = CFSTR("DeviceSupportsTethering");
+static const CFStringRef kMGDeviceSupportsSimplisticRoadMesh = CFSTR("DeviceSupportsSimplisticRoadMesh");
+static const CFStringRef kMGDeviceSupportsNavigation = CFSTR("DeviceSupportsNavigation");
+static const CFStringRef kMGDeviceSupportsLineIn = CFSTR("DeviceSupportsLineIn");
+static const CFStringRef kMGDeviceSupports9Pin = CFSTR("DeviceSupports9Pin");
+static const CFStringRef kMGDeviceSupports720p = CFSTR("DeviceSupports720p");
+static const CFStringRef kMGDeviceSupports4G = CFSTR("DeviceSupports4G");
+static const CFStringRef kMGDeviceSupports3DMaps = CFSTR("DeviceSupports3DMaps");
+static const CFStringRef kMGDeviceSupports3DImagery = CFSTR("DeviceSupports3DImagery");
+static const CFStringRef kMGDeviceSupports1080p = CFSTR("DeviceSupports1080p");
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN */
+
+#endif /* LIBMOBILEGESTALT_H_ */

--- a/Tests/OpenSwiftUICoreTests/Graphics/Color/DisplayGamutTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Graphics/Color/DisplayGamutTests.swift
@@ -1,0 +1,23 @@
+//
+//  DisplayGamutTests.swift
+//  OpenSwiftUICoreTests
+
+@_spi(Private)
+import OpenSwiftUICore
+import Testing
+
+struct DisplayGamutTests {
+    @Test
+    func enumInit() {
+        #expect(DisplayGamut(rawValue: 0) == .sRGB)
+        #expect(DisplayGamut(rawValue: 1) == .displayP3)
+        #expect(DisplayGamut(rawValue: 2) == nil)
+    }
+
+    @Test
+    func deviceDefault() {
+        let defaultGamut = DisplayGamut.deviceDefault
+        // For old devices, the defult may not be displayP3
+        #expect(defaultGamut == .displayP3 || defaultGamut == .sRGB)
+    }
+}


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#7C0l3BJNd`](https://gitbutler.com/kyle-ye/openswiftui/reviews/7C0l3BJNd)

**Add DisplayGamut API**


1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [Add DisplayGamut API](https://gitbutler.com/kyle-ye/openswiftui/reviews/7C0l3BJNd/commit/7977e2da-1973-4dfd-9c16-02e2f8f8b5aa) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/kyle-ye/openswiftui/reviews/7C0l3BJNd)_
<!-- GitButler Review Footer Boundary Bottom -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced display color management now automatically selects the optimal color gamut (sRGB or P3) based on your device, ensuring improved visual consistency.
  - Improved Apple platform integration enhances overall compatibility and performance across supported devices.

- **Chores**
  - Updated dependency configuration for seamless package integrity management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->