### PR TITLE
Fix DynamicContainer indexMap update issue

### DIFF
--- a/Example/HostingExample/ViewController.swift
+++ b/Example/HostingExample/ViewController.swift
@@ -66,6 +66,6 @@ class ViewController: NSViewController {
 
 struct ContentView: View {
     var body: some View {
-        ToggleExample()
+        DynamicLayoutViewExample()
     }
 }

--- a/Example/OpenSwiftUIUITests/Layout/Dynamic/DynamicLayoutViewUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/Dynamic/DynamicLayoutViewUITests.swift
@@ -1,0 +1,27 @@
+//
+//  DynamicLayoutViewUITests.swift
+//  OpenSwiftUIUITests
+
+import SnapshotTesting
+import Testing
+
+@MainActor
+@Suite(.snapshots(record: .never, diffTool: diffTool))
+struct DynamicLayoutViewUITests {
+    @Test
+    func dynamicLayout() {
+        struct ContentView: View {
+            @State var show = false
+            var body: some View {
+                VStack {
+                    Color.red
+                        .task { show = true }
+                    if show {
+                        Color.blue
+                    }
+                }
+            }
+        }
+        openSwiftUIAssertSnapshot(of: ContentView())
+    }
+}

--- a/Example/SharedExample/Layout/Dynamic/DynamicLayoutViewExample.swift
+++ b/Example/SharedExample/Layout/Dynamic/DynamicLayoutViewExample.swift
@@ -1,0 +1,22 @@
+//
+//  DynamicLayoutViewExample.swift
+//  SharedExample
+
+#if OPENSWIFTUI
+import OpenSwiftUI
+#else
+import SwiftUI
+#endif
+
+struct DynamicLayoutViewExample: View {
+    @State var show = false
+    var body: some View {
+        VStack {
+            Color.red
+                .task { show = true }
+            if show {
+                Color.blue
+            }
+        }
+    }
+}

--- a/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
+++ b/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
@@ -340,7 +340,9 @@ struct DynamicContainerInfo<Adapter>: StatefulRule, AsyncAttribute, ObservedAttr
             needsPhaseUpdate = false
         }
         let (changed, hasDepth) = updateItems(disableTransitions: disableTransitions)
-        if !changed {
+        if changed {
+            needsUpdate = true
+        } else {
             for (index, item) in info.items.enumerated().reversed() {
                 guard let phase = item.phase else {
                     continue


### PR DESCRIPTION
Close #567

The root cause is that DynamicContainer is missing updating. So `indexMap` is nil.

Then `DynamicLayoutViewChildGeometry` will set its value to .zero.

```
    func updateValue() {
        guard let index = containerInfo.viewIndex(id: id), index < childGeometries.count else {
            if !hasValue {
                value = .zero
            }
            return
        }
        value = childGeometries[index]
    }
```