### PR TITLE
Fix ForEach crash for nested MultiViewRoot

### DIFF
--- a/Sources/OpenSwiftUICore/View/DynamicViewContent/ForEach.swift
+++ b/Sources/OpenSwiftUICore/View/DynamicViewContent/ForEach.swift
@@ -648,17 +648,14 @@ private class ForEachState<Data, ID, Content> where Data: RandomAccessCollection
     func applyNodes(
         from start: inout Int,
         style: ViewList.IteratorStyle,
-        list: Attribute<any ViewList>?,
+        list _: Attribute<any ViewList>?,
         transform: inout ViewList.SublistTransform,
         to body: ViewList.ApplyBody
     ) -> Bool {
         forEachItem(
             from: &start,
             style: style
-        ) {
-            start,
-            style,
-            item in
+        ) { start, style, item in
             let idGenerator = view!.idGenerator
             switch item.views {
             case let .staticList(elements):

--- a/Tests/OpenSwiftUICoreTests/Layout/ZIndexTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Layout/ZIndexTests.swift
@@ -17,8 +17,7 @@ struct ZIndexTests {
         #expect(collection.zIndex.isApproximatelyEqual(to: 1.5))
     }
 
-    #if canImport(Darwin)
-    @Test
+    @Test(.enabled(if: attributeGraphEnabled))
     func zIndexDisplayList() {
         struct ContentView: View {
             var body: some View {
@@ -56,5 +55,4 @@ struct ZIndexTests {
         """#)
         #expect(displayList.description.contains(expectRegex))
     }
-    #endif
 }

--- a/Tests/OpenSwiftUICoreTests/View/IDViewTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/IDViewTests.swift
@@ -3,6 +3,7 @@
 //  OpenSwiftUICoreTests
 
 import Foundation
+import OpenAttributeGraphShims
 import OpenSwiftUICore
 import Testing
 
@@ -16,8 +17,7 @@ struct IDViewTests {
         _ = empty.id(UUID())
     }
 
-    #if canImport(Darwin)
-    @Test
+    @Test(.enabled(if: attributeGraphEnabled))
     func idViewDisplayList() {
         struct ContentView: View {
             var body: some View {
@@ -51,5 +51,4 @@ struct IDViewTests {
         """#)
         #expect(displayList.description.contains(expectRegex))
     }
-    #endif
 }

--- a/Tests/OpenSwiftUICoreTests/View/VariadicView/VariadicViewTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/VariadicView/VariadicViewTests.swift
@@ -1,0 +1,117 @@
+//
+//  VariadicViewTests.swift
+//  OpenSwiftUICoreTests
+
+import Foundation
+import OpenAttributeGraphShims
+import OpenSwiftUICore
+import Testing
+
+@MainActor
+@Suite(.enabled(if: attributeGraphEnabled))
+struct VariadicViewTests {
+
+    struct PassthroughUnaryViewRoot: _VariadicView.UnaryViewRoot {
+        func body(children: _VariadicView.Children) -> some View {
+            children
+        }
+    }
+
+    struct PassthroughMultiViewRoot: _VariadicView.MultiViewRoot {
+        func body(children: _VariadicView.Children) -> some View {
+            children
+        }
+    }
+
+    @Test
+    func nestedUnaryViewRoot() {
+        struct ContentView: View {
+            var body: some View {
+                _VariadicView.Tree(PassthroughUnaryViewRoot()) {
+                    _VariadicView.Tree(PassthroughUnaryViewRoot()) {
+                        Color.red
+                        Color.blue
+                    }
+                }
+            }
+        }
+        let graph = ViewGraph(
+            rootViewType: ContentView.self,
+            requestedOutputs: [.displayList]
+        )
+        graph.instantiateOutputs()
+        graph.setRootView(ContentView())
+        graph.setProposedSize(CGSize(width: 100, height: 100))
+        let (displayList, _) = graph.displayList()
+        let expectRegex = try! Regex(
+            #"""
+            \(display-list
+              \(item #:identity \d+ #:version \d+
+                \(frame \([^)]+\)\)
+                \(effect
+                  \(item #:identity \d+ #:version \d+
+                    \(frame \([^)]+\)\)
+                    \(effect
+                      \(item #:identity \d+ #:version \d+
+                        \(frame \([^)]+\)\)
+                        \(content-seed \d+\)
+                        \(color #[0-9A-F]{8}\)\)\)\)
+                  \(item #:identity \d+ #:version \d+
+                    \(frame \([^)]+\)\)
+                    \(effect
+                      \(item #:identity \d+ #:version \d+
+                        \(frame \([^)]+\)\)
+                        \(content-seed \d+\)
+                        \(color #[0-9A-F]{8}\)\)\)\)\)\)\)
+            """#)
+        #expect(displayList.description.contains(expectRegex))
+    }
+
+    @Test(
+        .bug(
+            "https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/791",
+            id: 791,
+            "Nested MultiViewRoots should not cause a force unwrapping crash"
+        )
+    )
+    func nestedMultiViewRoot() {
+        struct ContentView: View {
+            var body: some View {
+                _VariadicView.Tree(PassthroughMultiViewRoot()) {
+                    _VariadicView.Tree(PassthroughMultiViewRoot()) {
+                        Color.red
+                        Color.blue
+                    }
+                }
+            }
+        }
+
+        let graph = ViewGraph(
+            rootViewType: ContentView.self,
+            requestedOutputs: [.displayList]
+        )
+        graph.instantiateOutputs()
+        graph.setRootView(ContentView())
+        graph.setProposedSize(CGSize(width: 100, height: 100))
+        let (displayList, _) = graph.displayList()
+        let expectRegex = try! Regex(
+            #"""
+            \(display-list
+              \(item #:identity \d+ #:version \d+
+                \(frame \([^)]+\)\)
+                \(effect
+                  \(item #:identity \d+ #:version \d+
+                    \(frame \([^)]+\)\)
+                    \(content-seed \d+\)
+                    \(color #[0-9A-F]{8}\)\)\)\)
+              \(item #:identity \d+ #:version \d+
+                \(frame \([^)]+\)\)
+                \(effect
+                  \(item #:identity \d+ #:version \d+
+                    \(frame \([^)]+\)\)
+                    \(content-seed \d+\)
+                    \(color #[0-9A-F]{8}\)\)\)\)\)
+            """#)
+        #expect(displayList.description.contains(expectRegex))
+    }
+}

--- a/Tests/OpenSwiftUITests/View/Configuration/ViewAliasTests.swift
+++ b/Tests/OpenSwiftUITests/View/Configuration/ViewAliasTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Testing
+import OpenAttributeGraphShims
 @testable import OpenSwiftUI
 @_spi(ForOpenSwiftUIOnly)
 import OpenSwiftUICore
@@ -11,8 +12,7 @@ import OpenSwiftUITestsSupport
 
 @MainActor
 struct ViewAliasTests {
-    #if canImport(Darwin)
-    @Test
+    @Test(.enabled(if: attributeGraphEnabled))
     func optionalViewAliasDynamicProperty() async throws {
         struct ContentView: View {
             var confirmation: Confirmation?
@@ -46,6 +46,7 @@ struct ViewAliasTests {
                     }
             }
         }
+        #if canImport(Darwin)
         try await triggerLayoutWithWindow(expectedCount: 2) { confirmation in
             PlatformHostingController(
                 rootView: ContentView(
@@ -53,8 +54,7 @@ struct ViewAliasTests {
                 )
             )
         }
-
-        // DisplayList expectation
+        #endif
         let graph = ViewGraph(
             rootViewType: ContentView.self,
             requestedOutputs: [.displayList]
@@ -76,5 +76,4 @@ struct ViewAliasTests {
         """#)
         #expect(displayList.description.contains(expectRegex))
     }
-    #endif
 }


### PR DESCRIPTION
## Summary
- Fix force-unwrap crash in `ForEachState.applyNodes` when `list` is nil, triggered by nesting `_VariadicView.MultiViewRoot`
- Extract static/dynamic list apply logic into `applyStaticList`/`applyDynamicList` methods
- Add `VariadicViewTests` covering nested unary and multi view roots

Closes #791