### PR TITLE
Migrate to shared workflows from organization repository

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,39 +12,5 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-
+    uses: OpenSwiftUIProject/github-workflows/.github/workflows/claude.yml@main
+    secrets: inherit

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,76 +1,10 @@
 name: Issue Triage
+
 on:
   issues:
     types: [opened]
 
 jobs:
   triage-issue:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      issues: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Triage issue with Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          prompt: |
-            You're an issue triage assistant for GitHub issues. Your task is to analyze the issue and select appropriate labels from the provided list.
-
-            IMPORTANT: Don't post any comments or messages to the issue. Your only action should be to apply labels.
-
-            Issue Information:
-            - REPO: ${{ github.repository }}
-            - ISSUE_NUMBER: ${{ github.event.issue.number }}
-
-            TASK OVERVIEW:
-
-            1. First, fetch the list of labels available in this repository by running: `gh label list`. Run exactly this command with nothing else.
-
-            2. Next, use the GitHub tools to get context about the issue:
-               - You have access to these tools:
-                 - mcp__github__get_issue: Use this to retrieve the current issue's details including title, description, and existing labels
-                 - mcp__github__get_issue_comments: Use this to read any discussion or additional context provided in the comments
-                 - mcp__github__update_issue: Use this to apply labels to the issue (do not use this for commenting)
-                 - mcp__github__search_issues: Use this to find similar issues that might provide context for proper categorization and to identify potential duplicate issues
-                 - mcp__github__list_issues: Use this to understand patterns in how other issues are labeled
-               - Start by using mcp__github__get_issue to get the issue details
-
-            3. Analyze the issue content, considering:
-               - The issue title and description
-               - The type of issue (bug report, feature request, question, etc.)
-               - Technical areas mentioned
-               - Severity or priority indicators
-               - User impact
-               - Components affected
-
-            4. Select appropriate labels from the available labels list provided above:
-               - Choose labels that accurately reflect the issue's nature
-               - Be specific but comprehensive
-               - Select priority labels if you can determine urgency (high-priority, med-priority, or low-priority)
-               - Consider platform labels (android, ios) if applicable
-               - If you find similar issues using mcp__github__search_issues, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
-
-            5. Apply the selected labels:
-               - Use mcp__github__update_issue to apply your selected labels
-               - DO NOT post any comments explaining your decision
-               - DO NOT communicate directly with users
-               - If no labels are clearly applicable, do not apply any labels
-
-            IMPORTANT GUIDELINES:
-            - Be thorough in your analysis
-            - Only select labels from the provided list above
-            - DO NOT post any comments to the issue
-            - Your ONLY action should be to apply labels using mcp__github__update_issue
-            - It's okay to not add any labels if none are clearly applicable
-
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: |
-            --allowedTools "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
+    uses: OpenSwiftUIProject/github-workflows/.github/workflows/issue-triage.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

This PR migrates `claude.yml` and `issue-triage.yml` to use shared reusable workflows from the organization-wide [github-workflows](https://github.com/OpenSwiftUIProject/github-workflows) repository.

## Changes

- Updated `.github/workflows/claude.yml` to call the shared workflow
- Updated `.github/workflows/issue-triage.yml` to call the shared workflow

## Benefits

- Reduces maintenance burden by centralizing workflow logic
- Ensures consistency across all OpenSwiftUI organization repositories  
- Simplifies future updates to workflow behavior
- Follows the pattern used in [OpenAttributeGraph#188](https://github.com/OpenSwiftUIProject/OpenAttributeGraph/pull/188)

## Implementation

The workflows continue to trigger on the same events as before but now delegate to shared reusable workflows:

```yaml
jobs:
  claude:
    uses: OpenSwiftUIProject/github-workflows/.github/workflows/claude.yml@main
    secrets: inherit
```

## Related

- Organization workflows: https://github.com/OpenSwiftUIProject/github-workflows
- Similar change in OpenAttributeGraph: https://github.com/OpenSwiftUIProject/OpenAttributeGraph/pull/188