### PR TITLE
Fix Example Debug compilation conditions

### DIFF
--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -53,6 +53,8 @@ import ProjectDescription
 
 let examplePackageDestinations: Destinations = [.iPhone, .iPad, .mac, .appleVision]
 let openSwiftUIPackageDebugSettings: SettingsDictionary = [
+    "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) DEBUG=1",
+    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) DEBUG",
     "SWIFT_COMPILATION_MODE": "singlefile",
     "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
 ]

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
@@ -139,7 +139,7 @@ extension DisplayList {
         // OpenSwiftUI Addition:
         private static let rendererCheck: Void = {
             #if DEBUG
-            print("ViewRendererVendor: \(viewRendererVendor)")
+            print("OpenSwiftUI ViewRendererVendor: \(viewRendererVendor)")
             #endif
 
             // validateSwiftUIRendererABI

--- a/Sources/OpenSwiftUICore/Render/ViewRendererVendor.swift
+++ b/Sources/OpenSwiftUICore/Render/ViewRendererVendor.swift
@@ -5,12 +5,18 @@
 /// A type that identifies the underlying view renderer implementation vendor.
 ///
 /// Use `viewRendererVendor` to check which vendor is active at runtime.
-public struct ViewRendererVendor: RawRepresentable, Hashable, CaseIterable {
+public struct ViewRendererVendor: RawRepresentable, Hashable, CaseIterable, CustomStringConvertible, ExpressibleByStringLiteral {
     public let rawValue: String
 
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
+
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value)
+    }
+
+    public var description: String { rawValue }
 
     /// OpenSwiftUI's view renderer.
     public static let osui = ViewRendererVendor(rawValue: "org.OpenSwiftUIProject.OpenSwiftUI")

--- a/Tests/OpenSwiftUICoreTests/Render/ViewRendererVendorTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Render/ViewRendererVendorTests.swift
@@ -14,6 +14,15 @@ struct ViewRendererVendorTests {
     }
 
     @Test
+    func stringRepresentations() {
+        let vendor: ViewRendererVendor = "org.example.Renderer"
+
+        #expect(vendor.rawValue == "org.example.Renderer")
+        #expect(vendor.description == "org.example.Renderer")
+        #expect("\(ViewRendererVendor.osui)" == "org.OpenSwiftUIProject.OpenSwiftUI")
+    }
+
+    @Test
     func activeVendor() {
         #if OPENSWIFTUI_SWIFTUI_RENDERER
         #expect(viewRendererVendor == .sui)


### PR DESCRIPTION
## Agent Summary

This updates the Example Tuist package settings so generated package targets receive `DEBUG` in Debug configurations, matching the app targets and allowing debug-only code paths to compile into the Example build.

The change also makes `ViewRendererVendor` print as its raw vendor identifier, supports string literal initialization for the wrapper type, and prefixes the renderer diagnostic as `OpenSwiftUI ViewRendererVendor: ...` for easier console scanning.

Root cause: the Example app targets had Debug compilation conditions, but the Tuist-generated package targets such as `OpenSwiftUICore` used separate package settings that only configured optimization and compilation mode.

Validation:
- `mise exec -- tuist generate --no-open`
- `xcodebuild -workspace Example/Example.xcworkspace -scheme OSUI_Example -configuration OpenSwiftUIDebug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `swift build --target OpenSwiftUICore`