### PR TITLE
Use dedicated logging for interpose and development warnings

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "224cb5bcc7d28adef0733540010d136e98c5e3c9e4fb2b5771e44d34ca25772d",
+  "originHash" : "5df6e9019cf62bebb17ce17263bb199baabb9bf0e205b68f2e787623f4636d83",
   "pins" : [
     {
       "identity" : "equatable",

--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8deb6a062f729fe0bf8927f94e81819185ed66c2"
+        "revision" : "84f52c13724f8f3725853969a1fa3831b91c7cfb"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "4d5ce9dff2edeaf9a57822388b4d2bf09b2b8a01"
+        "revision" : "8deb6a062f729fe0bf8927f94e81819185ed66c2"
       }
     },
     {

--- a/Sources/OpenSwiftUICore/Log/Logging.swift
+++ b/Sources/OpenSwiftUICore/Log/Logging.swift
@@ -219,6 +219,10 @@ package enum Log {
 
     // Added in 6.4.41
     package static let timelineScheduleSequences: Logger = Logger(subsystem: subsystem, category: "TimelineSchedule Sequences")
+
+    #if DEBUG
+    fileprivate static let development: Logger = Logger(subsystem: subsystem, category: "Development")
+    #endif
 }
 
 @available(*, unavailable)
@@ -235,7 +239,7 @@ package func precondition(_ condition: @autoclosure () -> Bool, _ message: @auto
 package func preconditionFailure(_ message: @autoclosure () -> String, file: StaticString, line: UInt) -> Never {
     #if DEBUG && OPENSWIFTUI_DEVELOPMENT
     if message() == "TODO" {
-        print("💣 Hit unimplemented part of OpenSwiftUI at \(file):\(line).\nConsider adding a plain implementation to avoid crash.")
+        Log.development.warning("Hit unimplemented part of OpenSwiftUI at \(file):\(line).\nConsider adding a plain implementation to avoid crash.")
     }
     #endif
     Swift.fatalError(message(), file: file, line: line)
@@ -284,16 +288,20 @@ package func _openSwiftUIPlatformUnimplementedFailure(_ function: String = #func
 
 @_transparent
 package func _openSwiftUIUnimplementedWarning(_ function: String = #function, file: StaticString = #fileID, line: UInt = #line) {
-    print("\(file):\(line): Warning: \(function) is unimplemented")
-    #if DEBUG && OPENSWIFTUI_DEVELOPMENT
+    #if DEBUG
+    Log.development.warning("\(file):\(line): Warning: \(function) is unimplemented")
+    #if OPENSWIFTUI_DEVELOPMENT
     _openSwiftUIUnimplementedFailure(function, file: file, line: line)
+    #endif
     #endif
 }
 
 @_transparent
 package func _openSwiftUIPlatformUnimplementedWarning(_ function: String = #function, file: StaticString = #fileID, line: UInt = #line) {
-    print("\(file):\(line): Warning: \(function) is unimplemented on this platform")
-    #if DEBUG && OPENSWIFTUI_DEVELOPMENT
+    #if DEBUG
+    Log.development.warning("\(file):\(line): Warning: \(function) is unimplemented on this platform")
+    #if OPENSWIFTUI_DEVELOPMENT
     _openSwiftUIPlatformUnimplementedFailure(function, file: file, line: line)
+    #endif
     #endif
 }

--- a/Sources/OpenSwiftUI_SPI/Util/Interpose.c
+++ b/Sources/OpenSwiftUI_SPI/Util/Interpose.c
@@ -8,8 +8,18 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <dispatch/dispatch.h>
 #include <os/log.h>
 #include <CoreFoundation/CoreFoundation.h>
+
+static os_log_t interpose_log(void) {
+    static dispatch_once_t onceToken;
+    static os_log_t log = NULL;
+    dispatch_once(&onceToken, ^{
+        log = os_log_create("org.OpenSwiftUIProject.OpenSwiftUI", "Interpose");
+    });
+    return log;
+}
 
 // MARK: - Type Description Shim
 
@@ -71,7 +81,6 @@ static inline CFStringRef _interpose_protocol_description(const void *protocol) 
             return result;
         }
     }
-
     CFStringRef result = CFStringCreateWithCString(kCFAllocatorDefault, name, kCFStringEncodingUTF8);
     CFAutorelease(result);
     return result;
@@ -113,7 +122,7 @@ static bool my_swift_dynamicCast(void *dest, void *src, const void *srcType, con
          CFStringHasPrefix(targetDescription, CFSTR("SwiftUICore."))) &&
         (CFStringHasPrefix(srcDescription, CFSTR("OpenSwiftUI.")) ||
          CFStringHasPrefix(srcDescription, CFSTR("OpenSwiftUICore.")))) {
-        os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_dynamicCast failed for target: %{public}@ src: %{public}@", targetDescription, srcDescription);
+        os_log_info(interpose_log(), "swift_dynamicCast failed for target: %{public}@ src: %{public}@", targetDescription, srcDescription);
     }
     // If dynamicCast check failed and the target is SwiftUI's Color.Resolved
     // retry with OpenSwiftUI's Color.Resolved
@@ -121,7 +130,7 @@ static bool my_swift_dynamicCast(void *dest, void *src, const void *srcType, con
         result = swift_dynamicCast(dest, src, srcType, _OpenSwiftUI_ColorResolvedNTD(), flags);
         if (result) {
             CFStringRef description = _interpose_type_description(srcType);
-            os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_dynamicCast succeeded for %{public}@", description);
+            os_log_info(interpose_log(), "swift_dynamicCast succeeded for %{public}@", description);
         }
     }
     return result;
@@ -152,7 +161,7 @@ static const void *my_swift_conformsToProtocol2(const void *type, const void *pr
          CFStringHasPrefix(protocolDescription, CFSTR("SwiftUICore."))) &&
         (CFStringHasPrefix(typeDescription, CFSTR("OpenSwiftUI.")) ||
          CFStringHasPrefix(typeDescription, CFSTR("OpenSwiftUICore.")))) {
-        os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_conformsToProtocol2 failed for protocol: %{public}@ type: %{public}@", protocolDescription, typeDescription);
+        os_log_info(interpose_log(), "swift_conformsToProtocol2 failed for protocol: %{public}@ type: %{public}@", protocolDescription, typeDescription);
     }
     // If conformance check failed and the protocol is SwiftUI's PlatformDrawable,
     // retry with OpenSwiftUI's PlatformDrawable
