### PR TITLE
Add ApplicationDelegateAdapter support

### DIFF
--- a/Example/Example/EntryPoint.swift
+++ b/Example/Example/EntryPoint.swift
@@ -13,8 +13,8 @@ struct EntryPoint {
             BenchmarkApp.main()
         } else {
             ExampleApp.main()
-//            ObservableExampleApp.main()
 //            ObservableObjectExampleApp.main()
+//            ObservableExampleApp.main()
         }
     }
 }

--- a/Example/Example/EntryPoint.swift
+++ b/Example/Example/EntryPoint.swift
@@ -1,0 +1,20 @@
+//
+//  EntryPoint.swift
+//  Example
+//
+//  Created by Kyle on 2/23/26.
+//
+
+@main
+struct EntryPoint {
+    static func main() {
+        let runBenchmark = CommandLine.arguments.contains("benchmark")
+        if runBenchmark {
+            BenchmarkApp.main()
+        } else {
+            ExampleApp.main()
+//            ObservableExampleApp.main()
+//            ObservableObjectExampleApp.main()
+        }
+    }
+}

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -12,9 +12,58 @@ import SwiftUI
 #endif
 
 struct ExampleApp: App {
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    #else
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    #endif
+
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
     }
 }
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+import AppKit
+private class AppDelegate: NSResponder, NSApplicationDelegate {
+    var window: NSWindow?
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        return
+    }
+}
+#else
+import UIKit
+private class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+                                name: nil,
+                                sessionRole: connectingSceneSession.role)
+        if connectingSceneSession.role == .windowApplication {
+            configuration.delegateClass = SceneDelegate.self
+        }
+        return configuration
+    }
+}
+
+private class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        print("SceneDelegate will connect to scene: \(scene), session: \(session), options: \(connectionOptions)")
+    }
+}
+#endif

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -11,18 +11,6 @@ import OpenSwiftUI
 import SwiftUI
 #endif
 
-@main
-struct EntryPoint {
-    static func main() {
-        let runBenchmark = CommandLine.arguments.contains("benchmark")
-        if runBenchmark {
-            BenchmarkApp.main()
-        } else {
-            ExampleApp.main()
-        }
-    }
-}
-
 struct ExampleApp: App {
     var body: some Scene {
         WindowGroup {

--- a/Example/Example/ObservableExampleApp.swift
+++ b/Example/Example/ObservableExampleApp.swift
@@ -28,11 +28,17 @@ struct ObservableExampleApp: App {
 
 private struct ContentViewWrapper: View {
     @Environment(AppDelegate.self) private var appDelegate
+    #if canImport(UIKit)
+    @Environment(SceneDelegate.self) private var sceneDelegate
+    #endif
 
     var body: some View {
         ContentView()
             .onAppear {
                 print("appDelegate instance: \(appDelegate)")
+                #if canImport(UIKit)
+                print("sceneDelegate instance: \(sceneDelegate)")
+                #endif
             }
     }
 }
@@ -57,14 +63,43 @@ private class AppDelegate: NSResponder, NSApplicationDelegate {
 // Then Observation's Observable macro will conflict with OpenObservation's Observable macro.
 import class UIKit.UIApplication
 import class UIKit.UIResponder
+import class UIKit.UIScene
+import class UIKit.UISceneConfiguration
+import class UIKit.UISceneSession
 import class UIKit.UIWindow
 import protocol UIKit.UIApplicationDelegate
+import protocol UIKit.UIWindowSceneDelegate
+
 @Observable
 private class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(
+        _ application: UIApplication,
+        willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+                                name: nil,
+                                sessionRole: connectingSceneSession.role)
+        if connectingSceneSession.role == .windowApplication {
+            configuration.delegateClass = SceneDelegate.self
+        }
+        return configuration
+    }
+}
+
+@Observable
+private class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        print("SceneDelegate will connect to scene: \(scene), session: \(session), options: \(connectionOptions)")
     }
 }
 #endif

--- a/Example/Example/ObservableExampleApp.swift
+++ b/Example/Example/ObservableExampleApp.swift
@@ -1,0 +1,70 @@
+//
+//  ObservableExampleApp.swift
+//  Example
+//
+//  Created by Kyle on 2/23/26.
+//
+
+#if OPENSWIFTUI
+import OpenSwiftUI
+#else
+import SwiftUI
+#endif
+import OpenObservation
+
+struct ObservableExampleApp: App {
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    #else
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    #endif
+
+    var body: some Scene {
+        WindowGroup {
+            ContentViewWrapper()
+        }
+    }
+}
+
+private struct ContentViewWrapper: View {
+    @Environment(AppDelegate.self) private var appDelegate
+
+    var body: some View {
+        ContentView()
+            .onAppear {
+                print("appDelegate instance: \(appDelegate)")
+            }
+    }
+}
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+// Avoid AppKit export Foundation and Foundation export Observation issue.
+// Then Observation's Observable macro will conflict with OpenObservation's Observable macro.
+import class AppKit.NSResponder
+import class AppKit.NSWindow
+import protocol AppKit.NSApplicationDelegate
+import struct Foundation.Notification
+@Observable
+private class AppDelegate: NSResponder, NSApplicationDelegate {
+    var window: NSWindow?
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        return
+    }
+}
+#else
+// Avoid UIKit export Foundation and Foundation export Observation issue.
+// Then Observation's Observable macro will conflict with OpenObservation's Observable macro.
+import class UIKit.UIApplication
+import class UIKit.UIResponder
+import class UIKit.UIWindow
+import protocol UIKit.UIApplicationDelegate
+@Observable
+private class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        return true
+    }
+}
+#endif

--- a/Example/Example/ObservableObjectExampleApp.swift
+++ b/Example/Example/ObservableObjectExampleApp.swift
@@ -1,6 +1,9 @@
 //
-//  TestingHostApp.swift
-//  TestingHost
+//  ObservableObjectExampleApp.swift
+//  Example
+//
+//  Created by Kyle on 2/23/26.
+//
 
 #if OPENSWIFTUI
 import OpenSwiftUI
@@ -8,14 +11,13 @@ import OpenSwiftUI
 import SwiftUI
 #endif
 
-#if canImport(AppKit) && !targetEnvironment(macCatalyst)
-import AppKit
+#if OPENSWIFTUI_OPENCOMBINE
+import OpenCombine
 #else
-import UIKit
+import Combine
 #endif
 
