### PR TITLE
[Feature] Add Xcode Preview support for OpenSwiftUI

### DIFF
--- a/Example/Shared/PreviewShims.swift
+++ b/Example/Shared/PreviewShims.swift
@@ -1,0 +1,40 @@
+//
+//  PreviewShims.swift
+//  Shared
+
+import OpenSwiftUI
+import SwiftUI
+
+// Helper method before we add fully preview thunk and preview macro support for OpenSwiftUI
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+import AppKit
+extension OpenSwiftUI.View {
+    func _previewVC() -> some NSViewController {
+        OpenSwiftUI.NSHostingController(rootView: self)
+    }
+}
+extension SwiftUI.View {
+    func _previewVC() -> some NSViewController {
+        SwiftUI.NSHostingController(rootView: self)
+    }
+}
+#else
+import UIKit
+extension OpenSwiftUI.View {
+    func _previewVC() -> some UIViewController {
+        OpenSwiftUI.UIHostingController(rootView: self)
+    }
+}
+extension SwiftUI.View {
+    func _previewVC() -> some UIViewController {
+        SwiftUI.UIHostingController(rootView: self)
+    }
+}
+#endif
+
+#Preview {
+    // FIXME: Not working on macOS yet
+    ContentView()
+        ._previewVC()
+}

--- a/Sources/OpenSwiftUICore/Graph/GraphHost.swift
+++ b/Sources/OpenSwiftUICore/Graph/GraphHost.swift
@@ -690,11 +690,26 @@ extension Graph {
     }
 }
 
-// MARK: - Preview
+// MARK: - Preview [6.5.4]
 
 private var blockedGraphHosts: [Unmanaged<GraphHost>] = []
-private let waitingForPreviewThunks = EnvironmentHelper.bool(for: "XCODE_RUNNING_FOR_PREVIEWS")
+// NOTE: In SwiftUI, PreviewsInjection.framework's DYLDDynamicProductLoader calls
+// SwiftUI.__previewThunksHaveFinishedLoading() via a library-specific GOT binding after
+// all preview dylibs are dlopen'd. This unblocks graph instantiation for waiting hosts.
+// Since the binding targets SwiftUI specifically (two-level namespace), OpenSwiftUI's
+// version is never called. We disable the blocking to allow graph instantiation in Preview.
+// TODO: Re-enable when OpenSwiftUI implements its own preview thunk registration system.
+private var waitingForPreviewThunks = false // EnvironmentHelper.bool(for: "XCODE_RUNNING_FOR_PREVIEWS")
 
 public func __previewThunksHaveFinishedLoading() {
-    _openSwiftUIUnimplementedFailure()
+    guard waitingForPreviewThunks else { return }
+    waitingForPreviewThunks = false
+    let hosts = blockedGraphHosts
+    blockedGraphHosts = []
+    for host in hosts {
+        let graphHost = host.takeUnretainedValue()
+        if let graphDelegate = graphHost.graphDelegate {
+            graphDelegate.graphDidChange()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fix Xcode Preview rendering by disabling `waitingForPreviewThunks` blocking
- SwiftUI's `PreviewsInjection.framework` calls `__previewThunksHaveFinishedLoading()` via a two-level namespace binding targeting SwiftUI, so OpenSwiftUI's version is never invoked — causing graph instantiation to block indefinitely
- Implement `__previewThunksHaveFinishedLoading()` to properly unblock graph hosts
- Add `PreviewShims.swift` helper to bridge OpenSwiftUI views into `#Preview` via hosting controllers

<img width="1359" height="969" alt="Simulator" src="https://github.com/user-attachments/assets/70229d7c-3544-4d63-835c-0323f60d3939" />

![diagram](https://github.com/user-attachments/assets/0b7f2db2-7dd4-4192-a8e5-cb8562134b27)