@@ -160,7 +169,7 @@ static const void *my_swift_conformsToProtocol2(const void *type, const void *pr
         result = swift_conformsToProtocol2(type, _OpenSwiftUI_PlatformDrawablePD());
         if (result != NULL) {
             CFStringRef description = _interpose_type_description(type);
-            os_log_info(OS_LOG_DEFAULT, "[OpenSwiftUI] swift_conformsToProtocol2 succeeded via OpenSwiftUI fallback for %{public}@", description);
+            os_log_info(interpose_log(), "swift_conformsToProtocol2 succeeded via OpenSwiftUI fallback for %{public}@", description);
         }
     }
     return result;


### PR DESCRIPTION
## Summary
- Add a dedicated `Interpose` OSLog in `Interpose.c` and route interpose diagnostics through it instead of `OS_LOG_DEFAULT`.
- Remove the inline `[OpenSwiftUI]` text prefix from those interpose log messages now that the subsystem/category carry the context.
- Replace development-only `print` diagnostics in `Logging.swift` with a DEBUG-only development logger.
- Update resolved DarwinPrivateFrameworks pins to the merged 2024 default-release fix.

## Why
The interpose logs should be filterable through a dedicated category rather than mixed into the default log stream. Development diagnostics should also use the logging system instead of printing directly.

## Validation
- `xcrun clang -fsyntax-only -fblocks -std=c11 -I Sources/OpenSwiftUI_SPI -D_OPENSWIFTUI_SWIFTUI_RENDER=1 Sources/OpenSwiftUI_SPI/Util/Interpose.c`
- `DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE=2024 swift build --target OpenSwiftUI_SPI`
- `DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE=2024 swift build --target OpenSwiftUICore`
- `DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE=2024 swift build -c release --target OpenSwiftUICore`