### PR TITLE
Remove release mode test steps from CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,16 +51,6 @@ jobs:
             -instr-profile=.build-test-debug/debug/codecov/default.profdata \
             .build-test-debug/debug/OpenSwiftUIPackageTests.xctest/Contents/MacOS/OpenSwiftUIPackageTests \
             > coverage.txt
-      - name: Build and run tests in release mode
-        run: |
-          set -o pipefail
-          NSUnbufferedIO=YES swift test \
-            -c release \
-            --filter OpenSwiftUITests \
-            --filter OpenSwiftUICoreTests \
-            --enable-code-coverage \
-            --build-path .build-test-release \
-            2>&1 | xcbeautify --renderer github-actions --preserve-unbeautified
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -41,14 +41,6 @@ jobs:
             .build-test-debug/debug/OpenSwiftUIPackageTests.xctest \
             > coverage.txt
         id: debug-test
-      - name: Building and running tests in release mode
-        run: |
-          swift test \
-            -c release \
-            --filter OpenSwiftUITests \
-            --filter OpenSwiftUICoreTests \
-            --build-path .build-test-release
-        id: release-test
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove "Build and run tests in release mode" step from macOS workflow
- Remove "Building and running tests in release mode" step from Ubuntu workflow
- Debug test + coverage steps remain unchanged

## Test plan
- [ ] Verify macOS CI workflow runs successfully without release test step
- [ ] Verify Ubuntu CI workflow runs successfully without release test step