### PR TITLE
Add safe NSValue geometry wrappers

### DIFF
--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListAsyncLayer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListAsyncLayer.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import OpenQuartzCoreShims
+import UIFoundation_Private
 
 protocol _DisplayList_ViewUpdater_AsyncLayerProperty {
     associatedtype Value
@@ -106,7 +107,7 @@ extension DisplayList.ViewUpdater {
 
         static func boxValue(_ value: CGPoint) -> NSObject {
             #if canImport(QuartzCore)
-            NSValue(point: value)
+            NSValue(cgPoint: value)
             #else
             _openSwiftUIPlatformUnimplementedFailure()
             #endif
@@ -118,7 +119,7 @@ extension DisplayList.ViewUpdater {
 
         static func boxValue(_ value: CGRect) -> NSObject {
             #if canImport(QuartzCore)
-            NSValue(rect: value)
+            NSValue(cgRect: value)
             #else
             _openSwiftUIPlatformUnimplementedFailure()
             #endif

--- a/Sources/OpenSwiftUICore/Shape/ShapeLayer.swift
+++ b/Sources/OpenSwiftUICore/Shape/ShapeLayer.swift
@@ -9,6 +9,7 @@
 import Foundation
 import OpenQuartzCoreShims
 import OpenSwiftUI_SPI
+import UIFoundation_Private
 // import OpenRenderBoxShims
 
 // MARK: - ShapeLayerHelper [WIP]
@@ -175,7 +176,7 @@ extension DisplayList.ViewUpdater {
 
         static func boxValue(_ value: CGSize) -> NSObject {
             #if canImport(Darwin)
-            NSValue(size: value)
+            NSValue(cgSize: value)
             #else
             _openSwiftUIPlatformUnimplementedFailure()
             #endif

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/UIGeometry.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/UIGeometry.h
@@ -1,0 +1,26 @@
+//
+//  UIGeometry.h
+//  OpenSwiftUI_SPI
+
+#pragma once
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+OPENSWIFTUI_ASSUME_NONNULL_BEGIN
+
+@interface NSValue (OpenSwiftUI_UIGeometry)
+
++ (NSValue *)valueWithCGPoint_openswiftui_safe_wrapper:(CGPoint)point OPENSWIFTUI_SWIFT_NAME(init(cgPoint:));
++ (NSValue *)valueWithCGSize_openswiftui_safe_wrapper:(CGSize)size OPENSWIFTUI_SWIFT_NAME(init(cgSize:));
++ (NSValue *)valueWithCGRect_openswiftui_safe_wrapper:(CGRect)rect OPENSWIFTUI_SWIFT_NAME(init(cgRect:));
+
+@end
+
+OPENSWIFTUI_ASSUME_NONNULL_END
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN */

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/UIGeometry.m
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/UIGeometry.m
@@ -1,0 +1,55 @@
+//
+//  UIGeometry.m
+//  OpenSwiftUI_SPI
+
+#import "UIGeometry.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#import <objc/runtime.h>
+
+OPENSWIFTUI_ASSUME_NONNULL_BEGIN
+
+@implementation NSValue (OpenSwiftUI_UIGeometry)
+
++ (NSValue *)valueWithCGPoint_openswiftui_safe_wrapper:(CGPoint)point {
+    SEL selector = NSSelectorFromString(@"valueWithCGPoint:");
+    if ([self respondsToSelector:selector]) {
+        typedef NSValue *(*Func)(id, SEL, CGPoint);
+        Func func = (Func)class_getMethodImplementation(object_getClass(self), selector);
+        if (func != nil) {
+            return func(self, selector, point);
+        }
+    }
+    return [self valueWithBytes:&point objCType:@encode(CGPoint)];
+}
+
++ (NSValue *)valueWithCGSize_openswiftui_safe_wrapper:(CGSize)size {
+    SEL selector = NSSelectorFromString(@"valueWithCGSize:");
+    if ([self respondsToSelector:selector]) {
+        typedef NSValue *(*Func)(id, SEL, CGSize);
+        Func func = (Func)class_getMethodImplementation(object_getClass(self), selector);
+        if (func != nil) {
+            return func(self, selector, size);
+        }
+    }
+    return [self valueWithBytes:&size objCType:@encode(CGSize)];
+}
+
++ (NSValue *)valueWithCGRect_openswiftui_safe_wrapper:(CGRect)rect {
+    SEL selector = NSSelectorFromString(@"valueWithCGRect:");
+    if ([self respondsToSelector:selector]) {
+        typedef NSValue *(*Func)(id, SEL, CGRect);
+        Func func = (Func)class_getMethodImplementation(object_getClass(self), selector);
+        if (func != nil) {
+            return func(self, selector, rect);
+        }
+    }
+    return [self valueWithBytes:&rect objCType:@encode(CGRect)];
+}
+
+@end
+
+OPENSWIFTUI_ASSUME_NONNULL_END
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN */


### PR DESCRIPTION
## Summary

Adds a UIFoundation shim for `NSValue` geometry boxing so OpenSwiftUICore can use `CGPoint`, `CGSize`, and `CGRect` initializers without depending on UIKit.

The new wrappers first call the platform implementation when selectors like `valueWithCGSize:` are available, which should keep the UIKit/iOS path aligned with the system behavior. When those selectors are unavailable, such as on macOS where Foundation exposes `NSValue(size:)` instead of `NSValue(cgSize:)`, the wrappers fall back to `valueWithBytes:objCType:` using the CoreGraphics encoding.

## Changes

- Add `UIGeometry.h` / `UIGeometry.m` under `OpenSwiftUI_SPI/Shims/UIFoundation`.
- Expose Swift names for `NSValue(cgPoint:)`, `NSValue(cgSize:)`, and `NSValue(cgRect:)` through OpenSwiftUI-safe wrappers.
- Update display-list and shape-layer property boxing to use the new `cg*` APIs via `UIFoundation_Private`.

## Validation

- `swift package describe --type json`
- `OPENSWIFTUI_USE_LOCAL_DEPS=1 swift package describe --type json`
- `swift build --target OpenSwiftUICore`

Builds completed successfully with existing warnings only.