### PR TITLE
[Bug Fix] Fix CGDrawingView calling setNeedsDisplay on wrong target

### DIFF
--- a/Sources/OpenSwiftUI/Render/DisplayList/DisplayListViewDrawing.swift
+++ b/Sources/OpenSwiftUI/Render/DisplayList/DisplayListViewDrawing.swift
@@ -80,7 +80,7 @@ final class CGDrawingView: PlatformGraphicsView, PlatformDrawable {
     static var allowsContentsMultiplyColor: Bool {
         true
     }
-    
+
     func update(
         content: PlatformDrawableContent?,
         required: Bool
@@ -90,7 +90,7 @@ final class CGDrawingView: PlatformGraphicsView, PlatformDrawable {
             layer.content = content
         }
         #if os(iOS) || os(visionOS)
-        setNeedsDisplay()
+        layer.setNeedsDisplay()
         #elseif os(macOS)
         needsDisplay = true
         #endif


### PR DESCRIPTION
## Summary
- Fix `CGDrawingView.update(content:required:)` to call `setNeedsDisplay()` on the backing `layer` instead of the view itself on iOS/visionOS

## Problem
`setNeedsDisplay()` was called on the view, but the content is set directly on `layer.content`. Calling the view-level `setNeedsDisplay()` does not trigger a redraw of the layer content, causing stale rendering after updates.

## Fix
Call `layer.setNeedsDisplay()` to correctly invalidate the layer that holds the drawable content, matching the pattern used on macOS (`needsDisplay = true` which also triggers layer redraw).