### PR TITLE
Add auto-sync for binary repo and update integration docs

### DIFF
--- a/.github/actions/build-xcframework/action.yml
+++ b/.github/actions/build-xcframework/action.yml
@@ -23,6 +23,27 @@ outputs:
   body:
     description: 'Release body with .binaryTarget entries'
     value: ${{ steps.checksums.outputs.body }}
+  checksum_OpenSwiftUI:
+    description: 'Checksum for OpenSwiftUI.xcframework.zip'
+    value: ${{ steps.checksums.outputs.checksum_OpenSwiftUI }}
+  checksum_OpenSwiftUICore:
+    description: 'Checksum for OpenSwiftUICore.xcframework.zip'
+    value: ${{ steps.checksums.outputs.checksum_OpenSwiftUICore }}
+  checksum_OpenAttributeGraphShims:
+    description: 'Checksum for OpenAttributeGraphShims.xcframework.zip'
+    value: ${{ steps.checksums.outputs.checksum_OpenAttributeGraphShims }}
+  checksum_OpenCoreGraphicsShims:
+    description: 'Checksum for OpenCoreGraphicsShims.xcframework.zip'
+    value: ${{ steps.checksums.outputs.checksum_OpenCoreGraphicsShims }}
+  checksum_OpenObservation:
+    description: 'Checksum for OpenObservation.xcframework.zip'
+    value: ${{ steps.checksums.outputs.checksum_OpenObservation }}
+  checksum_OpenQuartzCoreShims:
+    description: 'Checksum for OpenQuartzCoreShims.xcframework.zip'
+    value: ${{ steps.checksums.outputs.checksum_OpenQuartzCoreShims }}
+  checksum_OpenRenderBoxShims:
+    description: 'Checksum for OpenRenderBoxShims.xcframework.zip'
+    value: ${{ steps.checksums.outputs.checksum_OpenRenderBoxShims }}
 
 runs:
   using: 'composite'
@@ -75,6 +96,7 @@ runs:
           if [ -n "$TAG_NAME" ]; then
             zip -ry "$fw.xcframework.zip" "$fw.xcframework"
             CHECKSUM=$(swift package compute-checksum "$fw.xcframework.zip")
+            echo "checksum_${fw}=${CHECKSUM}" >> $GITHUB_OUTPUT
             ENTRY=$(printf '.binaryTarget(\n    name: "%s",\n    url: "https://github.com/OpenSwiftUIProject/OpenSwiftUI/releases/download/%s/%s.xcframework.zip",\n    checksum: "%s"\n),' "$fw" "$TAG_NAME" "$fw" "$CHECKSUM")
           else
             ENTRY=$(printf '.binaryTarget(\n    name: "%s",\n    path: "%s.xcframework"\n),' "$fw" "$fw")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ jobs:
   release:
     name: Build and Release XCFrameworks
     runs-on: macos-15
+    outputs:
+      checksum_OpenSwiftUI: ${{ steps.build.outputs.checksum_OpenSwiftUI }}
+      checksum_OpenSwiftUICore: ${{ steps.build.outputs.checksum_OpenSwiftUICore }}
+      checksum_OpenAttributeGraphShims: ${{ steps.build.outputs.checksum_OpenAttributeGraphShims }}
+      checksum_OpenCoreGraphicsShims: ${{ steps.build.outputs.checksum_OpenCoreGraphicsShims }}
+      checksum_OpenObservation: ${{ steps.build.outputs.checksum_OpenObservation }}
+      checksum_OpenQuartzCoreShims: ${{ steps.build.outputs.checksum_OpenQuartzCoreShims }}
+      checksum_OpenRenderBoxShims: ${{ steps.build.outputs.checksum_OpenRenderBoxShims }}
     env:
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1
       OPENSWIFTUI_USE_LOCAL_DEPS: 1
@@ -35,3 +43,50 @@ jobs:
           allowUpdates: true
           artifacts: "build/*.xcframework.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  update-binary-repo:
