### PR TITLE
Enable selection and execution of multiple Shared Example samples in HostingExample (iOS only)

### DIFF
--- a/Example/HostingExample/Base.lproj/Main.storyboard
+++ b/Example/HostingExample/Base.lproj/Main.storyboard
@@ -6,19 +6,48 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Navigation Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                <navigationController id="BYZ-38-t0r" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="j3x-C4-Xhv">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="YgN-hb-4sP" kind="relationship" relationship="rootViewController" id="kpN-4l-Tk5"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yKT-vi-MvO" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+        <!--Table View Controller-->
+        <scene sceneID="tFJ-Hc-EiD">
+            <objects>
+                <tableViewController id="YgN-hb-4sP" customClass="ViewController" customModule="HostingExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" id="gqq-0N-dJ8">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="d8e-d1-pIp">
+                                <rect key="frame" x="0.0" y="44" width="393" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="d8e-d1-pIp" id="NjJ-Kk-kUr">
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="HostingExample" id="aPi-rZ-aYl"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fQ8-Hf-a1l" sceneMemberID="firstResponder"/>
             </objects>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/HostingExample/ViewController.swift
+++ b/Example/HostingExample/ViewController.swift
@@ -18,30 +18,102 @@ import AppKit
 #endif
 
 #if os(iOS)
-class ViewController: UINavigationController {
-    override func viewDidAppear(_ animated: Bool) {
-        pushViewController(EntryViewController(), animated: false)
+final class ViewController: UITableViewController {
+    private enum Section {
+        case animation([AnimationRow])
+        case view([ViewRow])
     }
-}
 
-final class EntryViewController: UIViewController {
+    private enum AnimationRow: CaseIterable {
+        case completion
+        case color
+        case spring
+    }
+
+    private enum ViewRow: CaseIterable {
+        case conditional
+        case equatable
+        case namespace
+    }
+
+    private let sections: [Section] = [
+        .animation(AnimationRow.allCases),
+        .view(ViewRow.allCases),
+    ]
+
     override func viewDidLoad() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "Push",
-            style: .plain,
-            target: self,
-            action: #selector(pushHostingVC)
-        )
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.pushHostingVC()
+        super.viewDidLoad()
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    }
+
+    // MARK: - UITableViewDelegate
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        sections.count
+    }
+
+    override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let navigationController else { return }
+        let hostingVC: UIViewController
+        switch sections[indexPath.section] {
+        case .animation(let rows):
+            switch rows[indexPath.row] {
+            case .completion:
+                hostingVC = UIHostingController(rootView: AnimationCompleteExample())
+            case .color:
+                hostingVC = UIHostingController(rootView: ColorAnimationExample())
+            case .spring:
+                hostingVC = UIHostingController(rootView: SpringAnimationExample())
+            }
+        case .view(let rows):
+            switch rows[indexPath.row] {
+            case .conditional:
+                hostingVC = UIHostingController(rootView: ConditionalContentExample())
+            case .equatable:
+                hostingVC = UIHostingController(rootView: EquatableDemoView(count: 1, tag: 1))
+            case .namespace:
+                hostingVC = UIHostingController(rootView: NamespaceExample())
+            }
+        }
+        hostingVC.title = titleForRow(at: indexPath)
+        navigationController.pushViewController(hostingVC, animated: true)
+    }
+
+    // MARK: - UITableViewDataSource
+    override func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch sections[section] {
+        case .animation: "Animation"
+        case .view: "View"
         }
     }
 
-    @objc
-    private func pushHostingVC() {
-        guard let navigationController else { return }
-        let hostingVC = UIHostingController(rootView: ContentView())
-        navigationController.pushViewController(hostingVC, animated: true)
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch sections[section] {
+        case .animation(let rows): rows.count
+        case .view(let rows): rows.count
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        cell.textLabel?.text = titleForRow(at: indexPath)
+        return cell
+    }
+
+    private func titleForRow(at indexPath: IndexPath) -> String {
+        switch sections[indexPath.section] {
+        case .animation(let rows):
+            switch rows[indexPath.row] {
+            case .color: "Color Animation"
+            case .completion: "Animation Completion"
+            case .spring: "Spring Animation"
+            }
+        case .view(let rows):
+            switch rows[indexPath.row] {
+            case .conditional: "Conditional Content"
+            case .equatable: "Equatable Demo"
+            case .namespace: "Namespace Example"
+            }
+        }
     }
 }
 #elseif os(macOS)


### PR DESCRIPTION
### Summary
Currently, HostingExample supports running only a single sample code.  
This change replaces the UINavigationController with a UITableViewController to display multiple Shared Example samples categorized into sections.  
Users can select a sample from the list and view it via a pushed UIHostingController.

### Major changes
- Replaced single-sample UINavigationController with UITableViewController providing a multi-sample selection UI
- Categorized samples into two sections: Animation and View samples
- On cell selection, push the corresponding SwiftUI view in a UIHostingController
- Modified storyboard to use Navigation Controller + Table View Controller setup

### Notes
- This PR implements the feature only for iOS; macOS support is not included yet.  
  I want to confirm if this approach is acceptable before implementing macOS version.
- Layout-related sample code is not supported in this implementation.
- The following demo video illustrates how the new multi-sample selection UI works.  
<video src="https://github.com/user-attachments/assets/8630f58d-57a5-481f-80e2-63c8240e25a2"></video>
