### PR TITLE
[Docs] Add Preview support documentation

### DIFF
--- a/Docs/Preview.md
+++ b/Docs/Preview.md
@@ -1,0 +1,91 @@
+# Preview Support
+
+## Current Status
+
+OpenSwiftUI supports Xcode Preview rendering as of [PR #829](https://github.com/OpenSwiftUIProject/OpenSwiftUI/pull/829).
+
+### How It Works
+
+Since OpenSwiftUI cannot use SwiftUI's `#Preview` macro directly (it targets `SwiftUI.View`), we use a **shim-based approach**:
+
+1. A `_previewVC()` helper wraps an `OpenSwiftUI.View` in a platform hosting controller (`UIHostingController` / `NSHostingController`)
+2. The hosting controller (a `UIViewController` / `NSViewController`) is returned to SwiftUI's `#Preview` macro
+
+```swift
+#Preview("HostingVC") {
+    ContentView()._previewVC()
+}
+```
+
+For `CAHostingLayer`-based previews:
+
+```swift
+#Preview("CAHostingLayerExample") {
+    CAHostingLayerExample(
+        content: ContentView(),
+        size: UIScreen.main.bounds.size
+    ).makeViewController()
+}
+```
+
+### The `waitingForPreviewThunks` Problem
+
+In Xcode Preview mode, SwiftUI gates graph instantiation behind a `waitingForPreviewThunks` flag (checked via `XCODE_RUNNING_FOR_PREVIEWS` env var). After all preview dylibs are loaded, `PreviewsInjection.framework` calls `SwiftUI.__previewThunksHaveFinishedLoading()` to unblock graph hosts.
+
+**The problem**: `PreviewsInjection` calls SwiftUI's version via a **library-specific GOT binding** (two-level namespace). OpenSwiftUI's version is never called, causing graph instantiation to block indefinitely and producing an empty display list.
+
+**Current fix**: `waitingForPreviewThunks` is hardcoded to `false`, bypassing the blocking entirely. This is semantically correct because OpenSwiftUI has no preview thunk producers today.
+
+## PreviewsInjection Sequence
+
+```mermaid
+sequenceDiagram
+    participant PI as PreviewsInjection
+    participant XOJIT as XOJITExecutor
+    participant DPL as DYLDDynamicProductLoader
+    participant SUI as SwiftUI
+    participant GH as GraphHost
+
+    Note over GH: waitingForPreviewThunks = true
+    Note over GH: instantiateIfNeeded() → BLOCKED
+
+    PI->>PI: __previews_injection_jit_link_entrypoint()
+    PI->>PI: Check __PREVIEWS_JIT_LINK env var
+    PI->>XOJIT: handleRunProgramOnMainThread()
+
+    Note over DPL: Called during JIT execution
+    loop For each DynamicProduct
+        alt .dylib type
+            DPL->>DPL: dlopen(bundlePath)
+            Note over DPL: Thunks registered during dlopen
+        else .xojit type
+            DPL->>DPL: Skip (already loaded by XOJIT)
+        end
+    end
+
+    DPL->>SUI: __previewThunksHaveFinishedLoading()
+    SUI->>SUI: waitingForPreviewThunks = false
+    SUI->>GH: graphDelegate.graphDidChange() for each blocked host
+    Note over GH: Next layout pass → instantiate() → renders
+
+    PI->>XOJIT: waitForTermination()
+```
+
+## Future Plan
+
+The current shim-based approach is a temporary bridge. The long-term goal is for OpenSwiftUI to have its **own** native preview support:
+
+### Phase 1: Own `#Preview` Macro
+- Implement OpenSwiftUI's own `#Preview` macro that targets `OpenSwiftUI.View` directly
+- Eliminate the need for `_previewVC()` shims and hosting controller wrappers
+- Users would write `#Preview { MyView() }` with OpenSwiftUI views directly
+
+### Phase 2: Own Preview Thunk Registration
+- Implement an independent preview thunk registration system
+- Re-enable `waitingForPreviewThunks` with OpenSwiftUI's own unblocking mechanism
+- Decouple entirely from `PreviewsInjection.framework`'s SwiftUI-specific GOT binding
+
+### Phase 3: Non-Apple Preview Host
+- Build a standalone preview host that works outside Xcode
+- Enable live previews on Linux/Windows where Xcode is not available
+- Support hot-reload workflows independent of Apple's preview infrastructure

--- a/Docs/Preview.md
+++ b/Docs/Preview.md
@@ -17,17 +17,6 @@ Since OpenSwiftUI cannot use SwiftUI's `#Preview` macro directly (it targets `Sw
 }
 ```
 
-For `CAHostingLayer`-based previews:
-
-```swift
-#Preview("CAHostingLayerExample") {
-    CAHostingLayerExample(
-        content: ContentView(),
-        size: UIScreen.main.bounds.size
-    ).makeViewController()
-}
-```
-
 ### The `waitingForPreviewThunks` Problem
 
 In Xcode Preview mode, SwiftUI gates graph instantiation behind a `waitingForPreviewThunks` flag (checked via `XCODE_RUNNING_FOR_PREVIEWS` env var). After all preview dylibs are loaded, `PreviewsInjection.framework` calls `SwiftUI.__previewThunksHaveFinishedLoading()` to unblock graph hosts.

--- a/Example/Shared/PreviewShims.swift
+++ b/Example/Shared/PreviewShims.swift
@@ -5,15 +5,8 @@
 import OpenSwiftUI
 import SwiftUI
 
-// Helper method before we add fully preview thunk and preview macro support for OpenSwiftUI
-
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
-extension OpenSwiftUI.View {
-    func _previewVC() -> some NSViewController {
-        OpenSwiftUI.NSHostingController(rootView: self)
-    }
-}
 extension SwiftUI.View {
     func _previewVC() -> some NSViewController {
         SwiftUI.NSHostingController(rootView: self)
@@ -21,11 +14,6 @@ extension SwiftUI.View {
 }
 #else
 import UIKit
-extension OpenSwiftUI.View {
-    func _previewVC() -> some UIViewController {
-        OpenSwiftUI.UIHostingController(rootView: self)
-    }
-}
 extension SwiftUI.View {
     func _previewVC() -> some UIViewController {
         SwiftUI.UIHostingController(rootView: self)
@@ -33,16 +21,18 @@ extension SwiftUI.View {
 }
 #endif
 
+#if canImport(UIKit)
+// FIXME: Not working on macOS yet
+
 #Preview("HostingVC") {
-    // FIXME: Not working on macOS yet
     ContentView()
         ._previewVC()
 }
 
 #Preview("CAHostingLayerExample") {
-    // FIXME: Not working on macOS yet
     CAHostingLayerExample(
         content: ContentView(),
         size: UIScreen.main.bounds.size
     ).makeViewController()
 }
+#endif

--- a/Sources/OpenSwiftUI/Integration/PreviewShims.swift
+++ b/Sources/OpenSwiftUI/Integration/PreviewShims.swift
@@ -1,0 +1,27 @@
+//
+//  PreviewShims.swift
+//  OpenSwiftUI
+//
+//  Bridging helpers for Xcode Preview support.
+//  Wraps OpenSwiftUI views in hosting controllers
+//  so they can be used with SwiftUI's #Preview macro.
+
+import OpenSwiftUICore
+
+// Helper method before we add fully preview thunk and preview macro support for OpenSwiftUI
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+import AppKit
+extension OpenSwiftUI.View {
+    public func _previewVC() -> some NSViewController {
+        OpenSwiftUI.NSHostingController(rootView: self)
+    }
+}
+#else
+import UIKit
+extension OpenSwiftUI.View {
+    public func _previewVC() -> some UIViewController {
+        OpenSwiftUI.UIHostingController(rootView: self)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `Docs/Preview.md` documenting OpenSwiftUI's Xcode Preview support
- Covers the current shim-based `_previewVC()` approach from #829
- Includes the `waitingForPreviewThunks` investigation and PreviewsInjection sequence diagram (mermaid)
- Outlines future plan: own `#Preview` macro → own preview thunk registration → standalone non-Apple preview host