### PR TITLE
Update documentation links for OpenObservation and OpenCombine

### DIFF
--- a/Sources/OpenSwiftUI/OpenSwiftUI.docc/DataAndStorage/ModelData/Managing-model-data-in-your-app.md
+++ b/Sources/OpenSwiftUI/OpenSwiftUI.docc/DataAndStorage/ModelData/Managing-model-data-in-your-app.md
@@ -20,16 +20,15 @@ thanks to Observation. With Observation, a view in OpenSwiftUI can form
 dependencies on observable data models and update the UI when data changes.
 
 > Note:
-> [Observation](https://developer.apple.com/documentation/observation) support
-> in OpenSwiftUI is available starting with iOS 17, iPadOS 17, macOS 14,
-> tvOS 17, and watchOS 10. For information about adopting Observation in
+> [OpenObservation](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation) support
+> in OpenSwiftUI has no explicit availability limit. For information about adopting Observation in
 > existing apps, see
 > [Migrating from the Observable Object protocol to the Observable macro](https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro).
 
 ### Make model data observable
 
 To make data changes visible to OpenSwiftUI, apply the
-[Observable()](https://developer.apple.com/documentation/observation/observable())
+[Observable()](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable())
 macro to your data model. This macro generates code that adds observation
 support to your data model at compile time, keeping your data model code focused
 on the properties that store data. For example, the following code defines a
@@ -48,10 +47,10 @@ type to use for your data model, see
 [Choosing Between Structures and Classes](https://developer.apple.com/documentation/swift/choosing-between-structures-and-classes).
 
 > Important:
-> The [Observable()](https://developer.apple.com/documentation/observation/observable())
+> The [Observable()](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable())
 > macro, in addition to adding observation functionality, also conforms your
 > data model type to the
-> [Observable](https://developer.apple.com/documentation/observation/observable)
+> [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
 > protocol, which serves as a signal to other APIs that your type supports
 > observation. Don’t apply the `Observable` protocol by itself to your data
 > model type, since that alone doesn’t add any observation functionality.
@@ -473,7 +472,7 @@ struct BookEditView: View {
 ```
 
 You can use the ``Bindable`` property wrapper on properties and variables to an
-[Observable](https://developer.apple.com/documentation/observation/observable)
+[Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
 object. This includes global variables, properties that exists outside of
 OpenSwiftUI types, or even local variables. For example, you can create a
 `@Bindable` variable within a view’s ``View/body-swift.property``:

--- a/Sources/OpenSwiftUICore/Data/Binding/Binding.swift
+++ b/Sources/OpenSwiftUICore/Data/Binding/Binding.swift
@@ -52,7 +52,7 @@
 /// `isPlaying` state.
 ///
 /// > Note: To create bindings to properties of a type that conforms to the
-/// [Observable](https://developer.apple.com/documentation/Observation/Observable)
+/// [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
 /// protocol, use the ``Bindable`` property wrapper. For more information,
 /// see <doc:Migrating-from-the-observable-object-protocol-to-the-observable-macro>.
 @frozen

--- a/Sources/OpenSwiftUICore/Data/Environment/Environment.swift
+++ b/Sources/OpenSwiftUICore/Data/Environment/Environment.swift
@@ -52,7 +52,7 @@ public import os
 ///
 /// You can also use `Environment` to get an observable object from a view's
 /// environment. The observable object must conform to the
-/// <doc://com.apple.documentation/documentation/Observation/Observable>
+/// [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
 /// protocol, and your app must set the object in the environment using the
 /// the object itself or a key path.
 ///

--- a/Sources/OpenSwiftUICore/Data/State/ObservedObject.swift
+++ b/Sources/OpenSwiftUICore/Data/State/ObservedObject.swift
@@ -16,7 +16,7 @@ public import Combine
 ///
 /// Add the `@ObservedObject` attribute to a parameter of an OpenSwiftUI ``View``
 /// when the input is an
-/// [ObservableObject](https://developer.apple.com/documentation/combine/observableobject)
+/// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
 /// and you want the view to update when the object's published properties
 /// change. You typically do this to pass a ``StateObject`` into a subview.
 ///
@@ -57,13 +57,13 @@ public import Combine
 /// above example.
 ///
 /// > Note: Don't wrap objects conforming to the
-/// [Observable](https://developer.apple.com/documentation/Observation/Observable)
+/// [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
 /// protocol with `@ObservedObject`. OpenSwiftUI automatically tracks dependencies
 /// to `Observable` objects used within body and updates dependent views when
 /// their data changes. Attempting to wrap an `Observable` object with
 /// `@ObservedObject` may cause a compiler error, because it requires that its
 /// wrapped object to conform to the
-/// [ObservableObject](https://developer.apple.com/documentation/combine/observableobject)
+/// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
 /// protocol.
 /// >
 /// > If the view needs a binding to a property of an `Observable` object in

--- a/Sources/OpenSwiftUICore/Data/State/StateObject.swift
+++ b/Sources/OpenSwiftUICore/Data/State/StateObject.swift
@@ -17,7 +17,7 @@ public import Combine
 /// you store in a view hierarchy. Create a state object in an ``App``,
 /// ``Scene``, or ``View`` by applying the `@StateObject` attribute to a
 /// property declaration and providing an initial value that conforms to the
-/// [ObservableObject](https://developer.apple.com/documentation/combine/observableobject)
+/// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
 /// protocol. Declare state objects as private to prevent setting them from a
 /// memberwise initializer, which can conflict with the storage management that
 /// OpenSwiftUI provides:
@@ -47,7 +47,7 @@ public import Combine
 /// > Note: If you need to store a value type, like a structure, string, or
 ///   integer, use the ``State`` property wrapper instead. Also use ``State``
 ///   if you need to store a reference type that conforms to the
-///   [Observable](https://developer.apple.com/documentation/observation/observable())
+///   [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable())
 ///   protocol. To learn more about Observation in OpenSwiftUI, see
 ///   <doc:Managing-model-data-in-your-app>.
 ///


### PR DESCRIPTION
## Summary
- Updated documentation links to point to OpenObservation and OpenCombine repositories
- Added GitBulter workflow rules to CLAUDE.md

## Changes
- Updated doc links in the codebase to reference the correct OpenSwiftUIProject repositories
- Enhanced CLAUDE.md with Git and GitHub workflow section for GitBulter compatibility

## Test plan
- [x] Documentation links are correct and accessible
- [x] CLAUDE.md properly documents GitBulter workflow requirements