### PR TITLE
Improve snapshot UITest artifact collection

### DIFF
--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -42,19 +42,21 @@ runs:
       shell: bash
       run: |
         cd Example
+        rm -rf /tmp/${{ inputs.platform }}-uitest.xcresult
         set -o pipefail
         NSUnbufferedIO=YES xcodebuild test \
           -scheme OSUI_UITests \
           -destination "${{ inputs.destination }}" \
           -skipMacroValidation \
           -skipPackagePluginValidation \
+          -resultBundlePath /tmp/${{ inputs.platform }}-uitest.xcresult \
           2>&1 | tee /tmp/${{ inputs.platform }}-uitest.log | xcbeautify --renderer github-actions --preserve-unbeautified
 
     - name: Collect failed snapshots
       if: steps.uitest.outcome == 'failure'
       shell: bash
       run: |
-        Scripts/CI/collect_uitest_failures.sh /tmp/${{ inputs.platform }}-uitest.log /tmp/uitest-artifacts
+        Scripts/CI/collect_uitest_failures.sh /tmp/${{ inputs.platform }}-uitest.log /tmp/uitest-artifacts /tmp/${{ inputs.platform }}-uitest.xcresult
 
     - name: Upload test artifacts
       if: steps.uitest.outcome == 'failure'

--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -56,7 +56,7 @@ runs:
       if: steps.uitest.outcome == 'failure'
       shell: bash
       run: |
-        Scripts/CI/collect_uitest_failures.sh /tmp/${{ inputs.platform }}-uitest.log /tmp/uitest-artifacts /tmp/${{ inputs.platform }}-uitest.xcresult
+        Scripts/CI/collect_uitest_failures.sh /tmp/${{ inputs.platform }}-uitest.log /tmp/uitest-artifacts
 
     - name: Upload test artifacts
       if: steps.uitest.outcome == 'failure'
@@ -64,4 +64,12 @@ runs:
       with:
         name: ${{ inputs.artifact-name }}
         path: /tmp/uitest-artifacts/
