### PR TITLE
Limit CI workflows to self-hosted runners

### DIFF
--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -15,7 +15,10 @@ jobs:
         os: [macos-15]
         xcode-version: ["16.4"]
         release: [2024]
-    runs-on: ${{ matrix.os }}
+    # Limit to self-hosted to reduce action cost
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
     env:
       OPENSWIFTUI_WERROR: 0 # Disable it to avoid enable OAG's werror and hit conflicts
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1
@@ -66,7 +69,10 @@ jobs:
         include:
           - ios-version: "18.5"
             ios-simulator-name: "iPhone 16 Pro"
-    runs-on: ${{ matrix.os }}
+    # Limit to self-hosted to reduce action cost
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
     env:
       OPENSWIFTUI_WERROR: 0 # Disable it to avoid enable OAG's werror and hit conflicts
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -19,7 +19,10 @@ jobs:
         include:
           - ios-version: "18.5"
             ios-simulator-name: "iPhone 16 Pro"
-    runs-on: ${{ matrix.os }}
+    # Limit to self-hosted to reduce action cost
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
     env:
       OPENSWIFTUI_WERROR: 0 # Disable it to avoid enable OAG's werror and hit conflicts
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,10 @@ jobs:
         os: [macos-15]
         xcode-version: ["16.4"]
         release: [2024]
-    runs-on: ${{ matrix.os }}
+    # Limit to self-hosted to reduce action cost
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
     env:
       OPENSWIFTUI_WERROR: 0 # Disable it to avoid enable OAG's werror and hit conflicts
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -19,7 +19,10 @@ jobs:
         include:
           - ios-version: "18.5"
             ios-simulator-name: "iPhone 16 Pro"
-    runs-on: ${{ matrix.os }}
+    # Limit to self-hosted to reduce action cost
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
     env:
       OPENSWIFTUI_WERROR: 0 # Disable it to avoid enable OAG's werror and hit conflicts
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1
@@ -59,7 +62,10 @@ jobs:
         os: [macos-15]
         xcode-version: ["16.4"]
         release: [2024]
-    runs-on: ${{ matrix.os }}
+    # Limit to self-hosted to reduce action cost
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
     env:
       OPENSWIFTUI_WERROR: 0
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1


### PR DESCRIPTION
## Problem

Although GitHub Actions is [free for standard runners in public repositories](https://docs.github.com/en/actions/concepts/billing-and-usage), GitHub still tracks a gross usage amount internally. Once an organization's gross usage crosses a certain threshold, GitHub's [fair use policy](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/running-jobs-on-larger-runners#understanding-queue-to-assign-time) begins to throttle job scheduling — jobs sit in "Queued" state for extended periods or never get picked up at all. This affects the entire organization, not just the heavy-usage repository.

## Summary
- Limit all macOS CI jobs to self-hosted runners to reduce GitHub Actions cost
- Updated `runs-on` in `ios.yml`, `macos.yml`, `compatibility_tests.yml`, and `uitests.yml` (6 jobs total)

Fix organization's free GitHub Actions credits being exhausted too quickly issue eg. #850

<img width="962" height="835" alt="image" src="https://github.com/user-attachments/assets/62e62e11-44d8-4b2a-944d-d28f82560388" />

<img width="2034" height="706" alt="image" src="https://github.com/user-attachments/assets/5813c264-810a-43c0-baf5-39eb6007a805" />

## Test plan
- [ ] Verify CI jobs are picked up by self-hosted runner (Kyles-Mac-mini)
- [ ] Confirm all workflow jobs pass on self-hosted runner