### PR TITLE
Move interpose hooks to OpenSwiftUI_SPI with improved diagnostics

### DIFF
--- a/Example/Shared/interpose.c
+++ b/Example/Shared/interpose.c
@@ -28,6 +28,49 @@ static inline CFStringRef _interpose_type_description(const void *type) {
 #endif
 }
 
+// MARK: - Protocol Description Shim
+
+// ProtocolDescriptor is a ContextDescriptor, not type metadata,
+// so AGTypeDescription/OAGTypeDescription cannot be used on it.
+// Read the name directly from the ContextDescriptor binary layout:
+//   offset 0: uint32_t Flags
+//   offset 4: int32_t  Parent (relative indirectable pointer)
+//   offset 8: int32_t  Name   (relative direct pointer to const char*)
+static inline CFStringRef _interpose_protocol_description(const void *protocol) {
+    const uint8_t *base = (const uint8_t *)protocol;
+
+    // Resolve Name (relative direct pointer at offset 8)
+    int32_t name_offset = *(const int32_t *)(base + 8);
+    const char *name = (const char *)(base + 8 + (intptr_t)name_offset);
+
+    // Resolve Parent (relative indirectable pointer at offset 4)
+    int32_t parent_raw = *(const int32_t *)(base + 4);
+    if (parent_raw != 0) {
+        const void *parent;
+        if (parent_raw & 1) {
+            // Indirect: low bit set, mask it out and dereference
+            const void **indirect = (const void **)(base + 4 + (intptr_t)(parent_raw & ~1));
+            parent = *indirect;
+        } else {
+            // Direct: offset as-is
+            parent = (const void *)(base + 4 + (intptr_t)parent_raw);
+        }
+        if (parent != NULL) {
+            // ModuleContextDescriptor.Name is also at offset 8
+            const uint8_t *parent_base = (const uint8_t *)parent;
+            int32_t module_name_offset = *(const int32_t *)(parent_base + 8);
+            const char *module_name = (const char *)(parent_base + 8 + (intptr_t)module_name_offset);
+            CFStringRef result = CFStringCreateWithFormat(kCFAllocatorDefault, NULL, CFSTR("%s.%s"), module_name, name);
+            CFAutorelease(result);
+            return result;
+        }
+    }
+
+    CFStringRef result = CFStringCreateWithCString(kCFAllocatorDefault, name, kCFStringEncodingUTF8);
+    CFAutorelease(result);
+    return result;
+}
+
 // Forward declare the original
 extern bool kdebug_is_enabled(uint32_t debugid);
 
