### PR TITLE
Fix OpenSwiftUI View Renderer requirement impl

### DIFF
--- a/Sources/OpenSwiftUI/View/Toggle/SwitchToggleStyle.swift
+++ b/Sources/OpenSwiftUI/View/Toggle/SwitchToggleStyle.swift
@@ -127,7 +127,7 @@ private struct Switch: UIViewRepresentable {
         let isOn = isOn
         let transaction = context.transaction
         Update.enqueueAction(reason: nil) { [transaction] in
-            uiView.setOn(isOn, animated: transaction.disablesAnimations)
+            uiView.setOn(isOn, animated: !transaction.disablesAnimations)
         }
         uiView.preferredStyle = .sliding
         let newTintColor: UIColor? = if let tint {

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewModel.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewModel.swift
@@ -91,26 +91,25 @@ extension DisplayList.ViewUpdater {
             static let visibleContent = MergedViewRequirements(rawValue: 1 << 2)
         }
 
+        @inline(__always)
         fileprivate static func merge(
             _ content: DisplayList.Content,
             from item: DisplayList.Item,
             into state: inout State,
             requirements: inout MergedViewRequirements
         ) {
-            requirements.insert(.itemView)
-            state.versions.properties.combine(with: item.version)
             switch content.value {
             case let .backdrop(effect):
                 appendInheritedFilters(effect.filters, version: item.version, into: &state)
             case let .chameleonColor(_, filters):
                 appendInheritedFilters(filters, version: item.version, into: &state)
-            case .view, .platformView, .platformLayer:
-                requirements.insert(.inheritedView)
             default:
                 break
             }
+            requirements.insert(.itemView)
         }
 
+        @inline(__always)
         fileprivate static func merge(
             _ effect: DisplayList.Effect,
             list: DisplayList,
@@ -162,6 +161,7 @@ extension DisplayList.ViewUpdater {
             }
         }
 
+        @inline(__always)
         private static func merge(
             _ transform: DisplayList.Transform,
             item: DisplayList.Item,
@@ -185,6 +185,7 @@ extension DisplayList.ViewUpdater {
             }
         }
 
+        @inline(__always)
         private static func merge(
             _ filter: GraphicsFilter,
             list: DisplayList,


### PR DESCRIPTION
## Agent Summary

This fixes two Toggle-related rendering issues in the OpenSwiftUI UIKit-backed path.

The switch now respects the transaction animation setting when updating `UISwitch.isOn`, so animated transactions animate the control update and disabled-animation transactions update immediately.

This also updates display-list content requirement merging for platform content. Platform-backed content now contributes an item view without forcing an inherited view boundary, matching the expected view hierarchy and avoiding misplaced platform controls.