### PR TITLE
Add SFSymbols direct linking support via DarwinPrivateFrameworks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1a1b5ecad37792a3e2709ae10deec8d8827ca2bb901071248a9da60807c037f2",
+  "originHash" : "4692319eee6113f2d8ccdc00492a12e19ef48427441972e51e4f26e7cfb3e810",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "ad86657d9bdd98f7c40c977b34ff0c3de3e2fcee"
+        "revision" : "2064a4e298e54b6062b0ca0337ed4a44b88ff837"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -157,6 +157,7 @@ let renderBoxCondition = envBoolValue("RENDERBOX", default: buildForDarwinPlatfo
 let anyAttributeFix = envBoolValue("ANY_ATTRIBUTE_FIX", default: !buildForDarwinPlatform)
 
 let linkCoreUI = envBoolValue("LINK_COREUI", default: buildForDarwinPlatform && !isSPIBuild)
+let linkSFSymbols = envBoolValue("LINK_SFSYMBOLS", default: buildForDarwinPlatform && !isSPIBuild)
 let linkBacklightServices = envBoolValue("LINK_BACKLIGHTSERVICES", default: buildForDarwinPlatform && !isSPIBuild)
 // This should be disabled for UI test target due to link issue of Testing.
 // Only enable for non-UI test targets.
@@ -245,6 +246,10 @@ sharedCSettings.append(.define("OPENSWIFTUI_LINK_COREUI", to: linkCoreUI ? "1" :
 sharedCxxSettings.append(.define("OPENSWIFTUI_LINK_COREUI", to: linkCoreUI ? "1" : "0"))
 if linkCoreUI {
     sharedSwiftSettings.append(.define("OPENSWIFTUI_LINK_COREUI"))
+}
+
+if linkSFSymbols {
+    sharedSwiftSettings.append(.define("OPENSWIFTUI_LINK_SFSYMBOLS"))
 }
 
 sharedCSettings.append(
@@ -391,6 +396,10 @@ extension Target {
         // FIXME: Weird SwiftPM behavior for test Target. Otherwize we'll get the following error message
         // "could not determine executable path for bundle 'CoreUI.framework'"
         dependencies.append(.product(name: "CoreUI", package: "DarwinPrivateFrameworks"))
+    }
+
+    func addSFSymbolsSettings() {
+        dependencies.append(.product(name: "SFSymbols", package: "DarwinPrivateFrameworks"))
     }
 
     func addBacklightServicesSettings() {
@@ -832,6 +841,10 @@ if linkCoreUI {
     openSwiftUISPITarget.addCoreUISettings()
 }
 
+if linkSFSymbols {
+    openSwiftUICoreTarget.addSFSymbolsSettings()
+}
+
 if linkBacklightServices {
     openSwiftUITarget.addBacklightServicesSettings()
     openSwiftUISPITarget.addBacklightServicesSettings()
@@ -844,7 +857,7 @@ if useLocalDeps {
         .package(path: "../OpenRenderBox"),
         .package(path: "../OpenObservation"),
     ]
-    if attributeGraphCondition || renderBoxCondition || linkCoreUI || linkBacklightServices {
+    if attributeGraphCondition || renderBoxCondition || linkCoreUI || linkSFSymbols || linkBacklightServices {
         dependencies.append(.package(path: "../DarwinPrivateFrameworks"))
     }
     package.dependencies += dependencies
@@ -856,7 +869,7 @@ if useLocalDeps {
         .package(url: "https://github.com/OpenSwiftUIProject/OpenRenderBox", branch: "main"),
         .package(url: "https://github.com/OpenSwiftUIProject/OpenObservation", branch: "main"),
     ]
-    if attributeGraphCondition || renderBoxCondition || linkCoreUI {
+    if attributeGraphCondition || renderBoxCondition || linkCoreUI || linkSFSymbols {
         dependencies.append(.package(url: "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git", branch: "main"))
     }
     package.dependencies += dependencies

--- a/Sources/OpenSwiftUICore/Util/SFSymbolsShims.swift
+++ b/Sources/OpenSwiftUICore/Util/SFSymbolsShims.swift
@@ -2,31 +2,20 @@
 //  SFSymbolsShims.swift
 //  OpenSwiftUICore
 //
-//  Status: WIP
-
-// MARK: - SFSymbols Framework Access
-//
-// Currently uses dlopen/dlsym for dynamic symbol resolution at
-// runtime. This avoids a hard link dependency on the private SFSymbols
-// framework.
-//
-// TODO: Migrate to add SFSymbols in DarwinPrivateFrameworks package and link it with a new
-// OPENSWIFTUI_LINK_SFSYMBOLS build flag (following the CoreUI pattern).
-// When that migration happens:
-//   1. Add `import SFSymbols` under `#if OPENSWIFTUI_LINK_SFSYMBOLS`.
-//   2. Replace the dlopen-based implementations with direct calls.
-//   3. Call sites using `SFSymbols.symbol_order` etc. remain unchanged
-//      because Swift resolves `SFSymbols.x` identically whether `SFSymbols`
-//      is a local enum or a qualified module name.
+//  Status: Complete
 
 #if canImport(Darwin)
+
+#if OPENSWIFTUI_LINK_SFSYMBOLS
+import SFSymbols
+#else
 import Foundation
 
 /// Shim for the private SFSymbols framework.
 ///
 /// Property names intentionally use snake_case to match the framework's
 /// original API surface, ensuring a seamless migration to direct linking
-/// (Option C) with no source-breaking changes at call sites.
+/// with no source-breaking changes at call sites.
 package enum SFSymbols {
     // MARK: - Module-level Properties
 
@@ -74,4 +63,6 @@ package enum SFSymbols {
         return unsafeBitCast(sym, to: type)
     }
 }
+#endif
+
 #endif


### PR DESCRIPTION
## Summary
- Add `LINK_SFSYMBOLS` build flag and `OPENSWIFTUI_LINK_SFSYMBOLS` Swift define following the CoreUI pattern
- Bump DarwinPrivateFrameworks dependency to include the new SFSymbols product
- Replace dlopen/dlsym shim with direct `import SFSymbols` when the flag is enabled, keeping the dlopen fallback for non-linking builds

## Test plan
- [ ] Verify `swift build` succeeds with `OPENSWIFTUI_USE_LOCAL_DEPS=1`
- [ ] Verify `SFSymbolsShimsTests` pass on Darwin
- [ ] Verify non-Darwin / SPI builds still compile (dlopen fallback)