### PR TITLE
Fix subgraph not being retained by SubgraphElements.retain()

### DIFF
--- a/Sources/OpenSwiftUICore/View/Input/ViewList.swift
+++ b/Sources/OpenSwiftUICore/View/Input/ViewList.swift
@@ -2336,6 +2336,7 @@ private struct SubgraphElements: ViewList.Elements {
         guard subgraph.isValid else {
             return nil
         }
+        subgraph.retain()
         return Release(base: base.retain(), subgraph: subgraph)
     }
 }


### PR DESCRIPTION
In situations where the data passed to a ForEach is a _VariadicView.Children, as is the case for nested variadic views like so:

```swift
struct PassthroughUnaryViewRoot: _VariadicView.UnaryViewRoot {
    func body(children: _VariadicView.Children) -> some View {
        children
    }
}

_VariadicView.Tree(PassthroughUnaryViewRoot()) {
    ForEach(["A"], id: \.self) { element in
        Text(element)
    }
}
```

The subgraph for the inner for each item is released more than it is retained, causing the subgraph to invalidate and the view to render an empty list.