### PR TITLE
Fix: Move -Wwarning flag to conditional compilation to avoid Xcode conflict

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "106a21412583c15dcfc5506af42f485123fabe106be5887207958028611f2bb0",
+  "originHash" : "2c64b45620932621276e50344e6c5fe6c9d3f5504944717f976fdeef05f66bc5",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,6 @@ var sharedSwiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("BareSlashRegexLiterals"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("InferSendableFromCaptures"),
-    .unsafeFlags(["-Wwarning", "DeprecatedDeclaration"]), // We want to use deprecated APIs in test targets
     // FIXME: -unavailable-decl-optimization=stub is not working somehow (eg. Color.vibrancy). Dig into this later
     .unsafeFlags(["-unavailable-decl-optimization=stub"]),
     .swiftLanguageMode(.v5),
@@ -190,6 +189,12 @@ if warningsAsErrorsCondition {
     sharedSwiftSettings.append(.unsafeFlags(["-Werror", "Unsafe"]))
     sharedSwiftSettings.append(.unsafeFlags(["-Werror", "UnknownWarningGroup"]))
     sharedSwiftSettings.append(.unsafeFlags(["-Werror", "ExistentialAny"]))
+
+    // This will cause conflict when used by Xcode from a non-local dependency
+    // "Conflicting options '-Wwarning' and '-suppress-warnings'"
+    // See: https://forums.swift.org/t/warnings-as-errors-in-sub-packages/70810
+    // So do not enable it by default here.
+    sharedSwiftSettings.append(.unsafeFlags(["-Wwarning", "DeprecatedDeclaration"])) // We want to use deprecated APIs in test targets)
 }
 
 // MARK: - [env] OPENSWIFTUI_LIBRARY_EVOLUTION


### PR DESCRIPTION
## Summary
Moves the `-Wwarning DeprecatedDeclaration` compiler flag from default settings to conditional compilation (only enabled when `OPENSWIFTUI_WERROR=1`).

## Problem
When OpenSwiftUI is used as a non-local dependency in Xcode, the `-Wwarning` flag conflicts with Xcode's `-suppress-warnings` flag, causing a build error:
```
Conflicting options '-Wwarning' and '-suppress-warnings'
```

## Solution
- Removed `-Wwarning DeprecatedDeclaration` from default `sharedSwiftSettings`
- Added it to the `warningsAsErrorsCondition` block instead
- This preserves the warning behavior in CI/strict builds while avoiding conflicts in dependent projects

## References
- Swift Forums discussion: https://forums.swift.org/t/warnings-as-errors-in-sub-packages/70810

## Test Plan
- [ ] Builds successfully when used as a local dependency
- [ ] Builds successfully when used as a non-local dependency in Xcode
- [ ] Deprecated API warnings still show when `OPENSWIFTUI_WERROR=1` is set