### PR TITLE
Fix DynamicContainer inusedCount issue

### DIFF
--- a/Example/OpenSwiftUIUITests/View/DynamicViewContent/ForEachUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/DynamicViewContent/ForEachUITests.swift
@@ -113,4 +113,28 @@ struct ForEachUITests {
         openSwiftUIAssertSnapshot(of: ContentView2(), named: "2")
         openSwiftUIAssertSnapshot(of: ContentView3(), named: "3")
     }
+
+    @Test(
+        .bug(
+            "https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/701",
+            id: 701
+        )
+    )
+    func emptyDynamicContainer() {
+        struct ContentView: View {
+            @State private var items = [6]
+            var body: some View {
+                VStack(spacing: 10) {
+                    ForEach(items, id: \.self) { item in
+                        Color.blue.opacity(Double(item) / 6.0)
+                            .frame(height: 50)
+                    }
+                }
+                .onAppear {
+                    items.removeAll { $0 == 6 }
+                }
+            }
+        }
+        openSwiftUIAssertSnapshot(of: ContentView())
+    }
 }

--- a/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
+++ b/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
@@ -369,7 +369,7 @@ struct DynamicContainerInfo<Adapter>: StatefulRule, AsyncAttribute, ObservedAttr
             }
             info.indexMap.removeAll(keepingCapacity: true)
             info.allUnary = true
-            Swift.assert(inusedCount > 0)
+            Swift.assert(inusedCount >= 0)
             if totalCount != unusedCount {
                 var precedingCount: Int32 = 0
                 var allUnary = true


### PR DESCRIPTION
Close #701

When all items are removed, no crash should happen.