-@main
-struct TestingHostApp: App {
+struct ObservableObjectExampleApp: App {
     #if canImport(AppKit) && !targetEnvironment(macCatalyst)
     @NSApplicationDelegateAdaptor private var appDelegate: AppDelegate
     #else
@@ -24,13 +26,25 @@ struct TestingHostApp: App {
 
     var body: some Scene {
         WindowGroup {
-            Color.red
+            ContentViewWrapper()
         }
     }
 }
 
+private struct ContentViewWrapper: View {
+    @EnvironmentObject private var appDelegate: AppDelegate
+
+    var body: some View {
+        ContentView()
+            .onAppear {
+                print("appDelegate instance: \(appDelegate)")
+            }
+    }
+}
+
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-class AppDelegate: NSResponder, NSApplicationDelegate {
+import AppKit
+private class AppDelegate: NSResponder, NSApplicationDelegate, ObservableObject {
     var window: NSWindow?
 
     func applicationWillFinishLaunching(_ notification: Notification) {
@@ -38,17 +52,11 @@ class AppDelegate: NSResponder, NSApplicationDelegate {
     }
 }
 #else
-class AppDelegate: UIResponder, UIApplicationDelegate {
+import UIKit
+private class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
     var window: UIWindow?
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        #if targetEnvironment(simulator)
-        // Disable hardware keyboards
-        let setHardwareLayout = NSSelectorFromString("setHardwareLayout:")
-        UITextInputMode.activeInputModes
-            .filter { $0.responds(to: setHardwareLayout) }
-            .forEach { $0.perform(setHardwareLayout, with: nil) }
-        #endif
         return true
     }
 }

--- a/Example/Example/ObservableObjectExampleApp.swift
+++ b/Example/Example/ObservableObjectExampleApp.swift
@@ -33,11 +33,17 @@ struct ObservableObjectExampleApp: App {
 
 private struct ContentViewWrapper: View {
     @EnvironmentObject private var appDelegate: AppDelegate
+    #if canImport(UIKit)
+    @EnvironmentObject private var sceneDelegate: SceneDelegate
+    #endif
 
     var body: some View {
         ContentView()
             .onAppear {
                 print("appDelegate instance: \(appDelegate)")
+                #if canImport(UIKit)
+                print("sceneDelegate instance: \(sceneDelegate)")
+                #endif
             }
     }
 }
@@ -56,8 +62,31 @@ import UIKit
 private class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
     var window: UIWindow?
 
-    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(
+        _ application: UIApplication,
+        willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+                                name: nil,
+                                sessionRole: connectingSceneSession.role)
+        if connectingSceneSession.role == .windowApplication {
+            configuration.delegateClass = SceneDelegate.self
+        }
+        return configuration
+    }
+}
+
+private class SceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        print("SceneDelegate will connect to scene: \(scene), session: \(session), options: \(connectionOptions)")
     }
 }
 #endif