+    name: Update OpenSwiftUI-spm
+    needs: release
+    runs-on: ubuntu-latest
+    if: ${{ secrets.BINARY_REPO_PAT != '' }}
+    steps:
+      - name: Clone binary repo
+        run: |
+          git clone https://x-access-token:${{ secrets.BINARY_REPO_PAT }}@github.com/OpenSwiftUIProject/OpenSwiftUI-spm.git
+          cd OpenSwiftUI-spm
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Generate Package.swift from template
+        env:
+          VERSION: ${{ github.ref_name }}
+          CHECKSUM_OpenSwiftUI: ${{ needs.release.outputs.checksum_OpenSwiftUI }}
+          CHECKSUM_OpenSwiftUICore: ${{ needs.release.outputs.checksum_OpenSwiftUICore }}
+          CHECKSUM_OpenAttributeGraphShims: ${{ needs.release.outputs.checksum_OpenAttributeGraphShims }}
+          CHECKSUM_OpenCoreGraphicsShims: ${{ needs.release.outputs.checksum_OpenCoreGraphicsShims }}
+          CHECKSUM_OpenObservation: ${{ needs.release.outputs.checksum_OpenObservation }}
+          CHECKSUM_OpenQuartzCoreShims: ${{ needs.release.outputs.checksum_OpenQuartzCoreShims }}
+          CHECKSUM_OpenRenderBoxShims: ${{ needs.release.outputs.checksum_OpenRenderBoxShims }}
+        run: |
+          cd OpenSwiftUI-spm
+          sed \
+            -e "s|{{VERSION}}|${VERSION}|g" \
+            -e "s|{{CHECKSUM_OpenSwiftUI}}|${CHECKSUM_OpenSwiftUI}|g" \
+            -e "s|{{CHECKSUM_OpenSwiftUICore}}|${CHECKSUM_OpenSwiftUICore}|g" \
+            -e "s|{{CHECKSUM_OpenAttributeGraphShims}}|${CHECKSUM_OpenAttributeGraphShims}|g" \
+            -e "s|{{CHECKSUM_OpenCoreGraphicsShims}}|${CHECKSUM_OpenCoreGraphicsShims}|g" \
+            -e "s|{{CHECKSUM_OpenObservation}}|${CHECKSUM_OpenObservation}|g" \
+            -e "s|{{CHECKSUM_OpenQuartzCoreShims}}|${CHECKSUM_OpenQuartzCoreShims}|g" \
+            -e "s|{{CHECKSUM_OpenRenderBoxShims}}|${CHECKSUM_OpenRenderBoxShims}|g" \
+            Package.swift.template > Package.swift
+          echo "Generated Package.swift:"
+          head -50 Package.swift
+      - name: Commit, push, and tag
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd OpenSwiftUI-spm
+          git add Package.swift
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "Update to ${VERSION} with code-signed XCFrameworks"
+          git tag "${VERSION}"
+          git push origin main --tags

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -15,9 +15,46 @@ This guide walks you through the steps to integrate OpenSwiftUI into your projec
 >
 > These private frameworks are ONLY for research and educational purposes.
 
-## Integration Steps for Swift Package Manager (SPM)
+## Binary Integration (Recommended)
 
-### Step 1: Add OpenSwiftUI Package Dependency
+The easiest way to use OpenSwiftUI is via the precompiled binary package [OpenSwiftUI-spm](https://github.com/OpenSwiftUIProject/OpenSwiftUI-spm). No need to compile from source or configure private frameworks.
+
+### Via Xcode
+
+1. In Xcode, select **File > Add Package Dependencies...**
+2. Enter the repository URL: `https://github.com/OpenSwiftUIProject/OpenSwiftUI-spm`
+3. Select the version you want to use
+4. Add `OpenSwiftUI` to your target
+
+### Via Package.swift
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/OpenSwiftUIProject/OpenSwiftUI-spm", from: "0.17.1"),
+]
+```
+
+Then add `OpenSwiftUI` to your target's dependencies:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(name: "OpenSwiftUI", package: "OpenSwiftUI-spm"),
+    ]
+),
+```
+
+> [!NOTE]
+> Binary integration does not support source-level debugging. If you need to debug OpenSwiftUI internals, use the source integration below.
+
+---
+
+## Source Integration (Advanced)
+
+Use source integration if you need to debug OpenSwiftUI internals or contribute to the project.
+
+### SPM Integration
 
 #### Using Branch or Revision (Recommended)
 
@@ -45,7 +82,7 @@ dependencies: [
 
 You can find the revision hash by checking the commit you want to use on GitHub.
 
-## Integration Steps for Xcode Project
+### Xcode Project Integration
 
 ### Step 1: Add OpenSwiftUI Package Dependency
 
@@ -130,8 +167,7 @@ OpenSwiftUI has **full debug support** for development and troubleshooting. You 
 
 ### Xcode Previews
 
-> [!NOTE]
-> Xcode Preview support is currently under development and will be available in a future release.
+See [Docs/Preview.md](Docs/Preview.md) for Xcode Preview support details.
 
 ## Platform-Specific Notes
 


### PR DESCRIPTION
## Summary
- Add reusable `codesign-xcframework` action with individual checksum outputs
- Add `update-binary-repo` job to release workflow that auto-updates OpenSwiftUI-spm `Package.swift` from template on each release
- Add binary integration (recommended) section to INTEGRATION.md
- Rename OpenSwiftUI-binary to OpenSwiftUI-spm

## Setup required
- `BINARY_REPO_PAT` org secret (already configured)

## Test plan
- [ ] Verify next tag release auto-updates OpenSwiftUI-spm