### PR TITLE
Configure self-hosted documentation in SPI manifest

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,3 @@
 version: 1
-builder:
-  configs:
-    - documentation_targets: [OpenSwiftUI]
+external_links:
+  documentation: "https://openswiftuiproject.github.io/OpenSwiftUI/documentation/openswiftui/"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Currently, this project is in early development.
 
 The full API [documentation](https://openswiftuiproject.github.io/OpenSwiftUI/documentation/openswiftui/) is hosted on GitHub Pages.
 
-A legacy version is available on [SwiftPackageIndex](https://swiftpackageindex.com/OpenSwiftUIProject/OpenSwiftUI/main/documentation/openswiftui), but it does not include OpenSwiftUICore APIs.
-
 ## Notes
 
 this project is for learning and research purposes only.


### PR DESCRIPTION
## Summary
- Update `.spi.yml` to configure external documentation URL pointing to GitHub Pages hosted docs
- Remove mention of legacy SwiftPackageIndex documentation from README

This follows the Swift Package Index documentation for [self-hosting documentation](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/~/documentation/spimanifest/commonusecases#selfHosting).

## Test plan
- Verify `.spi.yml` is valid YAML
- Check that SPI recognizes the external documentation link