### PR TITLE
Update MovableLock SPI implementation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -196,12 +196,19 @@ let cfCGTypes = envBoolValue("CF_CGTYPES", default: buildForDarwinPlatform)
 
 var sharedCSettings: [CSetting] = [
     .define("NDEBUG", .when(configuration: .release)),
+    // Rewrite malloc() to malloc_type_malloc() for type-isolated allocation buckets (xzone malloc).
+    .unsafeFlags(["-ftyped-memory-operations"], .when(platforms: .darwinPlatforms)),
     .unsafeFlags(["-fmodules"]),
     .define("_WASI_EMULATED_SIGNAL", .when(platforms: [.wasi])),
     .unsafeFlags(["-isystem", swiftCorelibsPath], .when(platforms: .nonDarwinPlatforms)),
 ]
 
 var sharedCxxSettings: [CXXSetting] = [
+    .define("NDEBUG", .when(configuration: .release)),
+    // Rewrite malloc() to malloc_type_malloc() for type-isolated allocation buckets (xzone malloc).
+    .unsafeFlags(["-ftyped-memory-operations"], .when(platforms: .darwinPlatforms)),
+    // Rewrite operator new/delete to typed variants (operator new(size_t, std::__type_descriptor_t)).
+    .unsafeFlags(["-ftyped-cxx-new-delete"], .when(platforms: .darwinPlatforms)),
     .unsafeFlags(["-fcxx-modules"]),
     .define("_WASI_EMULATED_SIGNAL", .when(platforms: [.wasi])),
     .unsafeFlags(["-isystem", swiftCorelibsPath], .when(platforms: .nonDarwinPlatforms)),

--- a/Sources/OpenSwiftUICore/Data/Update.swift
+++ b/Sources/OpenSwiftUICore/Data/Update.swift
@@ -17,7 +17,7 @@ package enum Update {
 
     private static var depth = 0
     private static var dispatchDepth = 0
-    private static let _lock = MovableLock.create()
+    private static let _lock = MovableLock()
     private static var actions: [() -> Void] = []
     private static let lockAssertionsAreEnabled = EnvironmentHelper.bool(for: "OPENSWIFTUI_ASSERT_LOCKS")
     

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
@@ -17,8 +17,8 @@
 extern pthread_t pthread_main_thread_np(void);
 #endif
 
-void wait_for_lock(MovableLock lock, pthread_t thread);
-void sync_main_callback(MovableLock lock);
+static void wait_for_lock(MovableLock lock, pthread_t thread) __attribute__((noinline));
+static void sync_main_callback(MovableLock lock);
 
 MovableLock _MovableLockCreate() {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
@@ -47,13 +47,16 @@ void _MovableLockDestroy(MovableLock lock) {
 }
 
 bool _MovableLockIsOwner(MovableLock lock) {
-    return pthread_self() == lock->owner;
+    pthread_t owner = lock->owner;
+    return pthread_self() == owner;
 }
 
-bool _MovableLockIsOuterMostOwner(MovableLock lock) {
-    return pthread_self() == lock->owner && lock->level == 1;
+bool _MovableLockIsOutermostOwner(MovableLock lock) {
+    pthread_t owner = lock->owner;
+    return pthread_self() == owner && lock->level == 1;
 }
 
+__attribute__((noinline))
 void _MovableLockLock(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     pthread_t owner = pthread_self();
@@ -70,6 +73,7 @@ void _MovableLockLock(MovableLock lock) {
     #endif
 }
 
+__attribute__((noinline))
 void _MovableLockUnlock(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     lock->level -= 1;
@@ -131,17 +135,20 @@ void _MovableLockBroadcast(MovableLock lock) {
     #endif
 }
 
-void wait_for_lock(MovableLock lock, pthread_t owner) {
+static void wait_for_lock(MovableLock lock, pthread_t owner) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     lock->waiterCount += 1;
     if (lock->main == owner) {
         lock->mainThreadWaiting = true;
         if (lock->function) {
+            pthread_t original_owner = __atomic_load_n(&lock->owner, __ATOMIC_SEQ_CST);
             uint32_t original_level = lock->level;
-            pthread_t original_owner = lock->owner;
-            lock->owner = lock->main;
+            pthread_t main = lock->main;
+            lock->owner = main;
             lock->level = original_level + 1;
-            lock->function(lock->context);
+            void (*function)(const void *) = lock->function;
+            const void *context = lock->context;
+            function(context);
             lock->level = original_level;
             lock->owner = original_owner;
             lock->function = NULL;
@@ -157,7 +164,7 @@ void wait_for_lock(MovableLock lock, pthread_t owner) {
     #endif
 }
 
-void sync_main_callback(MovableLock lock) {
+static void sync_main_callback(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     _MovableLockLock(lock);
     lock->syncMainCallbackPending = false;

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
@@ -56,7 +56,6 @@ bool _MovableLockIsOutermostOwner(MovableLock lock) {
     return pthread_self() == owner && lock->level == 1;
 }
 
-__attribute__((noinline))
 void _MovableLockLock(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     pthread_t owner = pthread_self();
@@ -73,7 +72,6 @@ void _MovableLockLock(MovableLock lock) {
     #endif
 }
 
-__attribute__((noinline))
 void _MovableLockUnlock(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     lock->level -= 1;
@@ -166,8 +164,10 @@ static void wait_for_lock(MovableLock lock, pthread_t owner) {
 
 static void sync_main_callback(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
+    [[clang::noinline]]
     _MovableLockLock(lock);
     lock->syncMainCallbackPending = false;
+    [[clang::noinline]]
     _MovableLockUnlock(lock);
     #endif
 }

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
@@ -29,82 +29,82 @@ MovableLock _MovableLockCreate() {
         abort();
     }
     pthread_mutex_init(&lock->mutex, NULL);
-    pthread_cond_init(&lock->lockCondition, NULL);
-    pthread_cond_init(&lock->syncMainCondition, NULL);
-    pthread_cond_init(&lock->waitCondition, NULL);
+    pthread_cond_init(&lock->lock_condition, NULL);
+    pthread_cond_init(&lock->main_callback_condition, NULL);
+    pthread_cond_init(&lock->broadcast_condition, NULL);
     #if OPENSWIFTUI_TARGET_OS_DARWIN
-    lock->main = pthread_main_thread_np();
+    lock->main_thread = pthread_main_thread_np();
     #endif
     return lock;
 }
 
 void _MovableLockDestroy(MovableLock lock) {
-    pthread_cond_destroy(&lock->lockCondition);
-    pthread_cond_destroy(&lock->syncMainCondition);
-    pthread_cond_destroy(&lock->waitCondition);
+    pthread_cond_destroy(&lock->lock_condition);
+    pthread_cond_destroy(&lock->main_callback_condition);
+    pthread_cond_destroy(&lock->broadcast_condition);
     pthread_mutex_destroy(&lock->mutex);
     free(lock);
 }
 
 bool _MovableLockIsOwner(MovableLock lock) {
-    pthread_t owner = lock->owner;
+    pthread_t owner = lock->owner_thread;
     return pthread_self() == owner;
 }
 
 bool _MovableLockIsOutermostOwner(MovableLock lock) {
-    pthread_t owner = lock->owner;
-    return pthread_self() == owner && lock->level == 1;
+    pthread_t owner = lock->owner_thread;
+    return pthread_self() == owner && lock->lock_level == 1;
 }
 
 void _MovableLockLock(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     pthread_t owner = pthread_self();
-    if (owner == lock->owner) {
-        lock->level += 1;
+    if (owner == lock->owner_thread) {
+        lock->lock_level += 1;
         return;
     }
     pthread_mutex_lock(&lock->mutex);
-    while (lock->owner) {
+    while (lock->owner_thread) {
         [[clang::noinline]]
         wait_for_lock(lock, owner);
     }
-    lock->owner = owner;
-    lock->level = 1;
+    lock->owner_thread = owner;
+    lock->lock_level = 1;
     #endif
 }
 
 void _MovableLockUnlock(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
-    lock->level -= 1;
-    if (lock->level != 0) {
+    lock->lock_level -= 1;
+    if (lock->lock_level != 0) {
         return;
     }
-    if (lock->waiterCount != 0) {
-        pthread_cond_signal(&lock->lockCondition);
+    if (lock->waiter_count != 0) {
+        pthread_cond_signal(&lock->lock_condition);
     }
-    lock->owner = NULL;
+    lock->owner_thread = NULL;
     pthread_mutex_unlock(&lock->mutex);
     #endif
 }
 
-void _MovableLockSyncMain(MovableLock lock, const void *context, void (*function)(const void *context)) {
+void _MovableLockSyncMain(MovableLock lock, const void *main_callback_context, void (*main_callback)(const void *main_callback_context)) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
-    if (pthread_self() == lock->main) {
-        function(context);
+    if (pthread_self() == lock->main_thread) {
+        main_callback(main_callback_context);
     } else {
-        lock->function = function;
-        lock->context = context;
-        if (lock->mainThreadWaiting) {
-            pthread_cond_signal_thread_np(&lock->lockCondition, lock->main);
-        } else if (!lock->syncMainCallbackPending) {
-            lock->syncMainCallbackPending = true;
+        lock->main_callback = main_callback;
+        lock->main_callback_context = main_callback_context;
+        if (lock->main_thread_waiting) {
+            pthread_cond_signal_thread_np(&lock->lock_condition, lock->main_thread);
+        } else if (!lock->main_callback_pending) {
+            lock->main_callback_pending = true;
             dispatch_async_f(dispatch_get_main_queue(), lock, (dispatch_function_t)&sync_main_callback);
-            if (lock->mainThreadWaiting) {
-                pthread_cond_signal_thread_np(&lock->lockCondition, lock->main);
+            if (lock->main_thread_waiting) {
+                pthread_cond_signal_thread_np(&lock->lock_condition, lock->main_thread);
             }
         }
-        while (lock->function) {
-            pthread_cond_wait(&lock->syncMainCondition, &lock->mutex);
+        while (lock->main_callback) {
+            pthread_cond_wait(&lock->main_callback_condition, &lock->mutex);
         }
     }
     #endif
@@ -113,54 +113,54 @@ void _MovableLockSyncMain(MovableLock lock, const void *context, void (*function
 void _MovableLockWait(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     pthread_t owner = pthread_self();
-    uint32_t level = lock->level;
-    lock->level = 0;
-    lock->owner = NULL;
-    if (lock->waiterCount != 0) {
-        pthread_cond_broadcast(&lock->lockCondition);
+    uint32_t level = lock->lock_level;
+    lock->lock_level = 0;
+    lock->owner_thread = NULL;
+    if (lock->waiter_count != 0) {
+        pthread_cond_broadcast(&lock->lock_condition);
     }
-    pthread_cond_wait(&lock->waitCondition, &lock->mutex);
-    while (lock->owner) {
+    pthread_cond_wait(&lock->broadcast_condition, &lock->mutex);
+    while (lock->owner_thread) {
         [[clang::noinline]]
         wait_for_lock(lock, owner);
     }
-    lock->owner = owner;
-    lock->level = level;
+    lock->owner_thread = owner;
+    lock->lock_level = level;
     #endif
 }
 
 void _MovableLockBroadcast(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
-    pthread_cond_broadcast(&lock->waitCondition);
+    pthread_cond_broadcast(&lock->broadcast_condition);
     #endif
 }
 
 static void wait_for_lock(MovableLock lock, pthread_t owner) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
-    lock->waiterCount += 1;
-    if (lock->main == owner) {
-        lock->mainThreadWaiting = true;
-        if (lock->function) {
-            pthread_t original_owner = __atomic_load_n(&lock->owner, __ATOMIC_SEQ_CST);
-            uint32_t original_level = lock->level;
-            pthread_t main = lock->main;
-            lock->owner = main;
-            lock->level = original_level + 1;
-            void (*function)(const void *) = lock->function;
-            const void *context = lock->context;
-            function(context);
-            lock->level = original_level;
-            lock->owner = original_owner;
-            lock->function = NULL;
-            lock->context = NULL;
-            pthread_cond_signal(&lock->syncMainCondition);
+    lock->waiter_count += 1;
+    if (lock->main_thread == owner) {
+        lock->main_thread_waiting = true;
+        if (lock->main_callback) {
+            pthread_t original_owner = __atomic_load_n(&lock->owner_thread, __ATOMIC_SEQ_CST);
+            uint32_t original_level = lock->lock_level;
+            pthread_t main_thread = lock->main_thread;
+            lock->owner_thread = main_thread;
+            lock->lock_level = original_level + 1;
+            void (*main_callback)(const void *) = lock->main_callback;
+            const void *main_callback_context = lock->main_callback_context;
+            main_callback(main_callback_context);
+            lock->lock_level = original_level;
+            lock->owner_thread = original_owner;
+            lock->main_callback = NULL;
+            lock->main_callback_context = NULL;
+            pthread_cond_signal(&lock->main_callback_condition);
         }
     }
-    pthread_cond_wait(&lock->lockCondition, &lock->mutex);
-    if (lock->main == owner) {
-        lock->mainThreadWaiting = false;
+    pthread_cond_wait(&lock->lock_condition, &lock->mutex);
+    if (lock->main_thread == owner) {
+        lock->main_thread_waiting = false;
     }
-    lock->waiterCount -= 1;
+    lock->waiter_count -= 1;
     #endif
 }
 
@@ -168,7 +168,7 @@ static void sync_main_callback(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     [[clang::noinline]]
     _MovableLockLock(lock);
-    lock->syncMainCallbackPending = false;
+    lock->main_callback_pending = false;
     [[clang::noinline]]
     _MovableLockUnlock(lock);
     #endif

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
@@ -17,7 +17,7 @@
 extern pthread_t pthread_main_thread_np(void);
 #endif
 
-static void wait_for_lock(MovableLock lock, pthread_t thread) __attribute__((noinline));
+static void wait_for_lock(MovableLock lock, pthread_t thread);
 static void sync_main_callback(MovableLock lock);
 
 MovableLock _MovableLockCreate() {
@@ -65,6 +65,7 @@ void _MovableLockLock(MovableLock lock) {
     }
     pthread_mutex_lock(&lock->mutex);
     while (lock->owner) {
+        [[clang::noinline]]
         wait_for_lock(lock, owner);
     }
     lock->owner = owner;
@@ -120,6 +121,7 @@ void _MovableLockWait(MovableLock lock) {
     }
     pthread_cond_wait(&lock->waitCondition, &lock->mutex);
     while (lock->owner) {
+        [[clang::noinline]]
         wait_for_lock(lock, owner);
     }
     lock->owner = owner;

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
@@ -2,7 +2,7 @@
 //  MovableLock.c
 //  OpenSwiftUI
 //
-//  Audited for 3.5.2
+//  Audited for 6.5.4
 //  Status: Complete
 
 #include "MovableLock.h"

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.c
@@ -29,9 +29,9 @@ MovableLock _MovableLockCreate() {
         abort();
     }
     pthread_mutex_init(&lock->mutex, NULL);
-    pthread_cond_init(&lock->cond1, NULL);
-    pthread_cond_init(&lock->cond2, NULL);
-    pthread_cond_init(&lock->cond3, NULL);
+    pthread_cond_init(&lock->lockCondition, NULL);
+    pthread_cond_init(&lock->syncMainCondition, NULL);
+    pthread_cond_init(&lock->waitCondition, NULL);
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     lock->main = pthread_main_thread_np();
     #endif
@@ -39,9 +39,9 @@ MovableLock _MovableLockCreate() {
 }
 
 void _MovableLockDestroy(MovableLock lock) {
-    pthread_cond_destroy(&lock->cond1);
-    pthread_cond_destroy(&lock->cond2);
-    pthread_cond_destroy(&lock->cond3);
+    pthread_cond_destroy(&lock->lockCondition);
+    pthread_cond_destroy(&lock->syncMainCondition);
+    pthread_cond_destroy(&lock->waitCondition);
     pthread_mutex_destroy(&lock->mutex);
     free(lock);
 }
@@ -76,8 +76,8 @@ void _MovableLockUnlock(MovableLock lock) {
     if (lock->level != 0) {
         return;
     }
-    if (lock->unknown != 0) {
-        pthread_cond_signal(&lock->cond1);
+    if (lock->waiterCount != 0) {
+        pthread_cond_signal(&lock->lockCondition);
     }
     lock->owner = NULL;
     pthread_mutex_unlock(&lock->mutex);
@@ -91,17 +91,17 @@ void _MovableLockSyncMain(MovableLock lock, const void *context, void (*function
     } else {
         lock->function = function;
         lock->context = context;
-        if (lock->unknown5) {
-            pthread_cond_signal_thread_np(&lock->cond1, lock->main);
-        } else if (!lock->unknown4) {
-            lock->unknown4 = true;
+        if (lock->mainThreadWaiting) {
+            pthread_cond_signal_thread_np(&lock->lockCondition, lock->main);
+        } else if (!lock->syncMainCallbackPending) {
+            lock->syncMainCallbackPending = true;
             dispatch_async_f(dispatch_get_main_queue(), lock, (dispatch_function_t)&sync_main_callback);
-            if (lock->unknown5) {
-                pthread_cond_signal_thread_np(&lock->cond1, lock->main);
+            if (lock->mainThreadWaiting) {
+                pthread_cond_signal_thread_np(&lock->lockCondition, lock->main);
             }
         }
         while (lock->function) {
-            pthread_cond_wait(&lock->cond2, &lock->mutex);
+            pthread_cond_wait(&lock->syncMainCondition, &lock->mutex);
         }
     }
     #endif
@@ -113,10 +113,10 @@ void _MovableLockWait(MovableLock lock) {
     uint32_t level = lock->level;
     lock->level = 0;
     lock->owner = NULL;
-    if (lock->unknown != 0) {
-        pthread_cond_broadcast(&lock->cond1);
+    if (lock->waiterCount != 0) {
+        pthread_cond_broadcast(&lock->lockCondition);
     }
-    pthread_cond_wait(&lock->cond3, &lock->mutex);
+    pthread_cond_wait(&lock->waitCondition, &lock->mutex);
     while (lock->owner) {
         wait_for_lock(lock, owner);
     }
@@ -127,15 +127,15 @@ void _MovableLockWait(MovableLock lock) {
 
 void _MovableLockBroadcast(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
-    pthread_cond_broadcast(&lock->cond3);
+    pthread_cond_broadcast(&lock->waitCondition);
     #endif
 }
 
 void wait_for_lock(MovableLock lock, pthread_t owner) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
-    lock->unknown += 1;
+    lock->waiterCount += 1;
     if (lock->main == owner) {
-        lock->unknown5 = 1;
+        lock->mainThreadWaiting = true;
         if (lock->function) {
             uint32_t original_level = lock->level;
             pthread_t original_owner = lock->owner;
@@ -146,21 +146,21 @@ void wait_for_lock(MovableLock lock, pthread_t owner) {
             lock->owner = original_owner;
             lock->function = NULL;
             lock->context = NULL;
-            pthread_cond_signal(&lock->cond2);
+            pthread_cond_signal(&lock->syncMainCondition);
         }
     }
-    pthread_cond_wait(&lock->cond1, &lock->mutex);
+    pthread_cond_wait(&lock->lockCondition, &lock->mutex);
     if (lock->main == owner) {
-        lock->unknown5 = 0;
+        lock->mainThreadWaiting = false;
     }
-    lock->unknown -= 1;
+    lock->waiterCount -= 1;
     #endif
 }
 
 void sync_main_callback(MovableLock lock) {
     #if OPENSWIFTUI_TARGET_OS_DARWIN
     _MovableLockLock(lock);
-    lock->unknown4 = 0;
+    lock->syncMainCallbackPending = false;
     _MovableLockUnlock(lock);
     #endif
 }

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
@@ -30,7 +30,7 @@ typedef struct MovableLock_s {
 
 typedef MovableLock_t *MovableLock __attribute((swift_newtype(struct)));
 
-MovableLock _MovableLockCreate(void) OPENSWIFTUI_SWIFT_NAME(MovableLock.create());
+MovableLock _MovableLockCreate(void) OPENSWIFTUI_SWIFT_NAME(MovableLock.init());
 
 void _MovableLockDestroy(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.destroy(self:));
 

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
@@ -38,7 +38,7 @@ OPENSWIFTUI_EXPORT
 OPENSWIFTUI_REFINED_FOR_SWIFT
 void _MovableLockDestroy(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.destroy(self:));
 bool _MovableLockIsOwner(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(getter:MovableLock.isOwner(self:));
-bool _MovableLockIsOuterMostOwner(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(getter:MovableLock.isOuterMostOwner(self:));
+bool _MovableLockIsOutermostOwner(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(getter:MovableLock.isOutermostOwner(self:));
 void _MovableLockLock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.lock(self:));
 void _MovableLockUnlock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.unlock(self:));
 void _MovableLockSyncMain(MovableLock lock, const void *context, void (*function)(const void *context)) OPENSWIFTUI_SWIFT_NAME(MovableLock.syncMain(self:_:function:));

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
@@ -2,7 +2,7 @@
 //  MovableLock.h
 //  OpenSwiftUI
 //
-//  Audited for 3.5.2
+//  Audited for 6.5.4
 //  Status: Complete
 
 #ifndef MovableLock_h
@@ -31,18 +31,30 @@ typedef struct MovableLock_s {
 typedef MovableLock_t *MovableLock __attribute((swift_newtype(struct)));
 
 OPENSWIFTUI_EXPORT
-OPENSWIFTUI_REFINED_FOR_SWIFT
 MovableLock _MovableLockCreate(void) OPENSWIFTUI_SWIFT_NAME(MovableLock.create());
 
 OPENSWIFTUI_EXPORT
-OPENSWIFTUI_REFINED_FOR_SWIFT
 void _MovableLockDestroy(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.destroy(self:));
+
+OPENSWIFTUI_EXPORT
 bool _MovableLockIsOwner(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(getter:MovableLock.isOwner(self:));
+
+OPENSWIFTUI_EXPORT
 bool _MovableLockIsOutermostOwner(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(getter:MovableLock.isOutermostOwner(self:));
+
+OPENSWIFTUI_EXPORT
 void _MovableLockLock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.lock(self:));
+
+OPENSWIFTUI_EXPORT
 void _MovableLockUnlock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.unlock(self:));
+
+OPENSWIFTUI_EXPORT
 void _MovableLockSyncMain(MovableLock lock, const void *context, void (*function)(const void *context)) OPENSWIFTUI_SWIFT_NAME(MovableLock.syncMain(self:_:function:));
+
+OPENSWIFTUI_EXPORT
 void _MovableLockWait(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.wait(self:));
+
+OPENSWIFTUI_EXPORT
 void _MovableLockBroadcast(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.broadcast(self:));
 
 OPENSWIFTUI_ASSUME_NONNULL_END

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
@@ -15,17 +15,17 @@ OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 
 typedef struct MovableLock_s {
     pthread_mutex_t mutex;
-    pthread_cond_t cond1;
-    pthread_cond_t cond2;
-    pthread_cond_t cond3;
+    pthread_cond_t lockCondition;
+    pthread_cond_t syncMainCondition;
+    pthread_cond_t waitCondition;
     pthread_t main;
     pthread_t owner;
     uint32_t level;
-    uint32_t unknown;
+    uint32_t waiterCount;
     void (* _Nullable function)(const void *context);
     const void * _Nullable context;
-    bool unknown4;
-    bool unknown5;
+    bool syncMainCallbackPending;
+    bool mainThreadWaiting;
 } MovableLock_t;
 
 typedef MovableLock_t *MovableLock __attribute((swift_newtype(struct)));

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
@@ -15,17 +15,17 @@ OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 
 typedef struct MovableLock_s {
     pthread_mutex_t mutex;
-    pthread_cond_t lockCondition;
-    pthread_cond_t syncMainCondition;
-    pthread_cond_t waitCondition;
-    pthread_t main;
-    pthread_t owner;
-    uint32_t level;
-    uint32_t waiterCount;
-    void (* _Nullable function)(const void *context);
-    const void * _Nullable context;
-    bool syncMainCallbackPending;
-    bool mainThreadWaiting;
+    pthread_cond_t lock_condition;
+    pthread_cond_t main_callback_condition;
+    pthread_cond_t broadcast_condition;
+    pthread_t main_thread;
+    pthread_t owner_thread;
+    uint32_t lock_level;
+    uint32_t waiter_count;
+    void (* _Nullable main_callback)(const void *main_callback_context);
+    const void * _Nullable main_callback_context;
+    bool main_callback_pending;
+    bool main_thread_waiting;
 } MovableLock_t;
 
 typedef MovableLock_t *MovableLock __attribute((swift_newtype(struct)));
@@ -42,7 +42,7 @@ void _MovableLockLock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.lock(
 
 void _MovableLockUnlock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.unlock(self:));
 
-void _MovableLockSyncMain(MovableLock lock, const void *context, void (*function)(const void *context)) OPENSWIFTUI_SWIFT_NAME(MovableLock.syncMain(self:_:function:));
+void _MovableLockSyncMain(MovableLock lock, const void *main_callback_context, void (*main_callback)(const void *main_callback_context)) OPENSWIFTUI_SWIFT_NAME(MovableLock.syncMain(self:_:function:));
 
 void _MovableLockWait(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.wait(self:));
 

--- a/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
+++ b/Sources/OpenSwiftUI_SPI/Util/MovableLock.h
@@ -30,31 +30,22 @@ typedef struct MovableLock_s {
 
 typedef MovableLock_t *MovableLock __attribute((swift_newtype(struct)));
 
-OPENSWIFTUI_EXPORT
 MovableLock _MovableLockCreate(void) OPENSWIFTUI_SWIFT_NAME(MovableLock.create());
 
-OPENSWIFTUI_EXPORT
 void _MovableLockDestroy(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.destroy(self:));
 
-OPENSWIFTUI_EXPORT
 bool _MovableLockIsOwner(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(getter:MovableLock.isOwner(self:));
 
-OPENSWIFTUI_EXPORT
 bool _MovableLockIsOutermostOwner(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(getter:MovableLock.isOutermostOwner(self:));
 
-OPENSWIFTUI_EXPORT
 void _MovableLockLock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.lock(self:));
 
-OPENSWIFTUI_EXPORT
 void _MovableLockUnlock(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.unlock(self:));
 
-OPENSWIFTUI_EXPORT
 void _MovableLockSyncMain(MovableLock lock, const void *context, void (*function)(const void *context)) OPENSWIFTUI_SWIFT_NAME(MovableLock.syncMain(self:_:function:));
 
-OPENSWIFTUI_EXPORT
 void _MovableLockWait(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.wait(self:));
 
-OPENSWIFTUI_EXPORT
 void _MovableLockBroadcast(MovableLock lock) OPENSWIFTUI_SWIFT_NAME(MovableLock.broadcast(self:));
 
 OPENSWIFTUI_ASSUME_NONNULL_END

--- a/Tests/OpenSwiftUI_SPITests/Util/MovableLockTests.swift
+++ b/Tests/OpenSwiftUI_SPITests/Util/MovableLockTests.swift
@@ -10,7 +10,7 @@ final class MovableLockTests {
     let lock: MovableLock
 
     init() {
-        lock = MovableLock.create()
+        lock = MovableLock()
     }
 
     deinit {
@@ -20,13 +20,13 @@ final class MovableLockTests {
     @Test
     func owner() {
         #expect(lock.isOwner == false)
-        #expect(lock.isOuterMostOwner == false)
+        #expect(lock.isOutermostOwner == false)
         lock.lock()
         #expect(lock.isOwner == true)
-        #expect(lock.isOuterMostOwner == true)
+        #expect(lock.isOutermostOwner == true)
         lock.unlock()
         #expect(lock.isOwner == false)
-        #expect(lock.isOuterMostOwner == false)
+        #expect(lock.isOutermostOwner == false)
     }
 }
 #endif


### PR DESCRIPTION
## Agent Summary

- Update MovableLock SPI layout, naming, typed allocation flags, and Swift importer surface
- Preserve public C symbol visibility while removing redundant export/refined-for-Swift annotations
- Import `_MovableLockCreate` as `MovableLock.init()` and update call sites/tests