### PR TITLE
Fix active item count when DynamicLayoutMap has non-unary items

### DIFF
--- a/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicLayoutMap.swift
+++ b/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicLayoutMap.swift
@@ -87,7 +87,7 @@ package struct DynamicLayoutMap {
         let lastActiveIndex = activeCount - 1
         if lastActiveIndex >= 0, !allUnary {
             let lastActiveItem = info.items[lastActiveIndex]
-            activeCount &+= Int(lastActiveItem.count)
+            activeCount = Int(lastActiveItem.count)
         }
         for index in 0 ..< activeCount {
             let targetIndex: Int


### PR DESCRIPTION
Since `lastActiveItem.count` reports to accumulated count of all subitems up to and including the last active item, we can simply assign it to `activeCount`.