+        retention-days: 7
+
+    - name: Upload xcresult bundle
+      if: steps.uitest.outcome == 'failure'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}-xcresult
+        path: /tmp/${{ inputs.platform }}-uitest.xcresult
         retention-days: 7

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -1373,10 +1373,10 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		275752022DEE147E003E467C /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
+			repositoryURL = "https://github.com/OpenSwiftUIProject/swift-snapshot-testing";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.18.4;
+				kind = exactVersion;
+				version = "1.18.9-osui";
 			};
 		};
 		278EF52B2E2272F2009C32EB /* XCRemoteSwiftPackageReference "equatable" */ = {

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c7e770eca4f57decd049cfbd48df537df88fad4eb98858a526f2bf297292e5be",
+  "originHash" : "f0af95bb2c5004a0c959c13b9912f962e247bb17fa1e7b4a9a3fb11002b4f7ec",
   "pins" : [
     {
       "identity" : "equatable",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "2a2a938798236b8fa0bc57c453ee9de9f9ec3ab0",
-        "version" : "1.4.1"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {
@@ -49,10 +49,10 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "location" : "https://github.com/OpenSwiftUIProject/swift-snapshot-testing",
       "state" : {
-        "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
-        "version" : "1.18.9"
+        "revision" : "6456a4fd141fa6ae4aedfb433987038293220cfd",
+        "version" : "1.18.9-osui"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
-        "version" : "1.8.1"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Scripts/CI/collect_uitest_failures.sh
+++ b/Scripts/CI/collect_uitest_failures.sh
@@ -3,15 +3,17 @@
 set -e
 
 if [ $# -lt 2 ]; then
-    echo "Usage: $0 <test_log_file> <output_dir>"
+    echo "Usage: $0 <test_log_file> <output_dir> [xcresult_path]"
     exit 1
 fi
 
 TEST_LOG="$1"
 OUTPUT_DIR="$2"
+XCRESULT_PATH="${3:-}"
 
 mkdir -p "$OUTPUT_DIR/reference"
 mkdir -p "$OUTPUT_DIR/failed"
+mkdir -p "$OUTPUT_DIR/diff"
 mkdir -p "$OUTPUT_DIR/logs"
 
 cp "$TEST_LOG" "$OUTPUT_DIR/logs/test_output.log" || true
@@ -38,17 +40,43 @@ grep -E 'odiff ".*" ".*"' "$TEST_LOG" | while IFS= read -r line; do
         mkdir -p "$OUTPUT_DIR/failed/$foldername"
         cp "$failed_path" "$OUTPUT_DIR/failed/$foldername/$filename"
         echo "Copied failed: $foldername/$filename"
+
+        # Generate diff image using odiff if both reference and failed exist
+        if [ -f "$reference_path" ] && command -v odiff &>/dev/null; then
+            ref_foldername=$(basename "$(dirname "$reference_path")")
+            mkdir -p "$OUTPUT_DIR/diff/$foldername"
+            diff_output="$OUTPUT_DIR/diff/$foldername/$filename"
+            odiff "$reference_path" "$failed_path" "$diff_output" 2>/dev/null || true
+            if [ -f "$diff_output" ]; then
+                echo "Generated diff: $foldername/$filename"
+            fi
+        fi
     else
         echo "Failed snapshot not found: $failed_path"
     fi
 done
 
-reference_count=$(ls -1 "$OUTPUT_DIR/reference" 2>/dev/null | wc -l)
-failed_count=$(ls -1 "$OUTPUT_DIR/failed" 2>/dev/null | wc -l)
+# Copy xcresult bundle if provided and exists
+if [ -n "$XCRESULT_PATH" ] && [ -d "$XCRESULT_PATH" ]; then
+    mkdir -p "$OUTPUT_DIR/xcresult"
+    cp -R "$XCRESULT_PATH" "$OUTPUT_DIR/xcresult/"
+    echo "Copied xcresult bundle: $(basename "$XCRESULT_PATH")"
+fi
 
+reference_count=$(find "$OUTPUT_DIR/reference" -type f 2>/dev/null | wc -l)
+failed_count=$(find "$OUTPUT_DIR/failed" -type f 2>/dev/null | wc -l)
+diff_count=$(find "$OUTPUT_DIR/diff" -type f 2>/dev/null | wc -l)
+
+echo ""
 echo "Collection complete:"
 echo "  Reference images: $reference_count"
 echo "  Failed images: $failed_count"
+echo "  Diff images: $diff_count"
+if [ -n "$XCRESULT_PATH" ] && [ -d "$XCRESULT_PATH" ]; then
+    echo "  xcresult bundle: copied"
+else
+    echo "  xcresult bundle: not provided or not found"
+fi
 
 if [ "$reference_count" -eq 0 ] && [ "$failed_count" -eq 0 ]; then
     echo "No failed snapshots found in test log"

--- a/Scripts/CI/collect_uitest_failures.sh
+++ b/Scripts/CI/collect_uitest_failures.sh
@@ -3,17 +3,15 @@
 set -e
 
 if [ $# -lt 2 ]; then
-    echo "Usage: $0 <test_log_file> <output_dir> [xcresult_path]"
+    echo "Usage: $0 <test_log_file> <output_dir>"
     exit 1
 fi
 
 TEST_LOG="$1"
 OUTPUT_DIR="$2"
-XCRESULT_PATH="${3:-}"
 
 mkdir -p "$OUTPUT_DIR/reference"
 mkdir -p "$OUTPUT_DIR/failed"
-mkdir -p "$OUTPUT_DIR/diff"
 mkdir -p "$OUTPUT_DIR/logs"
 
 cp "$TEST_LOG" "$OUTPUT_DIR/logs/test_output.log" || true
@@ -40,43 +38,18 @@ grep -E 'odiff ".*" ".*"' "$TEST_LOG" | while IFS= read -r line; do
         mkdir -p "$OUTPUT_DIR/failed/$foldername"
         cp "$failed_path" "$OUTPUT_DIR/failed/$foldername/$filename"
         echo "Copied failed: $foldername/$filename"
-
-        # Generate diff image using odiff if both reference and failed exist
-        if [ -f "$reference_path" ] && command -v odiff &>/dev/null; then
-            ref_foldername=$(basename "$(dirname "$reference_path")")
-            mkdir -p "$OUTPUT_DIR/diff/$foldername"
-            diff_output="$OUTPUT_DIR/diff/$foldername/$filename"
-            odiff "$reference_path" "$failed_path" "$diff_output" 2>/dev/null || true
-            if [ -f "$diff_output" ]; then
-                echo "Generated diff: $foldername/$filename"
-            fi
-        fi
     else
         echo "Failed snapshot not found: $failed_path"
     fi
 done
 
-# Copy xcresult bundle if provided and exists
-if [ -n "$XCRESULT_PATH" ] && [ -d "$XCRESULT_PATH" ]; then
-    mkdir -p "$OUTPUT_DIR/xcresult"
-    cp -R "$XCRESULT_PATH" "$OUTPUT_DIR/xcresult/"
-    echo "Copied xcresult bundle: $(basename "$XCRESULT_PATH")"
-fi
-
 reference_count=$(find "$OUTPUT_DIR/reference" -type f 2>/dev/null | wc -l)
 failed_count=$(find "$OUTPUT_DIR/failed" -type f 2>/dev/null | wc -l)
-diff_count=$(find "$OUTPUT_DIR/diff" -type f 2>/dev/null | wc -l)
 
 echo ""
 echo "Collection complete:"
 echo "  Reference images: $reference_count"
 echo "  Failed images: $failed_count"
-echo "  Diff images: $diff_count"
-if [ -n "$XCRESULT_PATH" ] && [ -d "$XCRESULT_PATH" ]; then
-    echo "  xcresult bundle: copied"
-else
-    echo "  xcresult bundle: not provided or not found"
-fi
 
 if [ "$reference_count" -eq 0 ] && [ "$failed_count" -eq 0 ]; then
     echo "No failed snapshots found in test log"


### PR DESCRIPTION
## Summary
- Update `swift-snapshot-testing` dependency to fork version with Swift Testing attachment support (ref/fail/diff images as XCTAttachments in xcresult)
- Add `-resultBundlePath` to OSUI xcodebuild command in CI to capture xcresult bundle
- Upload xcresult bundle as a separate CI artifact for direct viewing of snapshot diffs
- Use `find` instead of `ls` for accurate file counting in collect script

## Test plan
- [x] Ran SUI_UITests to record 207 baseline reference images
- [x] Ran OSUI_UITests — 131 tests, 1 real failure (AsyncImage), 16 known issues (animation timing)
- [x] Verified xcresult contains Swift Testing attachments (reference.png, failure.png, difference.png)
- [x] Verified collect script collects reference + failed images and logs