### PR TITLE
Add OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -225,6 +225,14 @@ if internalXRSDK {
     sharedSwiftSettings.append(.define("OPENSWIFTUI_INTERNAL_XR_SDK"))
 }
 
+// MARK: - [env] OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS
+
+let enablePrivateImports = envEnable("OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS", default: true)
+if enablePrivateImports {
+    sharedSwiftSettings.append(.define("OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS"))
+    sharedSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-enable-private-imports"]))
+}
+
 // MARK: - OpenSwiftUISPI Target
 
 let openSwiftUISPITarget = Target.target(

--- a/Sources/OpenSwiftUICore/Data/Location/Location.swift
+++ b/Sources/OpenSwiftUICore/Data/Location/Location.swift
@@ -89,10 +89,10 @@ extension AnyLocation: Sendable {}
 // MARK: - LocationBox
 
 final package class LocationBox<L>: AnyLocation<L.Value>, Location, @unchecked Sendable where L: Location {
-    final internal(set) package var location: L
-    
+    final private(set) package var location: L
+
     @AtomicBox
-    var cache = LocationProjectionCache()
+    private var cache = LocationProjectionCache()
 
     package init(_ location: L) {
         self.location = location

--- a/Tests/OpenSwiftUICoreTests/Data/Location/LocationTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Location/LocationTests.swift
@@ -2,8 +2,12 @@
 //  LocationTests.swift
 //  OpenSwiftUICoreTests
 
-@_spi(ForOpenSwiftUIOnly) import OpenSwiftUICore
-@testable import OpenSwiftUICore
+@_spi(ForOpenSwiftUIOnly)
+@testable
+#if OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS
+@_private(sourceFile: "Location.swift")
+#endif
+import OpenSwiftUICore
 import Testing
 
 struct LocationTests {
@@ -63,6 +67,7 @@ struct LocationTests {
         #expect(location.get() == 1)
     }
 
+    #if OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS
     @Test
     func boxProjectingAndCache() {
         struct V {
@@ -101,4 +106,5 @@ struct LocationTests {
         box.cache.reset()
         #expect(box.cache.cache.isEmpty == true)
     }
+    #endif
 }


### PR DESCRIPTION
Add OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS env to control the usage of `@_private(sourceFile:)` import

See more information here: https://github.com/swiftlang/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_privatesourcefile-filenameswift