### PR TITLE
Mics fix for EmptyView and TupleView

### DIFF
--- a/Sources/OpenSwiftUICore/View/EmptyView.swift
+++ b/Sources/OpenSwiftUICore/View/EmptyView.swift
@@ -42,6 +42,6 @@ public struct EmptyView: PrimitiveView {
 
     @available(OpenSwiftUI_v2_0, *)
     nonisolated public static func _viewListCount(inputs: _ViewListCountInputs) -> Int? {
-        0
+        inputs.options.contains(.isNonEmptyParent) ? 1 : 0
     }
 }

--- a/Tests/OpenSwiftUICoreTests/View/EmptyViewTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/EmptyViewTests.swift
@@ -1,0 +1,20 @@
+//
+//  EmptyViewTests.swift
+//  OpenSwiftUICoreTests
+
+@_spi(ForOpenSwiftUIOnly)
+import OpenSwiftUICore
+import Testing
+
+struct EmptyViewTests {
+    @Test("Test EmptyView._viewListCount with various options")
+    func viewListCount() {
+        let base = _ViewListCountInputs(.init(.invalid))
+        var inputs = base
+        inputs.options = []
+        #expect(EmptyView._viewListCount(inputs: inputs) == 0)
+
+        inputs.options = [.isNonEmptyParent]
+        #expect(EmptyView._viewListCount(inputs: inputs) == 1)
+    }
+}


### PR DESCRIPTION
- Fix TupleView._makeViewList to use makeList.inputs instead of original inputs parameter in concat calls
- Update EmptyView._viewListCount to respect .isNonEmptyParent option
- Add unit tests for EmptyView._viewListCount