### PR TITLE
Fix: Improve memory management in DynamicPropertyBuffer item transfer

### DIFF
--- a/Sources/OpenSwiftUICore/Data/DynamicProperty/DynamicPropertyBuffer.swift
+++ b/Sources/OpenSwiftUICore/Data/DynamicProperty/DynamicPropertyBuffer.swift
@@ -396,7 +396,7 @@ public struct _DynamicPropertyBuffer {
         while count > 0 {
             let newItemPointer = newBuffer.assumingMemoryBound(to: Item.self)
             let oldItemPointer = oldBuffer.assumingMemoryBound(to: Item.self)
-            newItemPointer.initialize(to: oldItemPointer.pointee)
+            newItemPointer.initialize(to: oldItemPointer.move())
             oldItemPointer.pointee.vtable.moveInitialize(
                 ptr: newBuffer.advanced(by: MemoryLayout<Item>.size),
                 from: oldBuffer.advanced(by: MemoryLayout<Item>.size)


### PR DESCRIPTION
## Summary
Fixes memory management in `_DynamicPropertyBuffer` when transferring items between old and new buffers.

## Changes
- Changed `oldItemPointer.pointee` to `oldItemPointer.move()` in the buffer reallocation logic
- This properly transfers ownership of the item instead of just copying the value

## Why
Using `move()` ensures proper memory ownership transfer when moving items between buffers, which is safer and more correct for memory management in this context.

## Test plan
- Existing tests should continue to pass
- No behavioral changes expected, only improved memory safety