### PR TITLE
Add environment-configurable formatter support

### DIFF
--- a/Sources/OpenSwiftUICore/View/Text/Util/EnvironmentConfigurableFormatter.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/EnvironmentConfigurableFormatter.swift
@@ -9,7 +9,20 @@ public import Foundation
 
 // MARK: - EnvironmentConfigurableFormatter
 
+/// A formatter that can apply text-related environment values before use.
+///
+/// OpenSwiftUI calls this hook for Foundation formatters whose output depends
+/// on environment-provided formatting state, such as locale, calendar, or time
+/// zone. Conforming formatters update only the environment-dependent properties
+/// they support.
+///
+/// - Note: Some Foundation formatter types are only available on Apple
+///   platforms.
 protocol EnvironmentConfigurableFormatter: AnyObject {
+    /// Updates the formatter with values from the current environment.
+    ///
+    /// - Parameter environment: The environment values that should influence
+    ///   the formatter's output.
     func configure(in environment: EnvironmentValues)
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Util/EnvironmentConfigurableFormatter.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/EnvironmentConfigurableFormatter.swift
@@ -1,0 +1,91 @@
+//
+//  EnvironmentConfigurableFormatter.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+public import Foundation
+
+// MARK: - EnvironmentConfigurableFormatter
+
+protocol EnvironmentConfigurableFormatter: AnyObject {
+    func configure(in environment: EnvironmentValues)
+}
+
+// MARK: - DateFormatter + EnvironmentConfigurableFormatter
+
+extension DateFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        locale = environment.locale
+        calendar = environment.calendar
+        timeZone = environment.timeZone
+    }
+}
+
+// MARK: - ISO8601DateFormatter + EnvironmentConfigurableFormatter
+
+extension ISO8601DateFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        timeZone = environment.timeZone
+    }
+}
+
+// MARK: - DateComponentsFormatter + EnvironmentConfigurableFormatter
+
+extension DateComponentsFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        calendar = environment.calendar
+    }
+}
+
+// MARK: - DateIntervalFormatter + EnvironmentConfigurableFormatter
+
+extension DateIntervalFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        calendar = environment.calendar
+        locale = environment.locale
+        timeZone = environment.timeZone
+    }
+}
+
+// MARK: - NumberFormatter + EnvironmentConfigurableFormatter
+
+extension NumberFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        locale = environment.locale
+    }
+}
+
+// MARK: - MeasurementFormatter + EnvironmentConfigurableFormatter
+
+extension MeasurementFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        locale = environment.locale
+        numberFormatter.locale = environment.locale
+    }
+}
+
+// MARK: - MassFormatter + EnvironmentConfigurableFormatter
+
+extension MassFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        numberFormatter.locale = environment.locale
+    }
+}
+
+// MARK: - LengthFormatter + EnvironmentConfigurableFormatter
+
+extension LengthFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        numberFormatter.locale = environment.locale
+    }
+}
+
+// MARK: - EnergyFormatter + EnvironmentConfigurableFormatter
+
+extension EnergyFormatter: EnvironmentConfigurableFormatter {
+    func configure(in environment: EnvironmentValues) {
+        numberFormatter.locale = environment.locale
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Text/Util/EnvironmentConfigurableFormatter.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/EnvironmentConfigurableFormatter.swift
@@ -33,11 +33,13 @@ extension ISO8601DateFormatter: EnvironmentConfigurableFormatter {
 
 // MARK: - DateComponentsFormatter + EnvironmentConfigurableFormatter
 
+#if canImport(Darwin)
 extension DateComponentsFormatter: EnvironmentConfigurableFormatter {
     func configure(in environment: EnvironmentValues) {
         calendar = environment.calendar
     }
 }
+#endif
 
 // MARK: - DateIntervalFormatter + EnvironmentConfigurableFormatter
 
@@ -59,12 +61,14 @@ extension NumberFormatter: EnvironmentConfigurableFormatter {
 
 // MARK: - MeasurementFormatter + EnvironmentConfigurableFormatter
 
+#if canImport(Darwin)
 extension MeasurementFormatter: EnvironmentConfigurableFormatter {
     func configure(in environment: EnvironmentValues) {
         locale = environment.locale
         numberFormatter.locale = environment.locale
     }
 }
+#endif
 
 // MARK: - MassFormatter + EnvironmentConfigurableFormatter
 

--- a/Tests/OpenSwiftUICoreTests/View/Text/Util/EnvironmentConfigurableFormatterTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/Text/Util/EnvironmentConfigurableFormatterTests.swift
@@ -1,0 +1,112 @@
+//
+//  EnvironmentConfigurableFormatterTests.swift
+//  OpenSwiftUICoreTests
+
+import Foundation
+@testable import OpenSwiftUICore
+import Testing
+
+struct EnvironmentConfigurableFormatterTests {
+    @Test
+    func dateFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = DateFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.locale == env.locale)
+        #expect(formatter.calendar == env.calendar)
+        #expect(formatter.timeZone == env.timeZone)
+    }
+
+    @Test
+    func iso8601DateFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = ISO8601DateFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.timeZone == env.timeZone)
+    }
+
+    #if canImport(Darwin)
+    @Test
+    func dateComponentsFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = DateComponentsFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.calendar == env.calendar)
+    }
+    #endif
+
+    @Test
+    func dateIntervalFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = DateIntervalFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.calendar == env.calendar)
+        #expect(formatter.locale == env.locale)
+        #expect(formatter.timeZone == env.timeZone)
+    }
+
+    @Test
+    func numberFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = NumberFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.locale == env.locale)
+    }
+
+    #if canImport(Darwin)
+    @Test
+    func measurementFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = MeasurementFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.locale == env.locale)
+        #expect(formatter.numberFormatter.locale == env.locale)
+    }
+    #endif
+
+    @Test
+    func massFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = MassFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.numberFormatter.locale == env.locale)
+    }
+
+    @Test
+    func lengthFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = LengthFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.numberFormatter.locale == env.locale)
+    }
+
+    @Test
+    func energyFormatterConfigureAppliesEnvironmentValues() {
+        let env = makeEnvironmentValues()
+
+        let formatter = EnergyFormatter()
+        formatter.configure(in: env)
+        #expect(formatter.numberFormatter.locale == env.locale)
+    }
+
+    private func makeEnvironmentValues() -> EnvironmentValues {
+        let locale = Locale(identifier: "fr_FR")
+        var calendar = Calendar(identifier: .buddhist)
+        calendar.timeZone = TimeZone(secondsFromGMT: 9 * 3600)!
+        let timeZone = TimeZone(secondsFromGMT: 5 * 3600)!
+
+        var environment = EnvironmentValues()
+        environment.locale = locale
+        environment.calendar = calendar
+        environment.timeZone = timeZone
+        return environment
+    }
+}


### PR DESCRIPTION
## Summary

- Add `EnvironmentConfigurableFormatter` for applying `EnvironmentValues` to Foundation formatters used by text formatting.
- Configure supported formatter types with environment locale, calendar, and time zone where applicable.
- Gate formatter conformances that are only available on Apple platforms.
- Add DocC comments and Swift Testing coverage for each formatter conformance.

## Testing

- `swift build`
- `swift build --target OpenSwiftUICoreTests`
- `swift test --scratch-path .build-env-formatter-test --disable-experimental-prebuilts --filter 'OpenSwiftUICoreTests.EnvironmentConfigurableFormatterTests'`\n- Linux `swift build --build-path .build-linux` with `OPENSWIFTUI_LIB_SWIFT_PATH`