### PR TITLE
Add code signing support for XCFrameworks

### DIFF
--- a/.github/actions/build-xcframework/action.yml
+++ b/.github/actions/build-xcframework/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: 'Tag name for release URLs (empty for manual builds)'
     required: false
     default: ''
+  signing-certificate-base64:
+    description: 'Base64-encoded .p12 signing certificate'
+    required: false
+    default: ''
+  signing-certificate-password:
+    description: 'Password for the .p12 signing certificate'
+    required: false
+    default: ''
 
 outputs:
   body:
@@ -29,6 +37,20 @@ runs:
     - name: Build XCFrameworks
       run: Scripts/build_xcframework.sh OpenSwiftUI
       shell: bash
+    - name: Code sign XCFrameworks
+      if: ${{ inputs.signing-certificate-base64 != '' }}
+      uses: ./.github/actions/codesign-xcframework
+      with:
+        signing-certificate-base64: ${{ inputs.signing-certificate-base64 }}
+        signing-certificate-password: ${{ inputs.signing-certificate-password }}
+        xcframework-paths: >-
+          build/OpenSwiftUI.xcframework
+          build/OpenSwiftUICore.xcframework
+          build/OpenAttributeGraphShims.xcframework
+          build/OpenCoreGraphicsShims.xcframework
+          build/OpenObservation.xcframework
+          build/OpenQuartzCoreShims.xcframework
+          build/OpenRenderBoxShims.xcframework
     - name: Compute Checksums and Generate Summary
       id: checksums
       shell: bash

--- a/.github/actions/codesign-xcframework/action.yml
+++ b/.github/actions/codesign-xcframework/action.yml
@@ -1,0 +1,104 @@
+name: 'Code Sign XCFramework'
+description: 'Import a signing certificate and code sign xcframeworks'
+
+inputs:
+  signing-certificate-base64:
+    description: 'Base64-encoded .p12 signing certificate'
+    required: true
+  signing-certificate-password:
+    description: 'Password for the .p12 signing certificate'
+    required: true
+  signing-identity:
+    description: 'Common Name of the signing certificate'
+    required: false
+    default: 'OpenSwiftUI'
+  xcframework-paths:
+    description: 'Space-separated paths to xcframeworks to sign'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up signing keychain
+      shell: bash
+      env:
+        CERTIFICATE_BASE64: ${{ inputs.signing-certificate-base64 }}
+        CERTIFICATE_PASSWORD: ${{ inputs.signing-certificate-password }}
+        SIGNING_IDENTITY: ${{ inputs.signing-identity }}
+      run: |
+        KEYCHAIN_PASSWORD="ci_signing_temp"
+        KEYCHAIN_NAME="ci_signing.keychain-db"
+        KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME"
+
+        # Save original keychain search list
+        ORIGINAL_KEYCHAINS=$(security list-keychains -d user | sed 's/^ *"//;s/" *$//' | tr '\n' ' ')
+
+        # Clean up any existing CI keychain
+        security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+        rm -f "$KEYCHAIN_PATH" 2>/dev/null || true
+
+        # Create and unlock keychain
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+        # NOTE: Do NOT call security set-keychain-settings here.
+        # It corrupts keychain state in non-interactive CI sessions.
+
+        # Add to search list (prepend CI keychain, keep existing)
+        security list-keychains -d user -s "$KEYCHAIN_PATH" $ORIGINAL_KEYCHAINS
+
+        # Decode and import certificate
+        # Use -A to allow all applications access without prompting.
+        # Per-app ACL entries (-T) cause "User interaction is not allowed" prompts.
+        echo "$CERTIFICATE_BASE64" | base64 -d > /tmp/signing.p12
+        security import /tmp/signing.p12 -k "$KEYCHAIN_PATH" -P "$CERTIFICATE_PASSWORD" -A
+        rm -f /tmp/signing.p12
+
+        # Set partition list to allow codesign access without prompting
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" 2>/dev/null || true
+
+        # Try to trust certificate for code signing (works on self-hosted runners)
+        security find-certificate -c "$SIGNING_IDENTITY" -p "$KEYCHAIN_PATH" > /tmp/signing-cert.pem
+        sudo security add-trusted-cert -d -r trustRoot -p codeSign /tmp/signing-cert.pem 2>/dev/null || true
+        rm -f /tmp/signing-cert.pem
+
+        # Debug: inspect keychain contents
+        echo "=== Certificates in keychain ==="
+        security find-certificate -a -c "$SIGNING_IDENTITY" -Z "$KEYCHAIN_PATH" 2>&1 | head -5 || true
+        echo "=== All identities (no policy filter) ==="
+        security find-identity "$KEYCHAIN_PATH" || true
+        echo "=== All identities (codesigning policy) ==="
+        security find-identity -p codesigning "$KEYCHAIN_PATH" || true
+        echo "=== Valid codesigning identities ==="
+        security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+
+    - name: Code sign xcframeworks
+      shell: bash
+      env:
+        SIGNING_IDENTITY: ${{ inputs.signing-identity }}
+        XCFRAMEWORK_PATHS: ${{ inputs.xcframework-paths }}
+      run: |
+        KEYCHAIN_PATH="$HOME/Library/Keychains/ci_signing.keychain-db"
+        # Try: trusted codesigning → all codesigning → any identity (no policy)
+        # Note: || true is needed because grep returns 1 on no match, which kills -e -o pipefail
+        SIGNING_HASH=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" 2>/dev/null | grep "$SIGNING_IDENTITY" | head -1 | awk '{print $2}' || true)
+        if [ -z "$SIGNING_HASH" ]; then
+            SIGNING_HASH=$(security find-identity -p codesigning "$KEYCHAIN_PATH" 2>/dev/null | grep "$SIGNING_IDENTITY" | head -1 | awk '{print $2}' || true)
+        fi
+        if [ -z "$SIGNING_HASH" ]; then
+            SIGNING_HASH=$(security find-identity "$KEYCHAIN_PATH" 2>/dev/null | grep "$SIGNING_IDENTITY" | head -1 | awk '{print $2}' || true)
+        fi
+        if [ -z "$SIGNING_HASH" ]; then
+            echo "::error::Signing identity '$SIGNING_IDENTITY' not found"
+            exit 1
+        fi
+        echo "Signing identity: $SIGNING_HASH ($SIGNING_IDENTITY)"
+        for fw_path in $XCFRAMEWORK_PATHS; do
+            if [ -d "$fw_path" ]; then
+                echo "Signing $fw_path..."
+                codesign --force --timestamp -v --sign "$SIGNING_HASH" --keychain "$KEYCHAIN_PATH" "$fw_path"
+            else
+                echo "::warning::$fw_path not found, skipping"
+            fi
+        done
+        echo "Code signing completed."

