### PR TITLE
Integrate xcbeautify into CI workflows

### DIFF
--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -20,15 +20,21 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install xcbeautify
+      shell: bash
+      run: brew install xcbeautify
+
     - name: Record baseline images with SwiftUI
       shell: bash
       run: |
         cd Example
+        set -o pipefail
         xcodebuild test \
           -scheme SUI_UITests \
           -destination "${{ inputs.destination }}" \
           -skipMacroValidation \
-          -skipPackagePluginValidation || true
+          -skipPackagePluginValidation \
+          | xcbeautify --renderer github-actions || true
 
     - name: Run UI tests with OpenSwiftUI
       id: uitest
@@ -36,11 +42,12 @@ runs:
       shell: bash
       run: |
         cd Example
+        set -o pipefail
         xcodebuild test \
           -scheme OSUI_UITests \
           -destination "${{ inputs.destination }}" \
           -skipMacroValidation \
-          -skipPackagePluginValidation 2>&1 | tee /tmp/${{ inputs.platform }}-uitest.log
+          -skipPackagePluginValidation 2>&1 | tee /tmp/${{ inputs.platform }}-uitest.log | xcbeautify --renderer github-actions
 
     - name: Collect failed snapshots
       if: steps.uitest.outcome == 'failure'

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -34,18 +34,24 @@ jobs:
       - name: Set up build environment
         run: Scripts/CI/darwin_setup_build.sh
         shell: bash
+      - name: Install xcbeautify
+        run: brew install xcbeautify
       - name: Run compatibility tests on OpenSwiftUI + macOS
         run: |
+          set -o pipefail
           swift test \
             --filter OpenSwiftUICompatibilityTests \
-            --build-path .build-compatibility-test-debug
+            --build-path .build-compatibility-test-debug \
+            | xcbeautify --renderer github-actions
         env:
           OPENSWIFTUI_COMPATIBILITY_TEST: 0
       - name: Run compatibility tests on SwiftUI + macOS
         run: |
+          set -o pipefail
           swift test \
             --filter OpenSwiftUICompatibilityTests \
-            --build-path .build-compatibility-test-debug
+            --build-path .build-compatibility-test-debug \
+            | xcbeautify --renderer github-actions
         env:
           OPENSWIFTUI_COMPATIBILITY_TEST: 1
   compatibility_tests_ios:
@@ -80,25 +86,31 @@ jobs:
       - name: Set up build environment
         run: Scripts/CI/darwin_setup_build.sh
         shell: bash
+      - name: Install xcbeautify
+        run: brew install xcbeautify
       - name: Run compatibility tests on OpenSwiftUI + iOS
         run: |
+          set -o pipefail
           xcodebuild test \
-          -scheme OpenSwiftUI \
-          -configuration Debug \
-          -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }}" \
-          -only-testing:OpenSwiftUICompatibilityTests \
-          -skipMacroValidation \
-          -skipPackagePluginValidation
+            -scheme OpenSwiftUI \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }}" \
+            -only-testing:OpenSwiftUICompatibilityTests \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            | xcbeautify --renderer github-actions
         env:
           OPENSWIFTUI_COMPATIBILITY_TEST: 0
       - name: Run compatibility tests on SwiftUI + iOS
         run: |
+          set -o pipefail
           xcodebuild test \
-          -scheme OpenSwiftUI \
-          -configuration Debug \
-          -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }}" \
-          -only-testing:OpenSwiftUICompatibilityTests \
-          -skipMacroValidation \
-          -skipPackagePluginValidation
+            -scheme OpenSwiftUI \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }}" \
+            -only-testing:OpenSwiftUICompatibilityTests \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            | xcbeautify --renderer github-actions
         env:
           OPENSWIFTUI_COMPATIBILITY_TEST: 1

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -42,7 +42,7 @@ jobs:
           swift test \
             --filter OpenSwiftUICompatibilityTests \
             --build-path .build-compatibility-test-debug \
