### PR TITLE
Fix AtomicBox deinit issue

### DIFF
--- a/Sources/OpenSwiftUICore/Util/ThreadUtils.swift
+++ b/Sources/OpenSwiftUICore/Util/ThreadUtils.swift
@@ -95,6 +95,12 @@ private final class AtomicBuffer<Value>: ManagedBuffer<os_unfair_lock_s, Value> 
         }
         return unsafeDowncast(buffer, to: AtomicBuffer<Value>.self)
     }
+
+    deinit {
+        withUnsafeMutablePointerToElements { pointer in
+            _ = pointer.deinitialize(count: 1)
+        }
+    }
 }
 #else
 private final class AtomicBuffer<Value>: ManagedBuffer<NSLock, Value> {
@@ -106,6 +112,12 @@ private final class AtomicBuffer<Value>: ManagedBuffer<NSLock, Value> {
             pointer.initialize(to: value)
         }
         return unsafeDowncast(buffer, to: AtomicBuffer<Value>.self)
+    }
+
+    deinit {
+        withUnsafeMutablePointerToElements { pointer in
+            _ = pointer.deinitialize(count: 1)
+        }
     }
 }
 #endif

--- a/Tests/OpenSwiftUICoreTests/Util/ThreadUtilsTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Util/ThreadUtilsTests.swift
@@ -55,4 +55,27 @@ struct AtomicBoxTests {
         @AtomicBox var box: Int = 3
         #expect($box.access { $0.description } == "3")
     }
+
+    @Test
+    func deinitCheck() async throws {
+        final class DeinitCheck {
+            let confirmation: Confirmation
+
+            init(confirmation: Confirmation) {
+                self.confirmation = confirmation
+            }
+
+            deinit {
+                confirmation()
+            }
+        }
+
+        func deinitCheck(_ confirmation: Confirmation) {
+            @AtomicBox var check = DeinitCheck(confirmation: confirmation)
+        }
+
+        await confirmation { confirmation in
+            deinitCheck(confirmation)
+        }
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced memory management by ensuring proper cleanup of atomic buffers during deallocation across all platforms.

- **Tests**
  - Added a test to confirm that objects wrapped in atomic containers are correctly deinitialized and cleanup actions are triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->