### PR TITLE
Fix: Use git commit --amend when FORCE_PUSH=true to prevent commit accumulation

### DIFF
--- a/Scripts/update-gh-pages-documentation.sh
+++ b/Scripts/update-gh-pages-documentation.sh
@@ -257,13 +257,24 @@ if git diff --cached --quiet; then
     log_info "No changes to documentation"
 else
     log_info "Committing documentation changes..."
-    git commit -m "Update documentation (generated from $CURRENT_BRANCH@$(git -C "$REPO_ROOT" rev-parse --short HEAD))"
 
-    log_info "Pushing to gh-pages branch..."
     if [[ "$FORCE_PUSH" == true ]]; then
+        # Use --amend to avoid accumulating commits with large binary files
+        # Check if there are any commits in the branch
+        if git rev-parse HEAD >/dev/null 2>&1; then
+            git commit --amend -m "Update documentation (generated from $CURRENT_BRANCH@$(git -C "$REPO_ROOT" rev-parse --short HEAD))"
+        else
+            # First commit on the branch
+            git commit -m "Update documentation (generated from $CURRENT_BRANCH@$(git -C "$REPO_ROOT" rev-parse --short HEAD))"
+        fi
+
+        log_info "Pushing to gh-pages branch..."
         log_info "Using --force to save git repo size (avoids accumulating large binary files)"
         git_push --force origin gh-pages
     else
+        git commit -m "Update documentation (generated from $CURRENT_BRANCH@$(git -C "$REPO_ROOT" rev-parse --short HEAD))"
+
+        log_info "Pushing to gh-pages branch..."
         git_push origin gh-pages
     fi
 


### PR DESCRIPTION
## Summary

Fix the gh-pages deployment script to actually prevent commit accumulation when `FORCE_PUSH=true`.

## Problem

The `update-gh-pages-documentation.sh` script has `FORCE_PUSH=true` as the default to "save git repo size (avoids accumulating large binary files)". However, it was creating a new commit each time and then force pushing, which defeats the purpose. This still accumulates commits with large binary files in the gh-pages branch history.

## Solution

When `FORCE_PUSH=true`, use `git commit --amend` instead of creating new commits. This ensures the gh-pages branch maintains only **one commit**, truly preventing accumulation of large binary files.

## Changes

- Use `git commit --amend` when `FORCE_PUSH=true` to modify the existing commit
- Handle the edge case for the first commit (when there's nothing to amend yet)
- Keep the original behavior when `FORCE_PUSH=false` (creates new commits)

## Result

- With `FORCE_PUSH=true`: gh-pages branch will have only 1 commit, repo size stays minimal
- With `FORCE_PUSH=false`: gh-pages branch preserves full history

## Related

This fixes the behavior introduced in the documentation build refactoring.