-            | xcbeautify --renderer github-actions
+            2>&1 | xcbeautify --renderer github-actions
         env:
           OPENSWIFTUI_COMPATIBILITY_TEST: 0
       - name: Run compatibility tests on SwiftUI + macOS
@@ -51,7 +51,7 @@ jobs:
           swift test \
             --filter OpenSwiftUICompatibilityTests \
             --build-path .build-compatibility-test-debug \
-            | xcbeautify --renderer github-actions
+            2>&1 | xcbeautify --renderer github-actions
         env:
           OPENSWIFTUI_COMPATIBILITY_TEST: 1
   compatibility_tests_ios:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -40,19 +40,25 @@ jobs:
       - name: Set up build environment
         run: Scripts/CI/darwin_setup_build.sh
         shell: bash
+      - name: Install xcbeautify
+        run: brew install xcbeautify
       - name: Build test target in debug mode
         run: |
+          set -o pipefail
           xcodebuild build \
             -scheme OpenSwiftUI \
             -configuration Debug \
             -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }}" \
             -skipMacroValidation \
-            -skipPackagePluginValidation
+            -skipPackagePluginValidation \
+            | xcbeautify --renderer github-actions
       - name: Run test target in debug mode
         run: |
+          set -o pipefail
           xcodebuild test \
             -scheme OpenSwiftUI \
             -configuration Debug \
             -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }}" \
             -skipMacroValidation \
-            -skipPackagePluginValidation
+            -skipPackagePluginValidation \
+            | xcbeautify --renderer github-actions

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
             --filter OpenSwiftUICoreTests \
             --enable-code-coverage \
             --build-path .build-test-debug \
-            | xcbeautify --renderer github-actions
+            2>&1 | xcbeautify --renderer github-actions
           xcrun llvm-cov show \
             -instr-profile=.build-test-debug/debug/codecov/default.profdata \
             .build-test-debug/debug/OpenSwiftUIPackageTests.xctest/Contents/MacOS/OpenSwiftUIPackageTests \
@@ -60,7 +60,7 @@ jobs:
             --filter OpenSwiftUICoreTests \
             --enable-code-coverage \
             --build-path .build-test-release \
-            | xcbeautify --renderer github-actions
+            2>&1 | xcbeautify --renderer github-actions
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,26 +35,32 @@ jobs:
       - name: Set up build environment
         run: Scripts/CI/darwin_setup_build.sh
         shell: bash
+      - name: Install xcbeautify
+        run: brew install xcbeautify
       - name: Build and run tests in debug mode with coverage
         run: |
+          set -o pipefail
           swift test \
             -c debug \
             --filter OpenSwiftUITests \
             --filter OpenSwiftUICoreTests \
             --enable-code-coverage \
-            --build-path .build-test-debug
+            --build-path .build-test-debug \
+            | xcbeautify --renderer github-actions
           xcrun llvm-cov show \
             -instr-profile=.build-test-debug/debug/codecov/default.profdata \
             .build-test-debug/debug/OpenSwiftUIPackageTests.xctest/Contents/MacOS/OpenSwiftUIPackageTests \
             > coverage.txt
       - name: Build and run tests in release mode
         run: |
+          set -o pipefail
           swift test \
             -c release \
             --filter OpenSwiftUITests \
             --filter OpenSwiftUICoreTests \
             --enable-code-coverage \
-            --build-path .build-test-release
+            --build-path .build-test-release \
+            | xcbeautify --renderer github-actions
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Install [xcbeautify](https://github.com/cpisciotta/xcbeautify) via Homebrew in all macOS CI workflows
- Pipe `xcodebuild` and `swift test` output through `xcbeautify --renderer github-actions` for cleaner logs and inline annotations
- Updated workflows: `ios.yml`, `macos.yml`, `compatibility_tests.yml`, and `uitests` composite action