--- a/.github/workflows/build_xcframework.yml
+++ b/.github/workflows/build_xcframework.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build XCFrameworks
         uses: ./.github/actions/build-xcframework
+        with:
+          signing-certificate-base64: ${{ secrets.SIGNING_CERTIFICATE_BASE_64 }}
+          signing-certificate-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
       - name: Zip XCFrameworks
         run: cd build && zip -ry xcframeworks.zip *.xcframework
       - name: Upload XCFrameworks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
         uses: ./.github/actions/build-xcframework
         with:
           tag-name: ${{ github.ref_name }}
+          signing-certificate-base64: ${{ secrets.SIGNING_CERTIFICATE_BASE_64 }}
+          signing-certificate-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Summary
- Sign all 7 xcframeworks (main + 6 dependency stubs) with a self-signed "OpenSwiftUI" certificate during the release build
- Import signing certificate from GitHub secrets via `apple-actions/import-codesign-certs@v3`
- Gracefully skip signing when certificate is not available (external contributor PRs, manual builds)

## Changes
- `Scripts/build_xcframework.sh` — added signing step after xcframework creation
- `.github/actions/build-xcframework/action.yml` — added certificate import step and new inputs
- `.github/workflows/release.yml` — pass signing secrets to the composite action

## Setup required
Add these GitHub repo secrets:
- `SIGNING_CERTIFICATE_BASE_64` — base64-encoded `.p12` certificate
- `SIGNING_CERTIFICATE_PASSWORD` — password for the `.p12` file

## Test plan
- [ ] Verify release workflow still succeeds without secrets (signing skipped)
- [ ] Add secrets and verify xcframeworks are signed in release
- [ ] Verify signature with `codesign -dv --verbose=4 OpenSwiftUI.xcframework`