### PR TITLE
Fix update scheduling seed checks

### DIFF
--- a/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingViewBase.swift
+++ b/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingViewBase.swift
@@ -847,8 +847,8 @@ final package class DisplayLink: NSObject {
 
     package func setNextUpdate(delay: Double, interval: Double, reasons: Set<UInt32>) {
         let newNextUpdate: Time
-        if delay >= 0.01 {
-            newNextUpdate = (currentUpdate ?? .systemUptime) + interval
+        if delay >= 0.001 {
+            newNextUpdate = (currentUpdate ?? .systemUptime) + delay
         } else {
             newNextUpdate = .zero
         }

--- a/Sources/OpenSwiftUICore/Graph/GraphHost.swift
+++ b/Sources/OpenSwiftUICore/Graph/GraphHost.swift
@@ -562,8 +562,7 @@ extension GraphHost {
     
     package final func updatePreferences() -> Bool {
         let seed = hostPreferenceValues.value?.seed ?? .empty
-        let lastSeed = lastHostPreferencesSeed
-        let didUpdate = !seed.isInvalid && !lastSeed.isInvalid && (seed.value != lastSeed.value)
+        let didUpdate = !seed.matches(lastHostPreferencesSeed)
         lastHostPreferencesSeed = seed
         return didUpdate
     }


### PR DESCRIPTION
## Summary

- Update `GraphHost.updatePreferences()` to use `VersionSeed.matches(_:)` when comparing the current host preference seed with the last recorded seed.
- Update `DisplayLink.setNextUpdate(delay:interval:reasons:)` to:
  - use `delay >= 0.001`
  - schedule with `(currentUpdate ?? .systemUptime) + delay`
  - keep `interval` for frame interval configuration
