### PR TITLE
Add test cases to track safeAreaPadding and GeometryReader safe area issues

### DIFF
--- a/Example/OpenSwiftUIUITests/Layout/Geometry/GeometryReaderUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/Geometry/GeometryReaderUITests.swift
@@ -8,7 +8,7 @@ import Testing
 @MainActor
 @Suite(.snapshots(record: .never, diffTool: diffTool))
 struct GeometryReaderUITests {
-    @Test
+    @Test(.bug("https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/474"))
     func centerView() {
         struct ContentView: View {
             var body: some View {
@@ -24,6 +24,13 @@ struct GeometryReaderUITests {
             }
         }
         openSwiftUIAssertSnapshot(of: ContentView())
+        #if OPENSWIFTUI
+        withKnownIssue {
+            openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
+        }
+        #else
+        openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
+        #endif
     }
 
     @Test

--- a/Example/OpenSwiftUIUITests/Layout/Geometry/GeometryReaderUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/Geometry/GeometryReaderUITests.swift
@@ -24,12 +24,14 @@ struct GeometryReaderUITests {
             }
         }
         openSwiftUIAssertSnapshot(of: ContentView())
+        #if os(iOS)
         #if OPENSWIFTUI
         withKnownIssue {
             openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
         }
         #else
         openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
+        #endif
         #endif
     }
 

--- a/Example/OpenSwiftUIUITests/Layout/Modifier/InsetViewModifierUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/Modifier/InsetViewModifierUITests.swift
@@ -4,6 +4,7 @@
 
 import Testing
 
+@MainActor
 struct InsetViewModifierUITests {
     @Test(.bug("https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/511"))
     func safeAreaPaddingWithEdgeInsets() {
@@ -15,10 +16,10 @@ struct InsetViewModifierUITests {
         }
         #if OPENSWIFTUI
         withKnownIssue {
-            openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
+            openSwiftUIAssertSnapshot(of: ContentView())
         }
         #else
-        openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
+        openSwiftUIAssertSnapshot(of: ContentView())
         #endif
     }
 }

--- a/Example/OpenSwiftUIUITests/Layout/Modifier/InsetViewModifierUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/Modifier/InsetViewModifierUITests.swift
@@ -1,0 +1,24 @@
+//
+//  InsetViewModifierUITests.swift
+//  OpenSwiftUIUITests
+
+import Testing
+
+struct InsetViewModifierUITests {
+    @Test(.bug("https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/511"))
+    func safeAreaPaddingWithEdgeInsets() {
+        struct ContentView: View {
+            var body: some View {
+                Color.red
+                    .safeAreaPadding(.init(top: 10, leading: 20, bottom: 30, trailing: 40))
+            }
+        }
+        #if OPENSWIFTUI
+        withKnownIssue {
+            openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
+        }
+        #else
+        openSwiftUIAssertSnapshot(of: ContentView(), as: .image)
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary

Adds test cases to track known visual rendering differences between OpenSwiftUI and SwiftUI for safe area handling: #511 and #474

## Changes

- Added InsetViewModifierUITests.swift in UI tests to track safeAreaPadding rendering differences
- Added GeometryReaderSafeAreaUITests.swift in UI tests to track GeometryReader safe area behavio
r
Both tests use withKnownIssue and .bug() tracking API to properly document expected failures
Tests pass with SwiftUI (reference behavior) and fail with known issues in OpenSwiftUI