### PR TITLE
Update License information

### DIFF
--- a/Docs/AvailabilityVersions/README.md
+++ b/Docs/AvailabilityVersions/README.md
@@ -41,3 +41,7 @@ When updating the project to support new OS versions:
 
 - [The Apple Wiki Timeline](https://theapplewiki.com/wiki/Timeline)
 - [Apple OSS Distributions](https://github.com/apple-oss-distributions/AvailabilityVersions)
+
+## License
+
+[APSL](http://www.opensource.apple.com/apsl/)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Kyle-Ye
+Copyright (c) 2023-2025 Kyle-Ye
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ for various platforms:
 
 ## License
 
-See LICENSE file - MIT
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+Part of the header file is from Apple Open Source project which is license under APSL
 
 ## Related Projects
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "License" section to the documentation with a reference to the Apple Public Source License (APSL).
  - Expanded the License section in the README to clarify licensing details and acknowledge use of Apple Open Source code.
- **Chores**
  - Updated the copyright year range in the MIT License to 2023-2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->