--- a/Example/TestingHost/TestingHostApp.swift
+++ b/Example/TestingHost/TestingHostApp.swift
@@ -16,13 +16,10 @@ import UIKit
 
 @main
 struct TestingHostApp: App {
-    // FIXME: OpenSwiftUI does not support ApplicationDelegateAdaptor yet
-    #if !OPENSWIFTUI
     #if canImport(AppKit)
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     #else
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    #endif
     #endif
 
     var body: some Scene {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5674484bf7bbc724d2ca67ef1cd44e23efdec1b5c043a67cf261ccee1aa0127c",
+  "originHash" : "b36005096a927b31cc17e488c95a44530bd77204998767e62705dce923352587",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -444,6 +444,16 @@ extension Target {
         self.swiftSettings = swiftSettings
     }
 
+    func addOpenCombineCSettings() {
+        var cSettings = cSettings ?? []
+        cSettings.append(.define("OPENSWIFTUI_OPENCOMBINE"))
+        self.cSettings = cSettings
+
+        var cxxSettings = cxxSettings ?? []
+        cxxSettings.append(.define("OPENSWIFTUI_OPENCOMBINE"))
+        self.cxxSettings = cxxSettings
+    }
+
     func addSwiftLogSettings() {
         dependencies.append(.product(name: "Logging", package: "swift-log"))
         var swiftSettings = swiftSettings ?? []
@@ -879,6 +889,7 @@ if openCombineCondition {
     package.dependencies.append(
         .package(url: "https://github.com/OpenSwiftUIProject/OpenCombine.git", from: "0.15.0")
     )
+    cOpenSwiftUITarget.addOpenCombineCSettings()
     openSwiftUICoreTarget.addOpenCombineSettings()
     openSwiftUITarget.addOpenCombineSettings()
 }

--- a/Scripts/build-documentation.sh
+++ b/Scripts/build-documentation.sh
@@ -94,7 +94,8 @@ log_error() {
 # Function to run docc command
 rundocc() {
     if command -v xcrun >/dev/null 2>&1; then
-        DOCC_HTML_DIR="/Users/kyle/tmp/Doc/swift-docc-render/dist" xcrun docc "$@"
+        # To use a custom template, set DOCC_HTML_DIR to the dist path of swift-docc-render
+        xcrun docc "$@"
     else
         docc "$@"
     fi
@@ -358,6 +359,9 @@ if [[ -n "$DOCC_CATALOG" ]]; then
     if [[ -d "$SYMBOL_GRAPH_DIR" ]] && [[ -n "$(ls -A "$SYMBOL_GRAPH_DIR")" ]]; then
         DOCC_ARGS+=(--additional-symbol-graph-dir "$SYMBOL_GRAPH_DIR")
     fi
+
+    # Enabled experimental features:
+    DOCC_ARGS+=(--enable-experimental-overloaded-symbol-presentation)
 
     if [[ "$PREVIEW_MODE" == true ]]; then
         # Check if port is already in use

--- a/Sources/COpenSwiftUI/Util/ProtocolDescriptor.c
+++ b/Sources/COpenSwiftUI/Util/ProtocolDescriptor.c
@@ -20,3 +20,20 @@ const void *_sceneProtocolDescriptor(void) {
 const void *_commandsProtocolDescriptor(void) {
     return &$s11OpenSwiftUI8CommandsMp;
 }
+
+#if OPENSWIFTUI_OPENCOMBINE
+OPENSWIFTUI_EXPORT
+const void *$s11OpenCombine16ObservableObjectMp;
+
+const void *_observableObjectProtocolDescriptor(void) {
+    return &$s11OpenCombine16ObservableObjectMp;
+}
+
+#else
+OPENSWIFTUI_EXPORT
+const void *$s7Combine16ObservableObjectMp;
+
+const void *_observableObjectProtocolDescriptor(void) {
+    return &$s7Combine16ObservableObjectMp;
+}
+#endif

--- a/Sources/COpenSwiftUI/Util/ProtocolDescriptor.h
+++ b/Sources/COpenSwiftUI/Util/ProtocolDescriptor.h
@@ -15,4 +15,6 @@ const void *_sceneProtocolDescriptor(void);
 
 const void *_commandsProtocolDescriptor(void);
 
+const void *_observableObjectProtocolDescriptor(void);
+
 OPENSWIFTUI_ASSUME_NONNULL_END

--- a/Sources/OpenSwiftUI/App/App/AppKit/AppKitAppDelegate.swift
+++ b/Sources/OpenSwiftUI/App/App/AppKit/AppKitAppDelegate.swift
@@ -59,35 +59,13 @@ class AppDelegate: NSResponder, NSApplicationDelegate {
         // FIXME
         let items = AppGraph.shared?.rootSceneList?.items ?? []
         let view = items[0].value.view
-        let hostingVC = NSHostingController(rootView: view.frame(width: 500, height: 300))
+        let hostingVC = NSHostingController(rootView: view.frame(width: 500, height: 300).rootEnvironment())
         let windowVC = WindowController(hostingVC)
         windowVC.showWindow(nil)
         self.windowVC = windowVC
     }
     
     var windowVC: NSWindowController?
-}
-
-// FIXME: frame is zero
-final class WindowController<Content>: NSWindowController where Content: View {
-    init(_ hostingVC: NSHostingController<Content>) {
-        self.hostingVC = hostingVC
-        super.init(window: nil)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override var windowNibName: NSNib.Name? { "" }
-
-    let hostingVC: NSHostingController<Content>
-
-    override func loadWindow() {
-        window = NSWindow(contentViewController: hostingVC)
-        window?.center()
-    }
 }
 
 // MARK: - App Utils

--- a/Sources/OpenSwiftUI/App/App/AppKit/AppWindowsController.swift
+++ b/Sources/OpenSwiftUI/App/App/AppKit/AppWindowsController.swift
@@ -1,0 +1,112 @@
+//
+//  AppWindowsController.swift
+//  OpenSwiftUI
+//
+//  Audited for 6.5.4
+//  Status: Empty
+//  ID: 72F61A03E62F0A97E0761B990CF02152 (SwiftUI)
+
+#if os(macOS)
+import AppKit
+import OpenAttributeGraphShims
+
+// FIXME
+final class WindowController<Content>: NSWindowController where Content: View {
+    init(_ hostingVC: NSHostingController<Content>) {
+        self.hostingVC = hostingVC
+        super.init(window: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var windowNibName: NSNib.Name? { "" }
+
+    let hostingVC: NSHostingController<Content>
+
+    override func loadWindow() {
+        window = NSWindow(contentViewController: hostingVC)
+        window?.center()
+    }
+}
+
+// MARK: - RootEnvironmentModifier [FIXME]
+
+extension View {
+    func rootEnvironment(
+        sceneBridge: SceneBridge? = nil,
+        sceneDelegateBox: AnyFallbackDelegateBox? = nil,
+        sceneStorageValues: SceneStorageValues? = nil,
+        scenePhase: ScenePhase = .background,
+        sceneID: SceneID? = nil
+    ) -> some View {
+        modifier(RootEnvironmentModifier(
+            sceneBridge: sceneBridge,
+            sceneDelegateBox: sceneDelegateBox,
+            sceneStorageValues: sceneStorageValues,
+            scenePhase: scenePhase,
+            sceneID: sceneID
+        ))
+    }
+}
+
+private struct RootEnvironmentModifier: PrimitiveViewModifier, _GraphInputsModifier {
+    weak var sceneBridge: SceneBridge?
+    weak var sceneDelegateBox: AnyFallbackDelegateBox?
+    weak var sceneStorageValues: SceneStorageValues?
+    var scenePhase: ScenePhase
+    var sceneID: SceneID?
+
+    static func _makeInputs(
+        modifier: _GraphValue<Self>,
+        inputs: inout _GraphInputs
+    ) {
+        inputs.environment = Attribute(
+            Child(
+                modifier: modifier.value,
+                env: inputs.environment
+            )
+        )
+    }
+
+    struct Child: StatefulRule {
+        @Attribute var modifier: RootEnvironmentModifier
+        @Attribute var env: EnvironmentValues
+        var oldModifier: RootEnvironmentModifier?
+
+        typealias Value = EnvironmentValues
+
+        mutating func updateValue() {
+            let (modifier, modifierChanged) = $modifier.changedValue()
+            let (environment, environmentChanged) = $env.changedValue()
+            let shouldUpdate: Bool
+            if environmentChanged {
+                shouldUpdate = true
+            } else if modifierChanged && oldModifier.map({ compareValues($0, modifier) }) != false {
+                shouldUpdate = true
+            } else if !hasValue {
+                shouldUpdate = true
+            } else {
+                shouldUpdate = false
+            }
+            guard shouldUpdate else {
+                return
+            }
+            var result = environment
+            result[keyPath: SceneBridge.environmentStore] = modifier.sceneBridge
+            result.sceneStorageValues = modifier.sceneStorageValues
+            result.scenePhase = modifier.scenePhase
+            result.sceneID = modifier.sceneID
+            if modifier.scenePhase != .active {
+                result.redactionReasons.formUnion(.privacy)
+            }
+            modifier.sceneDelegateBox?.addDelegate(to: &result)
+            AppGraph.delegateBox?.addDelegate(to: &result)
+            value = result
+            oldModifier = modifier
+        }
+    }
+}
+#endif

--- a/Sources/OpenSwiftUI/App/App/AppKit/NSApplicationDelegateAdaptor.swift
+++ b/Sources/OpenSwiftUI/App/App/AppKit/NSApplicationDelegateAdaptor.swift
@@ -107,7 +107,7 @@ public struct NSApplicationDelegateAdaptor<DelegateType>: DynamicProperty where 
     /// If you want OpenSwiftUI to put the instantiated delegate in the
     /// ``Environment``, make sure the delegate class also conforms to the
     /// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
-    /// protocol. That causes OpenSwiftUI to invoke the ``init(_:)-1dott``
+    /// protocol. That causes OpenSwiftUI to invoke the ``init(_:)-9lq9g``
     /// initializer rather than this one.
     ///
     /// - Parameter delegateType: The type of application delegate that you
@@ -167,7 +167,7 @@ extension NSApplicationDelegateAdaptor where DelegateType: ObservableObject {
     ///     @EnvironmentObject private var appDelegate: MyAppDelegate
     ///
     /// If your delegate isn't an observable object, OpenSwiftUI invokes the
-    /// ``init(_:)-67u91`` initializer rather than this one, and doesn't
+    /// ``init(_:)-9v4ao`` initializer rather than this one, and doesn't
     /// put the delegate instance in the environment.
     ///
     /// - Parameter delegateType: The type of application delegate that you
@@ -250,7 +250,7 @@ extension NSApplicationDelegateAdaptor where DelegateType: Observable {
     ///     @Environment(MyAppDelegate.self) private var appDelegate
     ///
     /// If your delegate isn't observable, OpenSwiftUI invokes the
-    /// ``init(_:)-67u91`` initializer rather than this one, and doesn't
+    /// ``init(_:)-9v4ao`` initializer rather than this one, and doesn't
     /// put the delegate instance in the environment.
     ///
     /// - Parameter delegateType: The type of application delegate that you

--- a/Sources/OpenSwiftUI/App/App/AppKit/NSApplicationDelegateAdaptor.swift
+++ b/Sources/OpenSwiftUI/App/App/AppKit/NSApplicationDelegateAdaptor.swift
@@ -1,12 +1,13 @@
+
 //
-//  UIApplicationDelegateAdaptor.swift
+//  NSApplicationDelegateAdaptor.swift
 //  OpenSwiftUI
 //
 //  Audited for 6.5.4
 //  Status: Complete
 
-#if os(iOS) || os(visionOS)
-public import UIKit
+#if os(macOS)
+public import AppKit
 @_spi(ForOpenSwiftUIOnly)
 import OpenSwiftUICore
 #if OPENSWIFTUI_OPENCOMBINE
@@ -16,31 +17,31 @@ public import Combine
 #endif
 public import OpenObservation
 
-/// A property wrapper type that you use to create a UIKit app delegate.
+/// A property wrapper type that you use to create an AppKit app delegate.
 ///
 /// To handle app delegate callbacks in an app that uses the
 /// OpenSwiftUI life cycle, define a type that conforms to the
-/// [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+/// [NSApplicationDelegate](https://developer.apple.com/documentation/appkit/nsapplicationdelegate)
 /// protocol, and implement the delegate methods that you need. For example,
 /// you can implement the
-/// [application(_:didRegisterForRemoteNotificationsWithDeviceToken:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622958-application)
+/// [application(_:didRegisterForRemoteNotificationsWithDeviceToken:)](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428766-application)
 /// method to handle remote notification registration:
 ///
-///     class MyAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
+///     class MyAppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 ///         func application(
-///             _ application: UIApplication,
+///             _ application: NSApplication,
 ///             didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
 ///         ) {
 ///             // Record the device token.
 ///         }
 ///     }
 ///
-/// Then use the `UIApplicationDelegateAdaptor` property wrapper inside your
+/// Then use the `NSApplicationDelegateAdaptor` property wrapper inside your
 /// ``App`` declaration to tell OpenSwiftUI about the delegate type:
 ///
 ///     @main
 ///     struct MyApp: App {
-///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+///         @NSApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
 ///
 ///         var body: some Scene { ... }
 ///     }
@@ -66,84 +67,36 @@ public import OpenObservation
 /// > Important: Manage an app's life cycle events without using an app
 /// delegate whenever possible. For example, prefer to handle changes
 /// in ``ScenePhase`` instead of relying on delegate callbacks, like
-/// [application(_:didFinishLaunchingWithOptions:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application).
-///
-/// ### Scene delegates
-///
-/// Some iOS apps define a
-/// [UIWindowSceneDelegate](https://developer.apple.com/documentation/uikit/uiwindowscenedelegate)
-/// to handle scene-based events, like app shortcuts:
-///
-///     class MySceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
-///         func windowScene(
-///             _ windowScene: UIWindowScene,
-///             performActionFor shortcutItem: UIApplicationShortcutItem
-///         ) async -> Bool {
-///             // Do something with the shortcut...
-///
-///             return true
-///         }
-///     }
-///
-/// You can provide this kind of delegate to a SwiftUI app by returning the
-/// scene delegate's type from the
-/// [application(_:configurationForConnecting:options:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/3197905-application)
-/// method inside your app delegate:
-///
-///     extension MyAppDelegate {
-///         func application(
-///             _ application: UIApplication,
-///             configurationForConnecting connectingSceneSession: UISceneSession,
-///             options: UIScene.ConnectionOptions
-///         ) -> UISceneConfiguration {
-///
-///             let configuration = UISceneConfiguration(
-///                                     name: nil,
-///                                     sessionRole: connectingSceneSession.role)
-///             if connectingSceneSession.role == .windowApplication {
-///                 configuration.delegateClass = MySceneDelegate.self
-///             }
-///             return configuration
-///         }
-///     }
-///
-/// When you configure the
-/// [UISceneConfiguration](https://developer.apple.com/documentation/uikit/uisceneconfiguration)
-/// instance, you only need to indicate the delegate class, and not a scene
-/// class or storyboard. OpenSwiftUI creates and manages the delegate instance,
-/// and sends it any relevant delegate callbacks.
-///
-/// As with the app delegate, if you make your scene delegate an observable
-/// object, OpenSwiftUI automatically puts it in the ``Environment``, from where
-/// you can access it with the ``EnvironmentObject`` property wrapper, and
-/// create bindings to its published properties.
+/// [applicationDidFinishLaunching(_:)](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428385-applicationdidfinishlaunching).
 @available(OpenSwiftUI_v2_0, *)
-@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@available(visionOS, unavailable)
 @MainActor
 @preconcurrency
 @propertyWrapper
-public struct UIApplicationDelegateAdaptor<DelegateType>: DynamicProperty where DelegateType: NSObject, DelegateType: UIApplicationDelegate {
+public struct NSApplicationDelegateAdaptor<DelegateType>: DynamicProperty where DelegateType: NSObject, DelegateType: NSApplicationDelegate {
 
-    /// The underlying app delegate.
+    /// The underlying delegate.
     public var wrappedValue: DelegateType {
         if AppGraph.delegateBox == nil {
             Log.runtimeIssues(
-                "UIApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
+                "NSApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
             )
         }
         return AppGraph.delegateBox!.delegate! as! DelegateType
     }
 
-    /// Creates a UIKit app delegate adaptor.
+    /// Creates an AppKit app delegate adaptor.
     ///
     /// Call this initializer indirectly by creating a property with the
-    /// ``UIApplicationDelegateAdaptor`` property wrapper from inside your
+    /// ``NSApplicationDelegateAdaptor`` property wrapper from inside your
     /// ``App`` declaration:
     ///
     ///     @main
     ///     struct MyApp: App {
-    ///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+    ///         @NSApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
     ///
     ///         var body: some Scene { ... }
     ///     }
@@ -154,12 +107,12 @@ public struct UIApplicationDelegateAdaptor<DelegateType>: DynamicProperty where 
     /// If you want OpenSwiftUI to put the instantiated delegate in the
     /// ``Environment``, make sure the delegate class also conforms to the
     /// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
-    /// protocol. That causes OpenSwiftUI to invoke the ``init(_:)``
+    /// protocol. That causes OpenSwiftUI to invoke the ``init(_:)-1dott``
     /// initializer rather than this one.
     ///
     /// - Parameter delegateType: The type of application delegate that you
     ///   define in your app, which conforms to the
-    ///   [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+    ///   [NSApplicationDelegate](https://developer.apple.com/documentation/appkit/nsapplicationdelegate)
     ///   protocol.
     public init(_ delegateType: DelegateType.Type = DelegateType.self) {
         let box = FallbackDelegateBox<DelegateType>(nil)
@@ -174,7 +127,7 @@ public struct UIApplicationDelegateAdaptor<DelegateType>: DynamicProperty where 
     ) {
         guard GraphHost.currentHost is AppGraph else {
             Log.externalWarning(
-                "UIApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
+                "NSApplicationDelegateAdaptor used outside of App declaration."
             )
             return
         }
@@ -182,18 +135,22 @@ public struct UIApplicationDelegateAdaptor<DelegateType>: DynamicProperty where 
 }
 
 @available(OpenSwiftUI_v2_0, *)
-extension UIApplicationDelegateAdaptor where DelegateType: ObservableObject {
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+extension NSApplicationDelegateAdaptor where DelegateType: ObservableObject {
 
-    /// Creates a UIKit app delegate adaptor using a delegate that's
+    /// Creates an AppKit app delegate adaptor using a delegate that's
     /// an observable object.
     ///
     /// Call this initializer indirectly by creating a property with the
-    /// ``UIApplicationDelegateAdaptor`` property wrapper from inside your
+    /// ``NSApplicationDelegateAdaptor`` property wrapper from inside your
     /// ``App`` declaration:
     ///
     ///     @main
     ///     struct MyApp: App {
-    ///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+    ///         @NSApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
     ///
     ///         var body: some Scene { ... }
     ///     }
@@ -210,16 +167,15 @@ extension UIApplicationDelegateAdaptor where DelegateType: ObservableObject {
     ///     @EnvironmentObject private var appDelegate: MyAppDelegate
     ///
     /// If your delegate isn't an observable object, OpenSwiftUI invokes the
-    /// ``init(_:)-59sfu`` initializer rather than this one, and doesn't
+    /// ``init(_:)-67u91`` initializer rather than this one, and doesn't
     /// put the delegate instance in the environment.
     ///
     /// - Parameter delegateType: The type of application delegate that you
     ///   define in your app, which conforms to the
-    ///   [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+    ///   [NSApplicationDelegate](https://developer.apple.com/documentation/appkit/nsapplicationdelegate)
     ///   and
     ///   [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
     ///   protocols.
-    ///
     public init(_ delegateType: DelegateType.Type = DelegateType.self) {
         let box = ObservableObjectFallbackDelegateBox<DelegateType>()
         AppGraph.delegateBox = box
@@ -233,15 +189,15 @@ extension UIApplicationDelegateAdaptor where DelegateType: ObservableObject {
     /// delegate instance with a dollar sign (`$`). For example, you might
     /// publish a Boolean value in your application delegate:
     ///
-    ///     class MyAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
+    ///     class MyAppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     ///         @Published var isEnabled = false
     ///
     ///         // ...
     ///     }
     ///
     /// If you declare the delegate in your ``App`` using the
-    /// ``UIApplicationDelegateAdaptor`` property wrapper, you can get
-    /// the delegate that SwiftUI instantiates from the environment and
+    /// ``NSApplicationDelegateAdaptor`` property wrapper, you can get
+    /// the delegate that OpenSwiftUI instantiates from the environment and
     /// access a binding to its published values from any view in your app:
     ///
     ///     struct MyView: View {
@@ -255,7 +211,7 @@ extension UIApplicationDelegateAdaptor where DelegateType: ObservableObject {
     public var projectedValue: ObservedObject<DelegateType>.Wrapper {
         if AppGraph.delegateBox == nil {
             Log.runtimeIssues(
-                "UIApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
+                "NSApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
             )
         }
         return ObservedObject<DelegateType>.Wrapper(root: wrappedValue)
@@ -263,19 +219,21 @@ extension UIApplicationDelegateAdaptor where DelegateType: ObservableObject {
 }
 
 @available(OpenSwiftUI_v5_0, *)
-@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension UIApplicationDelegateAdaptor where DelegateType: Observable {
+@available(visionOS, unavailable)
+extension NSApplicationDelegateAdaptor where DelegateType: Observable {
 
-    /// Creates a UIKit app delegate adaptor using an observable delegate.
+    /// Creates an AppKit app delegate adaptor using an observable delegate.
     ///
     /// Call this initializer indirectly by creating a property with the
-    /// ``UIApplicationDelegateAdaptor`` property wrapper from inside your
+    /// ``NSApplicationDelegateAdaptor`` property wrapper from inside your
     /// ``App`` declaration:
     ///
     ///     @main
     ///     struct MyApp: App {
-    ///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+    ///         @NSApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
     ///
     ///         var body: some Scene { ... }
     ///     }
@@ -291,13 +249,13 @@ extension UIApplicationDelegateAdaptor where DelegateType: Observable {
     ///
     ///     @Environment(MyAppDelegate.self) private var appDelegate
     ///
-    /// If your delegate isn't observable, SwiftUI invokes the
-    /// ``init(_:)-59sfu`` initializer rather than this one, and doesn't
+    /// If your delegate isn't observable, OpenSwiftUI invokes the
+    /// ``init(_:)-67u91`` initializer rather than this one, and doesn't
     /// put the delegate instance in the environment.
     ///
     /// - Parameter delegateType: The type of application delegate that you
     ///   define in your app, which conforms to the
-    ///   [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+    ///   [NSApplicationDelegate](https://developer.apple.com/documentation/appkit/nsapplicationdelegate)
     ///   and
     ///   [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
     ///   protocols.
@@ -308,7 +266,9 @@ extension UIApplicationDelegateAdaptor where DelegateType: Observable {
 }
 
 @available(OpenSwiftUI_v2_0, *)
-@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 @available(watchOS, unavailable)
-extension UIApplicationDelegateAdaptor: Sendable {}
+@available(visionOS, unavailable)
+extension NSApplicationDelegateAdaptor: Sendable {}
 #endif

--- a/Sources/OpenSwiftUI/App/App/AppKit/NSApplicationDelegateAdaptor.swift
+++ b/Sources/OpenSwiftUI/App/App/AppKit/NSApplicationDelegateAdaptor.swift
@@ -1,4 +1,3 @@
-
 //
 //  NSApplicationDelegateAdaptor.swift
 //  OpenSwiftUI

--- a/Sources/OpenSwiftUI/App/App/FallbackDelegateBox.swift
+++ b/Sources/OpenSwiftUI/App/App/FallbackDelegateBox.swift
@@ -140,22 +140,3 @@ class ObjectFallbackDelegateBox<Delegate>: AnyFallbackDelegateBox where Delegate
         env[objectType: type(of: typedDelegate)] = typedDelegate
     }
 }
-
-// MARK: - ObservableObjectTypeVisitor
-
-protocol ObservableObjectTypeVisitor {
-    mutating func visit<T>(type: T.Type) where T: ObservableObject
-}
-
-// MARK: - MakeObservableObjectDelegateBox
-
-struct MakeObservableObjectDelegateBox: ObservableObjectTypeVisitor {
-    var value: Any
-    var box: AnyFallbackDelegateBox?
-
-    mutating func visit<T>(type: T.Type) where T: ObservableObject {
-        guard let delegate = value as? T else { return }
-        box = UnsafeObservableObjectFallbackDelegateBox<T>(delegate)
-    }
-}
-

--- a/Sources/OpenSwiftUI/App/App/FallbackDelegateBox.swift
+++ b/Sources/OpenSwiftUI/App/App/FallbackDelegateBox.swift
@@ -3,7 +3,7 @@
 //  OpenSwiftUI
 //
 //  Audited for 6.5.4
-//  Status: WIP
+//  Status: Complete
 
 public import Foundation
 #if OPENSWIFTUI_OPENCOMBINE
@@ -11,6 +11,7 @@ import OpenCombine
 #else
 import Combine
 #endif
+import OpenObservation
 
 class AnyFallbackDelegateBox {
     var delegate: NSObject? {
@@ -23,9 +24,10 @@ class AnyFallbackDelegateBox {
 }
 
 #if canImport(Darwin)
-public typealias PlatformApplicationDelegateBase = NSObject
+// NSObject on Cocoa platform has a init() method. We use PlatformApplicationDelegateBase to align them.
+typealias PlatformApplicationDelegateBase = NSObject
 #else
-public protocol PlatformApplicationDelegateBase: NSObject {
+protocol PlatformApplicationDelegateBase: NSObject {
     init()
 }
 #endif
@@ -61,4 +63,99 @@ class FallbackDelegateBox<Delegate>: AnyFallbackDelegateBox where Delegate: Plat
     }
 }
 
-// TODO
+// MARK: - ObservableObjectFallbackDelegateBox
+
+class ObservableObjectFallbackDelegateBox<Delegate>: AnyFallbackDelegateBox where Delegate: PlatformApplicationDelegateBase, Delegate: ObservableObject {
+    var typedDelegate: Delegate
+
+    override init() {
+        self.typedDelegate = Delegate()
+        super.init()
+    }
+
+    override var delegate: NSObject? {
+        typedDelegate
+    }
+
+    override func addDelegate(to env: inout EnvironmentValues) {
+        let keyPath = Delegate.environmentStore
+        env[keyPath: keyPath] = typedDelegate
+    }
+}
+
+// MARK: - UnsafeObservableObjectFallbackDelegateBox
+
+class UnsafeObservableObjectFallbackDelegateBox<Delegate>: AnyFallbackDelegateBox where Delegate: ObservableObject {
+    var typedDelegate: Delegate
+
+    init(_ delegate: Delegate) {
+        self.typedDelegate = delegate
+        super.init()
+    }
+
+    override var delegate: NSObject? {
+        typedDelegate as? NSObject
+    }
+
+    override func addDelegate(to env: inout EnvironmentValues) {
+        let keyPath = Delegate.environmentStore
+        env[keyPath: keyPath] = typedDelegate
+    }
+}
+
+// MARK: - ObservableFallbackDelegateBox
+
+class ObservableFallbackDelegateBox<Delegate>: AnyFallbackDelegateBox where Delegate: PlatformApplicationDelegateBase, Delegate: Observable {
+    var typedDelegate: Delegate
+
+    override init() {
+        self.typedDelegate = Delegate()
+        super.init()
+    }
+
+    override var delegate: NSObject? {
+        typedDelegate
+    }
+
+    override func addDelegate(to env: inout EnvironmentValues) {
+        env[objectType: Delegate.self] = typedDelegate
+    }
+}
+
+// MARK: - ObjectFallbackDelegateBox
+
+class ObjectFallbackDelegateBox<Delegate>: AnyFallbackDelegateBox where Delegate: AnyObject {
+    var typedDelegate: Delegate
+
+    init(_ delegate: Delegate) {
+        self.typedDelegate = delegate
+        super.init()
+    }
+
+    override var delegate: NSObject? {
+        typedDelegate as? NSObject
+    }
+
+    override func addDelegate(to env: inout EnvironmentValues) {
+        env[objectType: type(of: typedDelegate)] = typedDelegate
+    }
+}
+
+// MARK: - ObservableObjectTypeVisitor
+
+protocol ObservableObjectTypeVisitor {
+    mutating func visit<T>(type: T.Type) where T: ObservableObject
+}
+
+// MARK: - MakeObservableObjectDelegateBox
+
+struct MakeObservableObjectDelegateBox: ObservableObjectTypeVisitor {
+    var value: Any
+    var box: AnyFallbackDelegateBox?
+
+    mutating func visit<T>(type: T.Type) where T: ObservableObject {
+        guard let delegate = value as? T else { return }
+        box = UnsafeObservableObjectFallbackDelegateBox<T>(delegate)
+    }
+}
+

--- a/Sources/OpenSwiftUI/App/App/ObservableObjectDescriptor.swift
+++ b/Sources/OpenSwiftUI/App/App/ObservableObjectDescriptor.swift
@@ -1,0 +1,14 @@
+//
+//  ObservableObjectDescriptor.swift
+//  OpenSwiftUI
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+import COpenSwiftUI
+
+struct ObservableObjectDescriptor: ProtocolDescriptor {
+    static var descriptor: UnsafeRawPointer {
+        _observableObjectProtocolDescriptor()
+    }
+}

--- a/Sources/OpenSwiftUI/App/App/ObservableObjectDescriptor.swift
+++ b/Sources/OpenSwiftUI/App/App/ObservableObjectDescriptor.swift
@@ -6,9 +6,42 @@
 //  Status: Complete
 
 import COpenSwiftUI
+#if OPENSWIFTUI_OPENCOMBINE
+import OpenCombine
+#else
+import Combine
+#endif
+
+// MARK: - ObservableObjectTypeVisitor
+
+protocol ObservableObjectTypeVisitor {
+    mutating func visit<T>(type: T.Type) where T: ObservableObject
+}
+
+// MARK: - MakeObservableObjectDelegateBox
+
+struct MakeObservableObjectDelegateBox: ObservableObjectTypeVisitor {
+    var value: Any
+    var box: AnyFallbackDelegateBox?
+
+    mutating func visit<T>(type: T.Type) where T: ObservableObject {
+        guard let delegate = value as? T else { return }
+        box = UnsafeObservableObjectFallbackDelegateBox<T>(delegate)
+    }
+}
+
+// MARK: - ObservableObjectDescriptor
 
 struct ObservableObjectDescriptor: ProtocolDescriptor {
     static var descriptor: UnsafeRawPointer {
         _observableObjectProtocolDescriptor()
+    }
+}
+
+// MARK: - TypeConformance + ObservableObjectDescriptor
+
+extension TypeConformance where P == ObservableObjectDescriptor {
+    func visitType<V>(visitor: UnsafeMutablePointer<V>) where V: ObservableObjectTypeVisitor {
+        visitor.pointee.visit(type: unsafeExistentialMetatype((any ObservableObject.Type).self))
     }
 }

--- a/Sources/OpenSwiftUI/App/App/UIKit/UIApplicationDelegateAdaptor.swift
+++ b/Sources/OpenSwiftUI/App/App/UIKit/UIApplicationDelegateAdaptor.swift
@@ -154,7 +154,7 @@ public struct UIApplicationDelegateAdaptor<DelegateType>: DynamicProperty where 
     /// If you want OpenSwiftUI to put the instantiated delegate in the
     /// ``Environment``, make sure the delegate class also conforms to the
     /// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
-    /// protocol. That causes OpenSwiftUI to invoke the ``init(_:)``
+    /// protocol. That causes OpenSwiftUI to invoke the ``init(_:)-8bybh``
     /// initializer rather than this one.
     ///
     /// - Parameter delegateType: The type of application delegate that you
@@ -210,7 +210,7 @@ extension UIApplicationDelegateAdaptor where DelegateType: ObservableObject {
     ///     @EnvironmentObject private var appDelegate: MyAppDelegate
     ///
     /// If your delegate isn't an observable object, OpenSwiftUI invokes the
-    /// ``init(_:)-59sfu`` initializer rather than this one, and doesn't
+    /// ``init(_:)-9462f`` initializer rather than this one, and doesn't
     /// put the delegate instance in the environment.
     ///
     /// - Parameter delegateType: The type of application delegate that you
@@ -292,7 +292,7 @@ extension UIApplicationDelegateAdaptor where DelegateType: Observable {
     ///     @Environment(MyAppDelegate.self) private var appDelegate
     ///
     /// If your delegate isn't observable, SwiftUI invokes the
-    /// ``init(_:)-59sfu`` initializer rather than this one, and doesn't
+    /// ``init(_:)-9462f`` initializer rather than this one, and doesn't
     /// put the delegate instance in the environment.
     ///
     /// - Parameter delegateType: The type of application delegate that you

--- a/Sources/OpenSwiftUI/App/App/UIKit/UIApplicationDelegateAdaptor.swift
+++ b/Sources/OpenSwiftUI/App/App/UIKit/UIApplicationDelegateAdaptor.swift
@@ -1,0 +1,314 @@
+//
+//  UIApplicationDelegateAdaptor.swift
+//  OpenSwiftUI
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+#if os(iOS) || os(visionOS)
+public import UIKit
+@_spi(ForOpenSwiftUIOnly)
+import OpenSwiftUICore
+#if OPENSWIFTUI_OPENCOMBINE
+public import OpenCombine
+#else
+public import Combine
+#endif
+public import OpenObservation
+
+/// A property wrapper type that you use to create a UIKit app delegate.
+///
+/// To handle app delegate callbacks in an app that uses the
+/// OpenSwiftUI life cycle, define a type that conforms to the
+/// [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+/// protocol, and implement the delegate methods that you need. For example,
+/// you can implement the
+/// [application(_:didRegisterForRemoteNotificationsWithDeviceToken:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622958-application)
+/// method to handle remote notification registration:
+///
+///     class MyAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
+///         func application(
+///             _ application: UIApplication,
+///             didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+///         ) {
+///             // Record the device token.
+///         }
+///     }
+///
+/// Then use the `UIApplicationDelegateAdaptor` property wrapper inside your
+/// ``App`` declaration to tell OpenSwiftUI about the delegate type:
+///
+///     @main
+///     struct MyApp: App {
+///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+///
+///         var body: some Scene { ... }
+///     }
+///
+/// OpenSwiftUI instantiates the delegate and calls the delegate's
+/// methods in response to life cycle events. Define the delegate adaptor
+/// only in your ``App`` declaration, and only once for a given app. If
+/// you declare it more than once, OpenSwiftUI generates a runtime error.
+///
+/// If your app delegate conforms to the
+/// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
+/// protocol, as in the example above, then OpenSwiftUI puts the delegate it
+/// creates into the ``Environment``. You can access the delegate from
+/// any scene or view in your app using the ``EnvironmentObject`` property
+/// wrapper:
+///
+///     @EnvironmentObject private var appDelegate: MyAppDelegate
+///
+/// This enables you to use the dollar sign (`$`) prefix to get a binding to
+/// published properties that you declare in the delegate. For more information,
+/// see ``projectedValue``.
+///
+/// > Important: Manage an app's life cycle events without using an app
+/// delegate whenever possible. For example, prefer to handle changes
+/// in ``ScenePhase`` instead of relying on delegate callbacks, like
+/// [application(_:didFinishLaunchingWithOptions:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application).
+///
+/// ### Scene delegates
+///
+/// Some iOS apps define a
+/// [UIWindowSceneDelegate](https://developer.apple.com/documentation/uikit/uiwindowscenedelegate)
+/// to handle scene-based events, like app shortcuts:
+///
+///     class MySceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
+///         func windowScene(
+///             _ windowScene: UIWindowScene,
+///             performActionFor shortcutItem: UIApplicationShortcutItem
+///         ) async -> Bool {
+///             // Do something with the shortcut...
+///
+///             return true
+///         }
+///     }
+///
+/// You can provide this kind of delegate to a SwiftUI app by returning the
+/// scene delegate's type from the
+/// [application(_:configurationForConnecting:options:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/3197905-application)
+/// method inside your app delegate:
+///
+///     extension MyAppDelegate {
+///         func application(
+///             _ application: UIApplication,
+///             configurationForConnecting connectingSceneSession: UISceneSession,
+///             options: UIScene.ConnectionOptions
+///         ) -> UISceneConfiguration {
+///
+///             let configuration = UISceneConfiguration(
+///                                     name: nil,
+///                                     sessionRole: connectingSceneSession.role)
+///             if connectingSceneSession.role == .windowApplication {
+///                 configuration.delegateClass = MySceneDelegate.self
+///             }
+///             return configuration
+///         }
+///     }
+///
+/// When you configure the
+/// [UISceneConfiguration](https://developer.apple.com/documentation/uikit/uisceneconfiguration)
+/// instance, you only need to indicate the delegate class, and not a scene
+/// class or storyboard. OpenSwiftUI creates and manages the delegate instance,
+/// and sends it any relevant delegate callbacks.
+///
+/// As with the app delegate, if you make your scene delegate an observable
+/// object, OpenSwiftUI automatically puts it in the ``Environment``, from where
+/// you can access it with the ``EnvironmentObject`` property wrapper, and
+/// create bindings to its published properties.
+@available(OpenSwiftUI_v2_0, *)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+@preconcurrency
+@propertyWrapper
+public struct UIApplicationDelegateAdaptor<DelegateType>: DynamicProperty where DelegateType: NSObject, DelegateType: UIApplicationDelegate {
+
+    /// The underlying app delegate.
+    public var wrappedValue: DelegateType {
+        if AppGraph.delegateBox == nil {
+            Log.runtimeIssues(
+                "UIApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
+            )
+        }
+        return AppGraph.delegateBox!.delegate! as! DelegateType
+    }
+
+    /// Creates a UIKit app delegate adaptor.
+    ///
+    /// Call this initializer indirectly by creating a property with the
+    /// ``UIApplicationDelegateAdaptor`` property wrapper from inside your
+    /// ``App`` declaration:
+    ///
+    ///     @main
+    ///     struct MyApp: App {
+    ///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+    ///
+    ///         var body: some Scene { ... }
+    ///     }
+    ///
+    /// OpenSwiftUI initializes the delegate and manages its lifetime, calling upon
+    /// it to handle application delegate callbacks.
+    ///
+    /// If you want OpenSwiftUI to put the instantiated delegate in the
+    /// ``Environment``, make sure the delegate class also conforms to the
+    /// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
+    /// protocol. That causes OpenSwiftUI to invoke the ``init(_:)``
+    /// initializer rather than this one.
+    ///
+    /// - Parameter delegateType: The type of application delegate that you
+    ///   define in your app, which conforms to the
+    ///   [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+    ///   protocol.
+    public init(_ delegateType: DelegateType.Type = DelegateType.self) {
+        let box = FallbackDelegateBox<DelegateType>(nil)
+        AppGraph.delegateBox = box
+    }
+
+    nonisolated public static func _makeProperty<Value>(
+        in buffer: inout _DynamicPropertyBuffer,
+        container: _GraphValue<Value>,
+        fieldOffset: Int,
+        inputs: inout _GraphInputs
+    ) {
+        guard GraphHost.currentHost is AppGraph else {
+            Log.externalWarning(
+                "UIApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
+            )
+            return
+        }
+    }
+}
+
+@available(OpenSwiftUI_v2_0, *)
+extension UIApplicationDelegateAdaptor where DelegateType: ObservableObject {
+
+    /// Creates a UIKit app delegate adaptor using a delegate that's
+    /// an observable object.
+    ///
+    /// Call this initializer indirectly by creating a property with the
+    /// ``UIApplicationDelegateAdaptor`` property wrapper from inside your
+    /// ``App`` declaration:
+    ///
+    ///     @main
+    ///     struct MyApp: App {
+    ///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+    ///
+    ///         var body: some Scene { ... }
+    ///     }
+    ///
+    /// OpenSwiftUI initializes the delegate and manages its lifetime, calling it
+    /// as needed to handle application delegate callbacks.
+    ///
+    /// OpenSwiftUI invokes this method when your app delegate conforms to the
+    /// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
+    /// protocol. In this case, OpenSwiftUI automatically places the delegate in the
+    /// ``Environment``. You can access such a delegate from any scene or
+    /// view in your app using the ``EnvironmentObject`` property wrapper:
+    ///
+    ///     @EnvironmentObject private var appDelegate: MyAppDelegate
+    ///
+    /// If your delegate isn't an observable object, OpenSwiftUI invokes the
+    /// ``init(_:)-59sfu`` initializer rather than this one, and doesn't
+    /// put the delegate instance in the environment.
+    ///
+    /// - Parameter delegateType: The type of application delegate that you
+    ///   define in your app, which conforms to the
+    ///   [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+    ///   and
+    /// [ObservableObject](https://swiftpackageindex.com/openswiftuiproject/opencombine/main/documentation/opencombine/observableobject)
+    ///   protocols.
+    ///
+    public init(_ delegateType: DelegateType.Type = DelegateType.self) {
+        let box = ObservableObjectFallbackDelegateBox<DelegateType>()
+        AppGraph.delegateBox = box
+    }
+
+    /// A projection of the observed object that provides bindings to its
+    /// properties.
+    ///
+    /// Use the projected value to get a binding to a value that the delegate
+    /// publishes. Access the projected value by prefixing the name of the
+    /// delegate instance with a dollar sign (`$`). For example, you might
+    /// publish a Boolean value in your application delegate:
+    ///
+    ///     class MyAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
+    ///         @Published var isEnabled = false
+    ///
+    ///         // ...
+    ///     }
+    ///
+    /// If you declare the delegate in your ``App`` using the
+    /// ``UIApplicationDelegateAdaptor`` property wrapper, you can get
+    /// the delegate that SwiftUI instantiates from the environment and
+    /// access a binding to its published values from any view in your app:
+    ///
+    ///     struct MyView: View {
+    ///         @EnvironmentObject private var appDelegate: MyAppDelegate
+    ///
+    ///         var body: some View {
+    ///             Toggle("Enabled", isOn: $appDelegate.isEnabled)
+    ///         }
+    ///     }
+    ///
+    public var projectedValue: ObservedObject<DelegateType>.Wrapper {
+        if AppGraph.delegateBox == nil {
+            Log.runtimeIssues(
+                "UIApplicationDelegateAdaptor was used outside of an App or Scene; this will not instantiate the delegate."
+            )
+        }
+        return ObservedObject<DelegateType>.Wrapper(root: wrappedValue)
+    }
+}
+
+@available(OpenSwiftUI_v5_0, *)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+extension UIApplicationDelegateAdaptor where DelegateType: Observable {
+
+    /// Creates a UIKit app delegate adaptor using an observable delegate.
+    ///
+    /// Call this initializer indirectly by creating a property with the
+    /// ``UIApplicationDelegateAdaptor`` property wrapper from inside your
+    /// ``App`` declaration:
+    ///
+    ///     @main
+    ///     struct MyApp: App {
+    ///         @UIApplicationDelegateAdaptor private var appDelegate: MyAppDelegate
+    ///
+    ///         var body: some Scene { ... }
+    ///     }
+    ///
+    /// OpenSwiftUI initializes the delegate and manages its lifetime, calling it
+    /// as needed to handle application delegate callbacks.
+    ///
+    /// OpenSwiftUI invokes this method when your app delegate conforms to the
+    /// [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
+    /// protocol. In this case, OpenSwiftUI automatically places the delegate in the
+    /// ``Environment``. You can access such a delegate from any scene or
+    /// view in your app using the ``Environment`` property wrapper:
+    ///
+    ///     @Environment(MyAppDelegate.self) private var appDelegate
+    ///
+    /// If your delegate isn't observable, SwiftUI invokes the
+    /// ``init(_:)-59sfu`` initializer rather than this one, and doesn't
+    /// put the delegate instance in the environment.
+    ///
+    /// - Parameter delegateType: The type of application delegate that you
+    ///   define in your app, which conforms to the
+    ///   [UIApplicationDelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+    ///   and
+    ///   [Observable](https://swiftpackageindex.com/openswiftuiproject/openobservation/main/documentation/openobservation/observable)
+    ///   protocols.
+    public init(_ delegateType: DelegateType.Type = DelegateType.self) {
+        let box = ObservableFallbackDelegateBox<DelegateType>()
+        AppGraph.delegateBox = box
+    }
+}
+
+@available(OpenSwiftUI_v2_0, *)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+extension UIApplicationDelegateAdaptor: Sendable {}
+#endif

--- a/Sources/OpenSwiftUI/OpenSwiftUI.docc/AppStructure/AppOrganization/App-Organization.md
+++ b/Sources/OpenSwiftUI/OpenSwiftUI.docc/AppStructure/AppOrganization/App-Organization.md
@@ -16,7 +16,8 @@ WatchKit app’s delegate, define a delegate object and instantiate it in your a
 structure using an appropriate delegate adaptor property wrapper, like
 ``UIApplicationDelegateAdaptor``.
 
-For platform-specific design guidance, see [Platforms](https://developer.apple.com/design/human-interface-guidelines/platforms)
+For platform-specific design guidance, see
+ [Getting started](https://developer.apple.com/design/human-interface-guidelines/getting-started)
 in the Human Interface Guidelines for Apple Platform and
 [Windows Design Documentation](https://learn.microsoft.com/windows/apps/design)
 for Windows.
@@ -25,4 +26,14 @@ for Windows.
 
 ### Creating an app
 
+- [UILaunchScreen](https://developer.apple.com/documentation/bundleresources/information-property-list/uilaunchscreen)
+- [UILaunchScreens](https://developer.apple.com/documentation/bundleresources/information-property-list/uilaunchscreens)
 - ``App``
+
+### Targeting iOS and iPadOS
+
+- ``UIApplicationDelegateAdaptor``
+
+### Targeting macOS
+
+- ``NSApplicationDelegateAdaptor``

--- a/Sources/OpenSwiftUI/OpenSwiftUI.docc/AppStructure/AppOrganization/NSApplicationDelegateAdaptor.md
+++ b/Sources/OpenSwiftUI/OpenSwiftUI.docc/AppStructure/AppOrganization/NSApplicationDelegateAdaptor.md
@@ -1,0 +1,12 @@
+# ``NSApplicationDelegateAdaptor``
+
+## Topics
+
+### Creating a delegate adaptor
+
+- ``init(_:)``
+
+### Getting the delegate adaptor
+
+- ``projectedValue``
+- ``wrappedValue``

--- a/Sources/OpenSwiftUI/OpenSwiftUI.docc/AppStructure/AppOrganization/UIApplicationDelegateAdaptor.md
+++ b/Sources/OpenSwiftUI/OpenSwiftUI.docc/AppStructure/AppOrganization/UIApplicationDelegateAdaptor.md
@@ -1,0 +1,12 @@
+# ``UIApplicationDelegateAdaptor``
+
+## Topics
+
+### Creating a delegate adaptor
+
+- ``init(_:)``
+
+### Getting the delegate adaptor
+
+- ``projectedValue``
+- ``wrappedValue``

--- a/Sources/OpenSwiftUICore/Data/Combine/ObservedObject.swift
+++ b/Sources/OpenSwiftUICore/Data/Combine/ObservedObject.swift
@@ -89,9 +89,9 @@ public struct ObservedObject<ObjectType>: DynamicProperty where ObjectType: Obse
     @frozen
     public struct Wrapper {
 
-        let root: ObjectType
+        package let root: ObjectType
 
-        init(root: ObjectType) {
+        package init(root: ObjectType) {
             self.root = root
         }
 


### PR DESCRIPTION
Close #771

## Summary
- Add `UIApplicationDelegateAdaptor` and `NSApplicationDelegateAdaptor` property wrappers
- Add `ObservableObjectDescriptor` for runtime protocol conformance checking
- Update `FallbackDelegateBox` with `sceneDelegateBox` support for scene delegate lifecycle
- Add missing `RootEnvironmentModifier` logic for AppKit
- Add example apps demonstrating `AppDelegate` and `SceneDelegate` usage

## Test plan
- [ ] Verify UIApplicationDelegateAdaptor works with Observable delegate classes
- [ ] Verify NSApplicationDelegateAdaptor works on macOS
- [ ] Verify SceneDelegate forwarding and lifecycle callbacks
- [ ] Run existing tests with `swift test`