### PR TITLE
Fix DynamicPreferenceCombiner returning early

### DIFF
--- a/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
+++ b/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
@@ -258,7 +258,7 @@ private struct DynamicPreferenceCombiner<K>: Rule, AsyncAttribute, CustomStringC
             }
             let item = info.items[itemIndex]
             guard let attribute = item.outputs[K.self] else {
-                return value
+                continue
             }
             if initialValue {
                 value = attribute.value


### PR DESCRIPTION
An item in a dynamic container may be missing a preference if, say, it does not return a display list:

```swift
struct MyEmptyView: View, PrimitiveView, UnaryView {
    func _makeView(view: _GraphValue<Self>, inputs: _ViewInputs) -> _ViewOutputs {
        _ViewOutputs()
    }
}
```

`Spacer` is an example of this.

When such a view is placed in a dynamic list such as a ForEach, any subsequent views fail to render because their display lists are never combined.