### PR TITLE
Fix UITest case crash for LabelsHiddenModifierUITests

### DIFF
--- a/Sources/OpenSwiftUICore/Data/Binding/Location.swift
+++ b/Sources/OpenSwiftUICore/Data/Binding/Location.swift
@@ -363,7 +363,7 @@ package struct FunctionalLocation<Value>: Location {
     }
 
     package static func == (lhs: FunctionalLocation<Value>, rhs: FunctionalLocation<Value>) -> Bool {
-        compareValues(lhs, rhs)
+        compareValues(lhs.functions, rhs.functions)
     }
 }
 

--- a/Tests/OpenSwiftUICoreTests/Data/Binding/LocationTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Binding/LocationTests.swift
@@ -136,5 +136,13 @@ struct LocationTests {
         location.set(2, transaction: .init())
         #expect(location.wasRead == true)
         #expect(location.get() == 4)
+
+        let location2 = FunctionalLocation {
+            value.count
+        } setValue: { newCount, _ in
+            value.count = newCount * newCount
+        }
+        #expect(location2 != location)
+        #expect(location == location)
     }
 }


### PR DESCRIPTION
Note: this new test case does not cover the fix. 

Only run all ui test case and then LabelsHiddenModifierUITests.toggleLabelsHidden will hit the recursive loop and cause infinite loop call for `FunctionalLocation==`.

```
Thread 0 Crashed:
0   libswiftCore.dylib            	       0x195a95f90 0x1957bb000 + 2994064
1   TestingHost.debug.dylib       	       0x10452c66c type metadata accessor for FunctionalLocation + 24
2   TestingHost.debug.dylib       	       0x10452b3e8 static FunctionalLocation.== infix(_:_:) + 188
3   TestingHost.debug.dylib       	       0x10452b548 protocol witness for static Equatable.== infix(_:_:) in conformance FunctionalLocation<A> + 16
4   AttributeGraph                	       0x1c00f153c 0x1c00c1000 + 197948
5   AttributeGraph                	       0x1c00db6e0 0x1c00c1000 + 108256
6   AttributeGraph                	       0x1c00dbb30 0x1c00c1000 + 109360
7   AttributeGraph                	       0x1c00f1640 0x1c00c1000 + 198208
8   AttributeGraph                	       0x1c00eaf5c 0x1c00c1000 + 171868
9   AttributeGraph                	       0x1c00f14e8 0x1c00c1000 + 197864
10  AttributeGraph                	       0x1c00f1498 0x1c00c1000 + 197784
11  AttributeGraph                	       0x1c00eaf5c 0x1c00c1000 + 171868
12  AttributeGraph                	       0x1c00f1478 0x1c00c1000 + 197752
13  TestingHost.debug.dylib       	       0x10452b404 static FunctionalLocation.== infix(_:_:) + 216 (Location.swift:366)
14  TestingHost.debug.dylib       	       0x10452b548 protocol witness for static Equatable.== infix(_:_:) in conformance FunctionalLocation<A> + 16
15  AttributeGraph                	       0x1c00f153c 0x1c00c1000 + 197948
16  AttributeGraph                	       0x1c00db6e0 0x1c00c1000 + 108256
17  AttributeGraph                	       0x1c00dbb30 0x1c00c1000 + 109360
18  AttributeGraph                	       0x1c00f1640 0x1c00c1000 + 198208
19  AttributeGraph                	       0x1c00eaf5c 0x1c00c1000 + 171868
20  AttributeGraph                	       0x1c00f14e8 0x1c00c1000 + 197864
21  AttributeGraph                	       0x1c00f1498 0x1c00c1000 + 197784
22  AttributeGraph                	       0x1c00eaf5c 0x1c00c1000 + 171868
23  AttributeGraph                	       0x1c00f1478 0x1c00c1000 + 197752
24  TestingHost.debug.dylib       	       0x10452b404 static FunctionalLocation.== infix(_:_:) + 216 (Location.swift:366)
25  TestingHost.debug.dylib       	       0x10452b548 protocol witness for static Equatable.== infix(_:_:) in conformance FunctionalLocation<A> + 16
26  AttributeGraph                	       0x1c00f153c 0x1c00c1000 + 197948
27  AttributeGraph                	       0x1c00db6e0 0x1c00c1000 + 108256
28  AttributeGraph                	       0x1c00dbb30 0x1c00c1000 + 109360
29  AttributeGraph                	       0x1c00f1640 0x1c00c1000 + 198208
30  AttributeGraph                	       0x1c00eaf5c 0x1c00c1000 + 171868
31  AttributeGraph                	       0x1c00f14e8 0x1c00c1000 + 197864
32  AttributeGraph                	       0x1c00f1498 0x1c00c1000 + 197784
33  AttributeGraph                	       0x1c00eaf5c 0x1c00c1000 + 171868
34  AttributeGraph                	       0x1c00f1478 0x1c00c1000 + 197752
35  TestingHost.debug.dylib       	       0x10452b404 static FunctionalLocation.== infix(_:_:) + 216 (Location.swift:366)
36  TestingHost.debug.dylib       	       0x10452b548 protocol witness for static Equatable.== infix(_:_:) in conformance FunctionalLocation<A> + 16
```