### PR TITLE
Add ShapeView support for Path

### DIFF
--- a/Example/OpenSwiftUIUITests/Layout/Stack/ZStackIndexUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/Stack/ZStackIndexUITests.swift
@@ -14,15 +14,12 @@ struct ZStackIndexUITests {
         struct ContentView: View {
             var body: some View {
                 VStack {
-                    // TODO: Path & Shape is not implemented yet.
-                    Color.yellow
-//                    Rectangle()
-//                        .fill(Color.yellow)
+                    Rectangle()
+                        .fill(Color.yellow)
                         .frame(width: 100, height: 100, alignment: .center)
                         .zIndex(1) // Top layer.
-                    Color.red
-//                    Rectangle()
-//                        .fill(Color.red)
+                    Rectangle()
+                        .fill(Color.red)
                         .frame(width: 100, height: 100, alignment: .center)
                         .rotationEffect(.degrees(45))
                         // Here a zIndex of 0 is the default making

--- a/Example/OpenSwiftUIUITests/Shape/ShapeUITests.swift
+++ b/Example/OpenSwiftUIUITests/Shape/ShapeUITests.swift
@@ -17,4 +17,14 @@ struct ShapeUITests {
         }
         openSwiftUIAssertSnapshot(of: ContentView())
     }
+
+    @Test
+    func circle() {
+        struct ContentView: View {
+            var body: some View {
+                Circle()
+            }
+        }
+        openSwiftUIAssertSnapshot(of: ContentView())
+    }
 }

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ for various platforms:
 
 ### Current supported feature
 
-- Color/Image rendering (Path/Text is not supported yet)
+- Color/Image/Path rendering (Text is not supported yet)
 - Layout system
 - Animation system
 - onAppear/onDisappear modifier

--- a/Sources/OpenSwiftUI/Render/DisplayList/AppKitDisplayList.swift
+++ b/Sources/OpenSwiftUI/Render/DisplayList/AppKitDisplayList.swift
@@ -82,6 +82,11 @@ final class NSViewPlatformViewDefinition: PlatformViewDefinition, @unchecked Sen
         Self.initView(view as! NSView, kind: kind)
     }
 
+    override static func setPath(_ path: Path, shapeView: AnyObject) {
+        let view = unsafeBitCast(shapeView, to: _NSShapeHitTestingView.self)
+        view.path = path
+    }
+
     override class func setProjectionTransform(_ transform: ProjectionTransform, projectionView: AnyObject) {
         guard let view = projectionView as? _NSProjectionView else {
             return

--- a/Sources/OpenSwiftUI/Render/DisplayList/UIKitDisplayList.swift
+++ b/Sources/OpenSwiftUI/Render/DisplayList/UIKitDisplayList.swift
@@ -47,6 +47,11 @@ final class UIViewPlatformViewDefinition: PlatformViewDefinition, @unchecked Sen
         return view
     }
 
+    override static func setPath(_ path: Path, shapeView: AnyObject) {
+        let view = unsafeBitCast(shapeView, to: _UIShapeHitTestingView.self)
+        view.path = path
+    }
+
     private static func initView(_ view: UIView, kind: PlatformViewDefinition.ViewKind) {
         if kind != .platformView && kind != .platformGroup {
             view.autoresizesSubviews = false

--- a/Sources/OpenSwiftUICore/Graphic/GraphicsContext.swift
+++ b/Sources/OpenSwiftUICore/Graphic/GraphicsContext.swift
@@ -5,6 +5,7 @@
 //  Audited for 6.0.87
 //  Status: WIP
 
+package import OpenRenderBoxShims
 #if canImport(Darwin)
 public import CoreGraphics
 #else
@@ -515,14 +516,24 @@ public struct GraphicsContext {
     package enum ResolvedShading: Sendable {
         case backdrop(Color.Resolved)
         case color(Color.Resolved)
+        case sRGBColor(ORBColor)
         case style(_ShapeStyle_Pack.Style)
         case levels([GraphicsContext.ResolvedShading])
     }
 }
 
 extension GraphicsContext {
+    #if canImport(Darwin) && _OPENSWIFTUI_SWIFTUI_RENDER
+    @_silgen_name("OpenSwiftUITestStub_GraphicsContextDrawPathWithShadingAndStyle")
+    private func swiftUI_draw(_ path: Path, with shading: GraphicsContext.ResolvedShading, style: PathDrawingStyle)
+    #endif
+
     package func draw(_ path: Path, with shading: GraphicsContext.ResolvedShading, style: PathDrawingStyle) {
-        _openSwiftUIUnimplementedFailure()
+        #if canImport(Darwin) && _OPENSWIFTUI_SWIFTUI_RENDER
+        swiftUI_draw(path, with: shading, style: style)
+        #else
+        _openSwiftUIUnimplementedWarning()
+        #endif
     }
 
     // FIXME

--- a/Sources/OpenSwiftUICore/Shape/Shape.swift
+++ b/Sources/OpenSwiftUICore/Shape/Shape.swift
@@ -6,6 +6,7 @@
 //  Status: Complete
 
 public import Foundation
+package import OpenCoreGraphicsShims
 
 // MARK: - Shape
 

--- a/Sources/OpenSwiftUICore/Shape/ShapeView.swift
+++ b/Sources/OpenSwiftUICore/Shape/ShapeView.swift
@@ -3,13 +3,14 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: Blocked by _ShapeView.makeView
+//  Status: Complete
 
 public import Foundation
 package import OpenAttributeGraphShims
 
 // MARK: - Shape + Extension (disfavoredOverload)
 
+@available(OpenSwiftUI_v1_0, *)
 extension Shape {
     /// Fills this shape with a color or gradient.
     ///
@@ -88,12 +89,14 @@ extension Shape {
 
 // MARK: - Shape + View
 
+@available(OpenSwiftUI_v1_0, *)
 extension Shape {
     public var body: _ShapeView<Self, ForegroundStyle> {
         _ShapeView(shape: self, style: ForegroundStyle())
     }
 }
 
+@available(OpenSwiftUI_v3_0, *)
 extension Shape {
     nonisolated public static func _makeView(view: _GraphValue<Self>, inputs: _ViewInputs) -> _ViewOutputs {
         makeView(view: view, inputs: inputs)
@@ -106,6 +109,7 @@ extension Shape {
 
 // MARK: - ShapeStyle + View
 
+@available(OpenSwiftUI_v1_0, *)
 extension ShapeStyle where Self: View, Body == _ShapeView<Rectangle, Self> {
     public var body: _ShapeView<Rectangle, Self> {
         _ShapeView(shape: Rectangle(), style: self)
@@ -122,7 +126,10 @@ extension ShapeStyle where Self: View, Body == _ShapeView<Rectangle, Self> {
 ///     Rectangle()
 ///         .fill(.red)
 ///
+@available(OpenSwiftUI_v1_0, *)
 @frozen
+@MainActor
+@preconcurrency
 public struct _ShapeView<Content, Style>: View, UnaryView, ShapeStyledLeafView, PrimitiveView, LeafViewLayout where Content: Shape, Style: ShapeStyle {
     public var shape: Content
 
@@ -131,7 +138,7 @@ public struct _ShapeView<Content, Style>: View, UnaryView, ShapeStyledLeafView, 
     public var fillStyle: FillStyle
 
     @inlinable
-    public init(shape: Content, style: Style, fillStyle: FillStyle = FillStyle()) {
+    nonisolated public init(shape: Content, style: Style, fillStyle: FillStyle = FillStyle()) {
         self.shape = shape
         self.style = style
         self.fillStyle = fillStyle
@@ -180,7 +187,22 @@ public struct _ShapeView<Content, Style>: View, UnaryView, ShapeStyledLeafView, 
             }
             return outputs
         } else {
-            _openSwiftUIUnimplementedFailure()
+            let shapeValue = view[offset: { .of(&$0.shape) }]
+            let animatedShape = Content.makeAnimatable(value: shapeValue, inputs: inputs.base)
+            let fillStyleAttr: Attribute<FillStyle> = view.value[offset: { .of(&$0.fillStyle) }]
+            let animatedView = _GraphValue(AnimatedShape<Content>.Init(
+                shape: animatedShape,
+                fillStyle: fillStyleAttr
+            ))
+            var outputs = AnimatedShape<Content>.makeLeafView(
+                view: animatedView,
+                inputs: inputs,
+                styles: styles
+            )
+            if isLinkedOnOrAfter(.v4) {
+                AnimatedShape<Content>.makeLeafLayout(&outputs, view: animatedView, inputs: inputs)
+            }
+            return outputs
         }
     }
 
@@ -206,6 +228,34 @@ extension ShapeStyle {
     }
 }
 
+// MARK: - AnimatedShape
+
+struct AnimatedShape<Content: Shape>: ShapeStyledLeafView, PrimitiveView, UnaryView, LeafViewLayout {
+    var shape: Content
+    var fillStyle: FillStyle
+
+    func shape(in size: CGSize) -> FramedShape {
+        let path = shape.effectivePath(in: CGRect(origin: .zero, size: size))
+        return FramedShape(
+            shape: .path(path, fillStyle),
+            frame: CGRect(origin: .zero, size: size)
+        )
+    }
+
+    func sizeThatFits(in proposedSize: _ProposedSize) -> CGSize {
+        shape.sizeThatFits(.init(proposedSize))
+    }
+
+    struct Init: Rule, AsyncAttribute {
+        @Attribute var shape: Content
+        @Attribute var fillStyle: FillStyle
+
+        var value: AnimatedShape<Content> {
+            AnimatedShape(shape: shape, fillStyle: fillStyle)
+        }
+    }
+}
+
 // MARK: - ShapeView
 
 /// A view that provides a shape that you can use for drawing operations.
@@ -218,13 +268,15 @@ extension ShapeStyle {
 ///         .fill(.yellow)
 ///         .stroke(.blue, lineWidth: 8)
 ///
+@available(OpenSwiftUI_v5_0, *)
 public protocol ShapeView<Content>: View {
     associatedtype Content: Shape
-    var shape: Self.Content { get }
+    var shape: Content { get }
 }
 
 // MARK: - Shape + Extension
 
+@available(OpenSwiftUI_v5_0, *)
 extension Shape {
     /// Fills this shape with a color or gradient.
     ///
@@ -293,6 +345,7 @@ extension Shape {
 
 // MARK: - InsettableShape + Extension
 
+@available(OpenSwiftUI_v5_0, *)
 extension InsettableShape {
     /// Returns a view that is the result of insetting `self` by
     /// `style.lineWidth / 2`, stroking the resulting shape with
@@ -322,15 +375,15 @@ extension InsettableShape {
     }
 }
 
+@available(OpenSwiftUI_v5_0, *)
 extension _ShapeView: ShapeView {}
-
-// TODO: AnimatedShape
 
 // MARK: - FillShapeView
 
 /// A shape provider that fills its shape.
 ///
 /// You do not create this type directly, it is the return type of `Shape.fill`.
+@available(OpenSwiftUI_v5_0, *)
 @frozen
 public struct FillShapeView<Content, Style, Background>: ShapeView, PrimitiveView, UnaryView where Content: Shape, Style: ShapeStyle, Background: View {
     @usableFromInline
@@ -395,6 +448,7 @@ extension FillShapeView: Sendable {}
 ///
 /// You don't create this type directly; it's the return type of
 /// `Shape.stroke`.
+@available(OpenSwiftUI_v5_0, *)
 @frozen
 public struct StrokeShapeView<Content, Style, Background>: ShapeView, PrimitiveView, UnaryView where Content: Shape, Style: ShapeStyle, Background: View {
     @usableFromInline
@@ -466,6 +520,7 @@ extension StrokeShapeView: Sendable {}
 ///
 /// You don't create this type directly; it's the return type of
 /// `Shape.strokeBorder`.
+@available(OpenSwiftUI_v5_0, *)
 @frozen
 public struct StrokeBorderShapeView<Content, Style, Background>: ShapeView, PrimitiveView, UnaryView where Content: InsettableShape, Style: ShapeStyle, Background: View {
     @usableFromInline
@@ -533,6 +588,7 @@ extension StrokeBorderShapeView: Sendable {}
 
 // MARK: - ShapeView + Extension
 
+@available(OpenSwiftUI_v5_0, *)
 extension ShapeView {
     /// Fills this shape with a color or gradient.
     ///
@@ -604,6 +660,7 @@ extension ShapeView {
     }
 }
 
+@available(OpenSwiftUI_v5_0, *)
 extension ShapeView where Content: InsettableShape {
     /// Returns a view that's the result of insetting this view by half of its style's line width.
     ///

--- a/Sources/OpenSwiftUICore/Shape/ShapeView.swift
+++ b/Sources/OpenSwiftUICore/Shape/ShapeView.swift
@@ -186,7 +186,6 @@ public struct _ShapeView<Content, Style>: View, UnaryView, ShapeStyledLeafView, 
 
     package func shape(in size: CGSize) -> FramedShape {
         let path = shape.effectivePath(in: CGRect(origin: .zero, size: size))
-        // TODO
         return FramedShape(
             shape: .path(path, fillStyle),
             frame: CGRect(origin: .zero, size: size)

--- a/Sources/OpenSwiftUICore/Shape/StrokedShape.swift
+++ b/Sources/OpenSwiftUICore/Shape/StrokedShape.swift
@@ -1,0 +1,74 @@
+//
+//  StrokedShape.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+public import OpenCoreGraphicsShims
+
+// MARK: - _StrokedShape
+
+/// An absolute shape that has been stroked.
+@available(OpenSwiftUI_v1_0, *)
+@frozen
+public struct _StrokedShape<S>: Shape where S: Shape {
+    /// The source shape.
+    public var shape: S
+
+    /// The stroke style.
+    public var style: StrokeStyle
+
+    @inlinable
+    public init(shape: S, style: StrokeStyle) {
+        self.shape = shape
+        self.style = style
+    }
+
+    nonisolated public func path(in rect: CGRect) -> Path {
+        shape.path(in: rect).strokedPath(style)
+    }
+
+    @available(OpenSwiftUI_v3_0, *)
+    nonisolated public static var role: ShapeRole {
+        .stroke
+    }
+
+    @available(OpenSwiftUI_v5_0, *)
+    nonisolated public var layoutDirectionBehavior: LayoutDirectionBehavior {
+        shape.layoutDirectionBehavior
+    }
+
+    public var animatableData: AnimatablePair<S.AnimatableData, StrokeStyle.AnimatableData> {
+        get {
+            AnimatablePair(shape.animatableData, style.animatableData)
+        }
+        set {
+            shape.animatableData = newValue.first
+            style.animatableData = newValue.second
+        }
+    }
+
+    @available(OpenSwiftUI_v4_0, *)
+    nonisolated public func sizeThatFits(_ proposal: ProposedViewSize) -> CGSize {
+        shape.sizeThatFits(proposal)
+    }
+}
+
+@available(OpenSwiftUI_v1_0, *)
+extension Shape {
+    /// Returns a new shape that is a stroked copy of `self`, using the
+    /// contents of `style` to define the stroke characteristics.
+    @inlinable
+    nonisolated public func stroke(style: StrokeStyle) -> some Shape {
+        return _StrokedShape(shape: self, style: style)
+    }
+
+    /// Returns a new shape that is a stroked copy of `self` with
+    /// line-width defined by `lineWidth` and all other properties of
+    /// `StrokeStyle` having their default values.
+    @inlinable
+    nonisolated public func stroke(lineWidth: CGFloat = 1) -> some Shape {
+        return stroke(style: StrokeStyle(lineWidth: lineWidth))
+    }
+}

--- a/Sources/OpenSwiftUISymbolDualTestsSupport/Graphic/GraphicsContextTestsStub.c
+++ b/Sources/OpenSwiftUISymbolDualTestsSupport/Graphic/GraphicsContextTestsStub.c
@@ -1,0 +1,13 @@
+//
+//  GraphicsContextTestsStub.c
+//  OpenSwiftUISymbolDualTestsSupport
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN && _OPENSWIFTUI_SWIFTUI_RENDER
+
+#import <SymbolLocator.h>
+
+DEFINE_SL_STUB_SLF(OpenSwiftUITestStub_GraphicsContextDrawPathWithShadingAndStyle, SwiftUI, $s7SwiftUI15GraphicsContextVAAE4draw_4with5styleyAA4PathV_AC15ResolvedShadingOAA0H12DrawingStyleOtF);
+
+#endif

--- a/Sources/OpenSwiftUISymbolDualTestsSupport/Render/DisplayList/DisplayListViewRendererTestsStub.c
+++ b/Sources/OpenSwiftUISymbolDualTestsSupport/Render/DisplayList/DisplayListViewRendererTestsStub.c
@@ -1,5 +1,5 @@
 //
-//  DisplayListViewRenderer+TestStub.c
+//  DisplayListViewRendererTestsStub.c
 //  OpenSwiftUISymbolDualTestsSupport
 
 #include "OpenSwiftUIBase.h"

--- a/Sources/OpenSwiftUISymbolDualTestsSupport/Render/GeometryEffect/Rotation3DEffectTestSub.c
+++ b/Sources/OpenSwiftUISymbolDualTestsSupport/Render/GeometryEffect/Rotation3DEffectTestSub.c
@@ -1,5 +1,5 @@
 //
-//  Rotation3DEffect+TestSub.c
+//  Rotation3DEffectTestsSub.c
 //  OpenSwiftUISymbolDualTestsSupport
 
 #include "OpenSwiftUIBase.h"


### PR DESCRIPTION
```
struct ContentView: View {
    var body: some View {
        VStack {
            Circle()
                .fill(Color.yellow)
                .frame(width: 100, height: 100, alignment: .center)
                .zIndex(1) // Top layer.
            RoundedRectangle(cornerRadius: 10)
                .fill(Color.red)
                .frame(width: 100, height: 100, alignment: .center)
                .rotationEffect(.degrees(45))
                // Here a zIndex of 0 is the default making
                // this the bottom layer.
        }
    }
}
```

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/92307c2e-f6a6-456c-b0dd-c7648d4212bc" />
