### PR TITLE
[Bug Fix] Fix Linux build failure for SystemColorDefinition

### DIFF
--- a/Sources/OpenSwiftUICore/Graphic/Color/CoreUIDefaultSystemColorDefinition.swift
+++ b/Sources/OpenSwiftUICore/Graphic/Color/CoreUIDefaultSystemColorDefinition.swift
@@ -118,7 +118,6 @@ package struct CUIDesignLibraryCacheKey: Hashable {
 
 struct CoreUIDefaultSystemColorDefinition: SystemColorDefinition {
     static func value(for type: SystemColorType, environment: EnvironmentValues) -> Color.Resolved {
-        #if canImport(Darwin) && OPENSWIFTUI_LINK_COREUI
         let name: CUIColorName
         switch type {
         case .red: name = .red
@@ -144,20 +143,6 @@ struct CoreUIDefaultSystemColorDefinition: SystemColorDefinition {
         let cacheKey = CUIDesignLibraryCacheKey(name: name, in: environment, allowsBlendMode: false)
         let entry = cacheKey.fetch()
         return entry.color
-        #else
-        // For non CoreUI supported platform, simply return a plain Color.Resolved color or black for now
-        return switch type {
-        case .red: .red
-        case .green: .green
-        case .blue: .blue
-        case .primary: .black
-        case .secondary: .gray_75
-        case .tertiary: .gray_50
-        case .quaternary: .gray_25
-        default: .black
-        }
-        #endif
-
     }
 
     static func opacity(at level: Int, environment: EnvironmentValues) -> Float {

--- a/Sources/OpenSwiftUICore/Graphic/Color/SystemColors.swift
+++ b/Sources/OpenSwiftUICore/Graphic/Color/SystemColors.swift
@@ -255,7 +255,11 @@ struct SystemColorDefinitionType {
 
 private struct SystemColorDefinitionKey: EnvironmentKey {
     static var defaultValue: SystemColorDefinitionType {
+        #if canImport(Darwin) && OPENSWIFTUI_LINK_COREUI
         SystemColorDefinitionType(base: CoreUIDefaultSystemColorDefinition.self)
+        #else
+        SystemColorDefinitionType(base: DefaultSystemColorDefinition_PhoneTV.self)
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary
- `CoreUIDefaultSystemColorDefinition` is entirely guarded by `#if canImport(Darwin) && OPENSWIFTUI_LINK_COREUI`, so it doesn't exist on Linux
- Added the same platform guard to `SystemColorDefinitionKey.defaultValue`, falling back to `DefaultSystemColorDefinition_PhoneTV` on non-Darwin platforms
- Removed the now-redundant inner `#if` guard inside `CoreUIDefaultSystemColorDefinition.value(for:environment:)` since the whole file is already conditionally compiled

## Test plan
- [ ] Verify Ubuntu CI passes
- [ ] Verify macOS build still succeeds