@@ -96,7 +139,7 @@ static const void *my_swift_conformsToProtocol2(const void *type, const void *pr
     if (result != NULL) {
         return result;
     }
-    CFStringRef protocolDescription = _interpose_type_description(protocol);
+    CFStringRef protocolDescription = _interpose_protocol_description(protocol);
     CFStringRef typeDescription = _interpose_type_description(type);
     if (protocolDescription != NULL && typeDescription != NULL &&
         (CFStringHasPrefix(protocolDescription, CFSTR("SwiftUI.")) ||
@@ -111,7 +154,7 @@ static const void *my_swift_conformsToProtocol2(const void *type, const void *pr
         result = swift_conformsToProtocol2(type, _OpenSwiftUI_PlatformDrawablePD());
         if (result != NULL) {
             CFStringRef description = _interpose_type_description(type);
-            os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_conformsToProtocol2 succeeded for %{public}@", description);
+            os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_conformsToProtocol2 succeeded via OpenSwiftUI fallback for %{public}@", description);
         }
     }
     return result;

--- a/Example/Shared/interpose.c
+++ b/Example/Shared/interpose.c
@@ -9,23 +9,29 @@
 #include <stdint.h>
 #include <dlfcn.h>
 #include <os/log.h>
-
-#if __has_include(<AttributeGraph/AttributeGraph.h>)
-#include <AttributeGraph/AttributeGraph.h>
-#elif __has_include(<Compute/Compute.h>)
-#include <Compute/Compute.h>
-#else
-#include <OpenAttributeGraph/OpenAttributeGraph.h>
-#endif
+#include <CoreFoundation/CoreFoundation.h>
 
 // MARK: - Type Description Shim
 
+// swift_getTypeName returns the module-qualified name (e.g. "OpenSwiftUI.CGDrawingView")
+// unlike AGTypeDescription which only returns the short name (e.g. "CGDrawingView").
+struct _interpose_type_name_pair {
+    const char *data;
+    uintptr_t length;
+};
+extern __attribute__((swiftcall))
+struct _interpose_type_name_pair swift_getTypeName(const void *type, bool qualified);
+
 static inline CFStringRef _interpose_type_description(const void *type) {
-#if __has_include(<AttributeGraph/AttributeGraph.h>) || __has_include(<Compute/Compute.h>)
-    return AGTypeDescription((AGTypeID)type);
-#else
-    return OAGTypeDescription((OAGTypeID)type);
-#endif
+    struct _interpose_type_name_pair name = swift_getTypeName(type, true);
+    if (name.data == NULL || name.length == 0) {
+        return NULL;
+    }
+    CFStringRef result = CFStringCreateWithBytes(
+        kCFAllocatorDefault, (const UInt8 *)name.data, (CFIndex)name.length,
+        kCFStringEncodingUTF8, false);
+    CFAutorelease(result);
+    return result;
 }
 
 // MARK: - Protocol Description Shim

--- a/Example/Shared/interpose.c
+++ b/Example/Shared/interpose.c
@@ -8,6 +8,25 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <dlfcn.h>
+#include <os/log.h>
+
+#if __has_include(<AttributeGraph/AttributeGraph.h>)
+#include <AttributeGraph/AttributeGraph.h>
+#elif __has_include(<Compute/Compute.h>)
+#include <Compute/Compute.h>
+#else
+#include <OpenAttributeGraph/OpenAttributeGraph.h>
+#endif
+
+// MARK: - Type Description Shim
+
+static inline CFStringRef _interpose_type_description(const void *type) {
+#if __has_include(<AttributeGraph/AttributeGraph.h>) || __has_include(<Compute/Compute.h>)
+    return AGTypeDescription((AGTypeID)type);
+#else
+    return OAGTypeDescription((OAGTypeID)type);
+#endif
+}
 
 // Forward declare the original
 extern bool kdebug_is_enabled(uint32_t debugid);
@@ -38,10 +57,23 @@ static bool my_swift_dynamicCast(void *dest, void *src, const void *srcType, con
     if (result) {
         return result;
     }
+    CFStringRef targetDescription = _interpose_type_description(targetType);
+    CFStringRef srcDescription = _interpose_type_description(srcType);
+    if (targetDescription != NULL && srcDescription != NULL &&
+        (CFStringHasPrefix(targetDescription, CFSTR("SwiftUI.")) ||
+         CFStringHasPrefix(targetDescription, CFSTR("SwiftUICore."))) &&
+        (CFStringHasPrefix(srcDescription, CFSTR("OpenSwiftUI.")) ||
+         CFStringHasPrefix(srcDescription, CFSTR("OpenSwiftUICore.")))) {
+        os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_dynamicCast failed for target: %{public}@ src: %{public}@", targetDescription, srcDescription);
+    }
     // If dynamicCast check failed and the target is SwiftUI's Color.Resolved
     // retry with OpenSwiftUI's Color.Resolved
     if (targetType == &$s7SwiftUI5ColorV8ResolvedVN) {
         result = swift_dynamicCast(dest, src, srcType, _OpenSwiftUI_ColorResolvedNTD(), flags);
+        if (result) {
+            CFStringRef description = _interpose_type_description(srcType);
+            os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_dynamicCast succeeded for %{public}@", description);
+        }
     }
     return result;
 }
@@ -60,15 +92,27 @@ const void *_OpenSwiftUI_PlatformDrawablePD(void) {
 extern const void *swift_conformsToProtocol2(const void *type, const void *protocol);
 
 static const void *my_swift_conformsToProtocol2(const void *type, const void *protocol) {
-    
     const void *result = swift_conformsToProtocol2(type, protocol);
     if (result != NULL) {
         return result;
+    }
+    CFStringRef protocolDescription = _interpose_type_description(protocol);
+    CFStringRef typeDescription = _interpose_type_description(type);
+    if (protocolDescription != NULL && typeDescription != NULL &&
+        (CFStringHasPrefix(protocolDescription, CFSTR("SwiftUI.")) ||
+         CFStringHasPrefix(protocolDescription, CFSTR("SwiftUICore."))) &&
+        (CFStringHasPrefix(typeDescription, CFSTR("OpenSwiftUI.")) ||
+         CFStringHasPrefix(typeDescription, CFSTR("OpenSwiftUICore.")))) {
+        os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_conformsToProtocol2 failed for protocol: %{public}@ type: %{public}@", protocolDescription, typeDescription);
     }
     // If conformance check failed and the protocol is SwiftUI's PlatformDrawable,
     // retry with OpenSwiftUI's PlatformDrawable
     if (protocol == &$s7SwiftUI16PlatformDrawableMp) {
         result = swift_conformsToProtocol2(type, _OpenSwiftUI_PlatformDrawablePD());
+        if (result != NULL) {
+            CFStringRef description = _interpose_type_description(type);
+            os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_conformsToProtocol2 succeeded for %{public}@", description);
+        }
     }
     return result;
 }

--- a/Example/Shared/interpose.c
+++ b/Example/Shared/interpose.c
@@ -9,14 +9,6 @@
 #include <stdint.h>
 #include <dlfcn.h>
 
-#if __has_include(<AttributeGraph/AttributeGraph.h>)
-#include <AttributeGraph/AttributeGraph.h>
-#elif __has_include(<Compute/Compute.h>)
-#include <Compute/Compute.h>
-#else
-#include <OpenAttributeGraph/OpenAttributeGraph.h>
-#endif
-
 // Forward declare the original
 extern bool kdebug_is_enabled(uint32_t debugid);
 
@@ -25,11 +17,16 @@ static bool my_kdebug_is_enabled(uint32_t debugid) {
     return true;
 }
 
+// MARK: - Color.Resolved Nominal Type Descriptor
+
+extern const void $s7SwiftUI5ColorV8ResolvedVN;
 extern const void *$s15OpenSwiftUICore5ColorV8ResolvedVN;
 
 const void *_OpenSwiftUI_ColorResolvedNTD(void) {
     return &$s15OpenSwiftUICore5ColorV8ResolvedVN;
 }
+
+// MARK: - swift_dynamicCast
 
 extern bool swift_dynamicCast(void *dest, void *src,
                   const void *srcType,
@@ -37,17 +34,43 @@ extern bool swift_dynamicCast(void *dest, void *src,
                   uint64_t flags);
 
 static bool my_swift_dynamicCast(void *dest, void *src, const void *srcType, const void *targetType, uint64_t flags) {
-    CFStringRef target_description = AGTypeDescription((AGTypeID)targetType);
-    // Check if target_description contains "Color.Resolved"
-    if (target_description != NULL) {
-        CFRange range = CFStringFind(target_description, CFSTR("Color.Resolved"), 0);
-        if (range.location != kCFNotFound) {
-            // First try the original cast, if it fails try with OpenSwiftUI's Color.Resolved
-            return swift_dynamicCast(dest, src, srcType, targetType, flags) ||
-                   swift_dynamicCast(dest, src, srcType, _OpenSwiftUI_ColorResolvedNTD(), flags);
-        }
+    bool result = swift_dynamicCast(dest, src, srcType, targetType, flags);
+    if (result) {
+        return result;
     }
-    return swift_dynamicCast(dest, src, srcType, targetType, flags);
+    // If dynamicCast check failed and the target is SwiftUI's Color.Resolved
+    // retry with OpenSwiftUI's Color.Resolved
+    if (targetType == &$s7SwiftUI5ColorV8ResolvedVN) {
+        result = swift_dynamicCast(dest, src, srcType, _OpenSwiftUI_ColorResolvedNTD(), flags);
+    }
+    return result;
+}
+
+// MARK: - PlatformDrawable Protocol Descriptor
+
+extern const void $s7SwiftUI16PlatformDrawableMp;
+extern const void $s15OpenSwiftUICore16PlatformDrawableMp;
+
+const void *_OpenSwiftUI_PlatformDrawablePD(void) {
+    return &$s15OpenSwiftUICore16PlatformDrawableMp;
+}
+
+// MARK: - swift_conformsToProtocol2
+
+extern const void *swift_conformsToProtocol2(const void *type, const void *protocol);
+
+static const void *my_swift_conformsToProtocol2(const void *type, const void *protocol) {
+    
+    const void *result = swift_conformsToProtocol2(type, protocol);
+    if (result != NULL) {
+        return result;
+    }
+    // If conformance check failed and the protocol is SwiftUI's PlatformDrawable,
+    // retry with OpenSwiftUI's PlatformDrawable
+    if (protocol == &$s7SwiftUI16PlatformDrawableMp) {
+        result = swift_conformsToProtocol2(type, _OpenSwiftUI_PlatformDrawablePD());
+    }
+    return result;
 }
 
 // Interpose using Mach-O section
@@ -62,4 +85,6 @@ __attribute__((used)) static const interpose_t interposers[]
     { (const void *)my_kdebug_is_enabled, (const void *)kdebug_is_enabled },
     // Interpose swift_dynamicCast to handle casts to SwiftUI's internal Color.Resolved type to fix SwiftUI.ShapeLayerHelper visit check for Shape.fill API
     { (const void *)my_swift_dynamicCast, (const void *)swift_dynamicCast },
+    // Interpose swift_conformsToProtocol2 to redirect SwiftUI.PlatformDrawable conformance checks to OpenSwiftUI.PlatformDrawable
+    { (const void *)my_swift_conformsToProtocol2, (const void *)swift_conformsToProtocol2 },
 };

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8abf0153558536a1dd22b597d0ed8dc7469a7e4af954c5ea3d7851118c9806a4",
+  "originHash" : "3c0b1860417beca3e0a1aaa211e04d53bd0595952819fabc34b7b969e5e2a09a",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c0b1860417beca3e0a1aaa211e04d53bd0595952819fabc34b7b969e5e2a09a",
+  "originHash" : "fce498ad25d55659c7a117ab904a3a879c9faded477d00d3c4818005d21d51fd",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "4f25f694fc0e1939879c0636daed309534ed6c39"
+        "revision" : "b466b79931d3ef1f38022bd14a5e6523cb5fdf39"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -530,7 +530,10 @@ let openSwiftUISPITarget = Target.target(
         // -lMobileGestalt
         // For MGCopyAnswer API support
         .linkedLibrary("MobileGestalt", .when(platforms: .darwinPlatforms)),
-    ]
+    ] + (swiftUIRenderCondition ? [
+        // For Interpose.c or we can choose to use dlsm approach to load them dynamically
+        .linkedFramework("SwiftUI", .when(platforms: .darwinPlatforms))
+    ] : [])
 )
 
 let openSwiftUISPITestTarget = Target.testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -526,7 +526,11 @@ let openSwiftUISPITarget = Target.target(
     publicHeadersPath: ".",
     cSettings: sharedCSettings + [.define("_GNU_SOURCE", .when(platforms: .nonDarwinPlatforms))],
     cxxSettings: sharedCxxSettings,
-    linkerSettings: [.unsafeFlags(["-lMobileGestalt"], .when(platforms: .darwinPlatforms))] // For MGCopyAnswer API support
+    linkerSettings: [
+        // -lMobileGestalt
+        // For MGCopyAnswer API support
+        .linkedLibrary("MobileGestalt", .when(platforms: .darwinPlatforms)),
+    ]
 )
 
 let openSwiftUISPITestTarget = Target.testTarget(

--- a/Sources/OpenSwiftUI/Integration/PreviewShims.swift
+++ b/Sources/OpenSwiftUI/Integration/PreviewShims.swift
@@ -11,16 +11,16 @@ import OpenSwiftUICore
 // Helper method before we add fully preview thunk and preview macro support for OpenSwiftUI
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-import AppKit
+public import AppKit
 extension OpenSwiftUI.View {
-    public func _previewVC() -> some NSViewController {
+    public func _previewVC() -> NSViewController {
         OpenSwiftUI.NSHostingController(rootView: self)
     }
 }
 #else
-import UIKit
+public import UIKit
 extension OpenSwiftUI.View {
-    public func _previewVC() -> some UIViewController {
+    public func _previewVC() -> UIViewController {
         OpenSwiftUI.UIHostingController(rootView: self)
     }
 }

--- a/Sources/OpenSwiftUI_SPI/Util/Interpose.c
+++ b/Sources/OpenSwiftUI_SPI/Util/Interpose.c
@@ -1,13 +1,13 @@
 //
-//  interpose.c
-//  Shared
-//
-//  Created by Kyle on 2025/10/3.
-//
+//  Interpose.c
+//  OpenSwiftUI_SPI
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN && _OPENSWIFTUI_SWIFTUI_RENDER
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <os/log.h>
 #include <CoreFoundation/CoreFoundation.h>
 
@@ -77,10 +77,10 @@ static inline CFStringRef _interpose_protocol_description(const void *protocol) 
     return result;
 }
 
-// Forward declare the original
+// MARK: - kdebug_is_enabled
+
 extern bool kdebug_is_enabled(uint32_t debugid);
 
-// Our replacement
 static bool my_kdebug_is_enabled(uint32_t debugid) {
     return true;
 }
@@ -166,7 +166,8 @@ static const void *my_swift_conformsToProtocol2(const void *type, const void *pr
     return result;
 }
 
-// Interpose using Mach-O section
+// MARK: - Interpose Registration
+
 typedef struct interpose_s {
     const void *replacement;
     const void *original;
@@ -178,6 +179,8 @@ __attribute__((used)) static const interpose_t interposers[]
     { (const void *)my_kdebug_is_enabled, (const void *)kdebug_is_enabled },
     // Interpose swift_dynamicCast to handle casts to SwiftUI's internal Color.Resolved type to fix SwiftUI.ShapeLayerHelper visit check for Shape.fill API
     { (const void *)my_swift_dynamicCast, (const void *)swift_dynamicCast },
-    // Interpose swift_conformsToProtocol2 to redirect SwiftUI.PlatformDrawable conformance checks to OpenSwiftUI.PlatformDrawable
+    // Interpose swift_conformsToProtocol2 to redirect SwiftUI.PlatformDrawable conformance checks to OpenSwiftUI.PlatformDrawable for Text's CGDrawingView
     { (const void *)my_swift_conformsToProtocol2, (const void *)swift_conformsToProtocol2 },
 };
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN && _OPENSWIFTUI_SWIFTUI_RENDER */


### PR DESCRIPTION
## Summary
- Move Mach-O interpose hooks from Example/Shared/interpose.c to Sources/OpenSwiftUI_SPI/Util/Interpose.c, guarded by OPENSWIFTUI_TARGET_OS_DARWIN && _OPENSWIFTUI_SWIFTUI_RENDER
- Use swift_getTypeName from Swift runtime for module-qualified type names (e.g. OpenSwiftUI.CGDrawingView instead of just CGDrawingView)
- Add _interpose_protocol_description shim that reads protocol names directly from the ProtocolDescriptor binary layout, since AGTypeDescription crashes on protocol descriptors
- Add swift_conformsToProtocol2 interpose for PlatformDrawable (Text's CGDrawingView)
- Fix PreviewShims to use public import and concrete return types
