### PR TITLE
Fix rotate effect merging for OpenSwiftUI renderer

### DIFF
--- a/Example/OpenSwiftUIUITests/Layout/Stack/ZStackIndexUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/Stack/ZStackIndexUITests.swift
@@ -7,7 +7,7 @@ import Testing
 import SnapshotTesting
 
 @MainActor
-@Suite(.snapshots(record: .never, diffTool: diffTool), .disabled(if: viewRendererVendor == .osui, "rotate is not supported"))
+@Suite(.snapshots(record: .never, diffTool: diffTool))
 struct ZStackIndexUITests {
     @Test
     func rotateOverlap() {

--- a/Example/OpenSwiftUIUITests/Render/GeometryEffect/Rotation3DEffectUITests.swift
+++ b/Example/OpenSwiftUIUITests/Render/GeometryEffect/Rotation3DEffectUITests.swift
@@ -6,7 +6,7 @@ import Testing
 import SnapshotTesting
 
 @MainActor
-@Suite(.snapshots(record: .never, diffTool: diffTool), .disabled(if: viewRendererVendor == .osui, "rotate is not supported"))
+@Suite(.snapshots(record: .never, diffTool: diffTool))
 struct Rotation3DEffectUITests {
     @Test
     func rotation3DEffect() {

--- a/Example/OpenSwiftUIUITests/Render/GeometryEffect/RotationEffectUITests.swift
+++ b/Example/OpenSwiftUIUITests/Render/GeometryEffect/RotationEffectUITests.swift
@@ -6,7 +6,7 @@ import Testing
 import SnapshotTesting
 
 @MainActor
-@Suite(.snapshots(record: .never, diffTool: diffTool), .disabled(if: viewRendererVendor == .osui, "rotate is not supported"))
+@Suite(.snapshots(record: .never, diffTool: diffTool))
 struct RotationEffectUITests {
     @Test
     func rotationEffect() {

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewModel.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewModel.swift
@@ -168,20 +168,14 @@ extension DisplayList.ViewUpdater {
             into state: inout State,
             requirements: inout MergedViewRequirements
         ) {
-            switch transform {
-            case let .affine(transform):
-                state.adjust(for: transform)
-                state.transform = transform.concatenating(state.transform)
+            if let affineTransform = transform.affineTransform {
+                state.transform = affineTransform.concatenating(state.transform)
+                state.adjust(for: affineTransform)
                 state.versions.transform.combine(with: item.version)
-                requirements.insert(.visibleContent)
-            case let .projection(transform) where transform.isAffine:
-                let affine = CGAffineTransform(transform)
-                state.adjust(for: affine)
-                state.transform = affine.concatenating(state.transform)
-                state.versions.transform.combine(with: item.version)
-                requirements.insert(.visibleContent)
-            default:
-                requirements.formUnion([.inheritedView, .visibleContent])
+            } else if let projectionTransform = transform.projectionTransform {
+                if !projectionTransform.isIdentity {
+                    requirements.insert(.itemView)
+                }
             }
         }
 


### PR DESCRIPTION
Close #878 

## Agent Summary

This updates display-list transform merging so 2D rotation effects are folded into the accumulated affine transform path, while projection and 3D rotation effects only require item-level rendering when they are non-identity.

It also restores the rotate-related UI snapshot suites for the OpenSwiftUI renderer:

- `RotationEffectUITests`
- `Rotation3DEffectUITests`
- `ZStackIndexUITests.rotateOverlap`

The previous merge behavior could leave rotate effects on the renderer-backed path with an incorrect view hierarchy. This keeps the affine transform state updated for 2D rotation and re-enables the matching UI coverage.

## Validation

- `xcrun swift build --target OpenSwiftUICore`
