### PR TITLE
[CI] Preserve xcresult bundle structure in CI artifacts

### DIFF
--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -71,13 +71,14 @@ runs:
       shell: bash
       run: |
         cd /tmp
-        zip -r -q ${{ inputs.platform }}-uitest.xcresult.zip ${{ inputs.platform }}-uitest.xcresult
+        mv ${{ inputs.platform }}-uitest.xcresult ${{ inputs.artifact-name }}.xcresult
+        zip -r -q ${{ inputs.artifact-name }}.xcresult.zip ${{ inputs.artifact-name }}.xcresult
 
     - name: Upload xcresult bundle
       if: steps.uitest.outcome == 'failure'
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ inputs.artifact-name }}-xcresult.zip
-        path: /tmp/${{ inputs.platform }}-uitest.xcresult.zip
+        name: ${{ inputs.artifact-name }}.xcresult.zip
+        path: /tmp/${{ inputs.artifact-name }}.xcresult.zip
         archive: false
         retention-days: 7

--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -66,10 +66,18 @@ runs:
         path: /tmp/uitest-artifacts/
         retention-days: 7
 
+    - name: Zip xcresult bundle
+      if: steps.uitest.outcome == 'failure'
+      shell: bash
+      run: |
+        cd /tmp
+        zip -r -q ${{ inputs.platform }}-uitest.xcresult.zip ${{ inputs.platform }}-uitest.xcresult
+
     - name: Upload xcresult bundle
       if: steps.uitest.outcome == 'failure'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
-        name: ${{ inputs.artifact-name }}-xcresult
-        path: /tmp/${{ inputs.platform }}-uitest.xcresult
+        name: ${{ inputs.artifact-name }}-xcresult.zip
+        path: /tmp/${{ inputs.platform }}-uitest.xcresult.zip
+        archive: false
         retention-days: 7


### PR DESCRIPTION
## Summary
- Zip the `.xcresult` bundle before uploading to preserve its macOS package structure
- Bump `upload-artifact` from v4 to v7 with `archive: false` to avoid double-zipping

Fixes the issue where downloading the `macos-uitest-snapshots-xcresult.zip` artifact would produce a flat `macos-uitest-snapshots-xcresult/` folder instead of a proper `.xcresult` bundle.

Reference: https://github.com/actions/upload-artifact/issues/39

## Test plan
- [ ] Trigger a UI test failure and verify the downloaded xcresult artifact extracts as a valid `.xcresult` bundle openable in Xcode