### PR TITLE
Add Text localization support

### DIFF
--- a/Example/Shared/ContentView.swift
+++ b/Example/Shared/ContentView.swift
@@ -10,6 +10,12 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        ImageConversionsExample()
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                // .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
     }
 }

--- a/Example/Shared/View/Text/TextExample.swift
+++ b/Example/Shared/View/Text/TextExample.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct TextExample: View {
     var body: some View {
         VStack {
-            Text(verbatim: "Hello World")
-            Text(verbatim: "From OpenSwiftUI")
+            Text("Hello World")
+            Text("From OpenSwiftUI")
                 .foregroundStyle(.red)
         }
     }

--- a/Sources/OpenSwiftUICore/View/Text/Resolve/ResolvedText.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Resolve/ResolvedText.swift
@@ -121,7 +121,13 @@ extension Text {
             with options: Text.ResolveOptions,
             isUniqueSizeVariant: Bool
         ) {
-            _openSwiftUIUnimplementedFailure()
+            // FIXME: Workaround append issue
+            if self.attributedString == nil {
+                self.attributedString = NSMutableAttributedString(attributedString: attributedString)
+            } else {
+                self.attributedString?.append(attributedString)
+            }
+            _openSwiftUIUnimplementedWarning()
         }
 
         package mutating func append(

--- a/Sources/OpenSwiftUICore/View/Text/Resolve/ResolvedText.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Resolve/ResolvedText.swift
@@ -489,7 +489,7 @@ extension Text {
             in environment: EnvironmentValues,
             with options: Text.ResolveOptions
         ) {
-            string.append("￼") // object replacement character (U+FFFC)
+            string.append(String.nsAttachment)
         }
 
         mutating func append(
@@ -497,7 +497,7 @@ extension Text {
             in environment: EnvironmentValues,
             with options: Text.ResolveOptions
         ) {
-            string.append("￼") // object replacement character (U+FFFC)
+            string.append(String.nsAttachment)
         }
 
         mutating func append<R>(

--- a/Sources/OpenSwiftUICore/View/Text/Text/CapitalizationContextDependentFormatStyle.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/CapitalizationContextDependentFormatStyle.swift
@@ -1,0 +1,47 @@
+//
+//  CapitalizationContextDependentFormatStyle.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete (Blocked by SystemFormatStyle)
+//  ID: B2C9C13C743DF2F6E22ED614C39E3A5D (SwiftUICore)
+
+#if canImport(Darwin)
+public import Foundation
+
+protocol CapitalizationContextDependentFormatStyle: FormatStyle {
+    func capitalizationContext(_ context: FormatStyleCapitalizationContext) -> Self
+}
+
+extension EnvironmentValues {
+    enum CapitalizationContext {
+        case resolved(FormatStyleCapitalizationContext)
+        case lazy(() -> FormatStyleCapitalizationContext)
+
+        @inline(__always)
+        var resolved: FormatStyleCapitalizationContext {
+            switch self {
+            case let .resolved(context):
+                context
+            case let .lazy(resolve):
+                resolve()
+            }
+        }
+    }
+
+    private struct Key: EnvironmentKey {
+        static let defaultValue: EnvironmentValues.CapitalizationContext = .resolved(.standalone)
+    }
+
+    var capitalizationContext: CapitalizationContext {
+        get { self[Key.self] }
+        set { self[Key.self] = newValue }
+    }
+}
+
+// TODO: Add conformance
+// SystemFormatStyle.DateReference
+// Date.AnchoredRelativeFormatStyle
+// Date.FormatStyle
+// ...
+#endif

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+DiscreteFormatStyle.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+DiscreteFormatStyle.swift
@@ -5,3 +5,21 @@
 //  Audited for 6.5.4
 //  Status: Empty
 //  ID: C8A98712CE9284278805F6E671356D1B (SwiftUICore)
+
+package import Foundation
+
+package protocol AttributedStringConvertible {
+    var attributedString: AttributedString { get }
+}
+
+extension AttributedString: AttributedStringConvertible {
+    package var attributedString: AttributedString {
+        self
+    }
+}
+
+extension String: AttributedStringConvertible {
+    package var attributedString: AttributedString {
+        AttributedString(self)
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Formatter.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Formatter.swift
@@ -3,5 +3,27 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: Empty
+//  Status: WIP
 //  ID: 7267202B6A40C9B73733978AB256B462 (SwiftUICore)
+
+public import Foundation
+
+@available(OpenSwiftUI_v3_0, *)
+extension Text {
+    public init<F>(
+        _ input: F.FormatInput,
+        format: F
+    ) where F: FormatStyle, F.FormatInput: Equatable, F.FormatOutput == String {
+        _openSwiftUIUnimplementedFailure()
+    }
+}
+
+@available(OpenSwiftUI_v6_0, *)
+extension Text {
+    public init<F>(
+        _ input: F.FormatInput,
+        format: F
+    ) where F: FormatStyle, F.FormatInput: Equatable, F.FormatOutput == AttributedString {
+        _openSwiftUIUnimplementedFailure()
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -333,7 +333,7 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
                 }
                 result = string
             case let .text(_, token):
-                result = "\u{FFFC}\(token.id.description)\u{FFFC}"
+                result = token.string
             case let .attributedString(attributedString):
                 _ = environment.accessibilityEnabled
                 result = NSAttributedString(openSwiftUIAttributedString: attributedString)
@@ -380,6 +380,14 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
 
             init(id: Int) {
                 self.id = id
+            }
+
+            @inline(__always)
+            static var delimiter: Character { .nsAttachment }
+
+            @inline(__always)
+            var string: String {
+                "\(Self.delimiter)\(id.description)\(Self.delimiter)"
             }
         }
     }

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -3,14 +3,85 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: WIP
+//  Status: Complete
 //  ID: 8C53218A357EE528547B0855666BD2E5 (SwiftUICore)
 
 public import Foundation
 
+// MARK: - Text + LocalizedStringKey
+
 @available(OpenSwiftUI_v1_0, *)
 extension Text {
+
+    /// Creates a text view that displays localized content identified by a key.
+    ///
+    /// Use this initializer to look for the `key` parameter in a localization
+    /// table and display the associated string value in the initialized text
+    /// view. If the initializer can't find the key in the table, or if no table
+    /// exists, the text view displays the string representation of the key
+    /// instead.
+    ///
+    ///     Text("pencil") // Localizes the key if possible, or displays "pencil" if not.
+    ///
+    /// When you initialize a text view with a string literal, the view triggers
+    /// this initializer because it assumes you want the string localized, even
+    /// when you don't explicitly specify a table, as in the above example. If
+    /// you haven't provided localization for a particular string, you still get
+    /// reasonable behavior, because the initializer displays the key, which
+    /// typically contains the unlocalized string.
+    ///
+    /// If you initialize a text view with a string variable rather than a
+    /// string literal, the view triggers the ``Text/init(_:)-9d1g4``
+    /// initializer instead, because it assumes that you don't want localization
+    /// in that case. If you do want to localize the value stored in a string
+    /// variable, you can choose to call the `init(_:tableName:bundle:comment:)`
+    /// initializer by first creating a ``LocalizedStringKey`` instance from the
+    /// string variable:
+    ///
+    ///     Text(LocalizedStringKey(someString)) // Localizes the contents of `someString`.
+    ///
+    /// If you have a string literal that you don't want to localize, use the
+    /// ``Text/init(verbatim:)`` initializer instead.
+    ///
+    /// ### Styling localized strings with markdown
+    ///
+    /// If the localized string or the fallback key contains Markdown, the
+    /// view displays the text with appropriate styling. For example, consider
+    /// an app with the following entry in its Spanish localization file:
+    ///
+    ///     "_Please visit our [website](https://www.example.com)._" = "_Visita nuestro [sitio web](https://www.example.com)._";
+    ///
+    /// You can create a `Text` view with the Markdown-formatted base language
+    /// version of the string as the localization key, like this:
+    ///
+    ///     Text("_Please visit our [website](https://www.example.com)._")
+    ///
+    /// When viewed in a Spanish locale, the view uses the Spanish text from the
+    /// strings file, applying the Markdown styling.
+    ///
+    /// ![A text view that says Visita nuestro sitio web, with all text
+    /// displayed in italics. The words sitio web are colored blue to indicate
+    /// they are a link.](OpenSwiftUI-Text-init-localized.png)
+    ///
+    /// > Important: `Text` doesn't render all styling possible in Markdown. It
+    /// doesn't support line breaks, soft breaks, or any style of paragraph- or
+    /// block-based formatting like lists, block quotes, code blocks, or tables.
+    /// It also doesn't support the
+    /// [https://developer.apple.com/documentation/Foundation/AttributeScopes/FoundationAttributes/3796122-imageURL](imageURL)
+    /// attribute. Parsing with OpenSwiftUI treats any whitespace in the Markdown
+    /// string as described by the
+    /// [https://developer.apple.com/documentation/Foundation/AttributedString/MarkdownParsingOptions/InterpretedSyntax/inlineOnlyPreservingWhitespace](inlineOnlyPreservingWhitespace)
+    /// parsing option.
+    ///
+    /// - Parameters:
+    ///   - key: The key for a string in the table identified by `tableName`.
+    ///   - tableName: The name of the string table to search. If `nil`, use the
+    ///     table in the `Localizable.strings` file.
+    ///   - bundle: The bundle containing the strings file. If `nil`, use the
+    ///     main bundle.
+    ///   - comment: Contextual information about this key-value pair.
     @_semantics("openswiftui.init_with_localization")
+    @_semantics("swiftui.init_with_localization")
     public init(
         _ key: LocalizedStringKey,
         tableName: String? = nil,
@@ -27,6 +98,8 @@ extension Text {
     }
 }
 
+// MARK: - LocalizedStringKey
+
 @available(OpenSwiftUI_v1_0, *)
 @frozen
 public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
@@ -35,23 +108,22 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
     private var arguments: [LocalizedStringKey.FormatArgument]
 
     public init(_ value: String) {
-        self.key = value
-        self.arguments = []
-        _openSwiftUIUnimplementedWarning()
+        self.init(stringLiteral: value)
     }
 
     @_semantics("openswiftui.localized_string_key.init_literal")
+    @_semantics("swiftui.localized_string_key.init_literal")
     public init(stringLiteral value: String) {
         self.key = value
         self.arguments = []
-        _openSwiftUIUnimplementedWarning()
     }
 
     @_semantics("openswiftui.localized_string_key.init_interpolation")
+    @_semantics("swiftui.localized_string_key.init_interpolation")
     public init(stringInterpolation: LocalizedStringKey.StringInterpolation) {
-        self.key = ""
-        self.arguments = []
-        _openSwiftUIUnimplementedWarning()
+        self.key = stringInterpolation.key
+        self.hasFormatting = true
+        self.arguments = stringInterpolation.arguments
     }
 
     package func resolve(
@@ -59,8 +131,9 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         table: String?,
         bundle: Bundle?
     ) -> String {
-        _openSwiftUIUnimplementedWarning()
-        return key
+        var resolved = Text.ResolvedString()
+        resolve(into: &resolved, in: environment, options: [], table: table, bundle: bundle)
+        return resolved.string
     }
 
     @usableFromInline
@@ -238,142 +311,142 @@ public protocol _FormatSpecifiable: Equatable {
 @available(OpenSwiftUI_v1_0, *)
 extension Int: _FormatSpecifiable {
     public var _arg: Int64 {
-        _openSwiftUIUnimplementedFailure()
+        Int64(self)
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension Int8: _FormatSpecifiable {
     public var _arg: Int32 {
-        _openSwiftUIUnimplementedFailure()
+        Int32(self)
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension Int16: _FormatSpecifiable {
     public var _arg: Int32 {
-        _openSwiftUIUnimplementedFailure()
+        Int32(self)
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension Int32: _FormatSpecifiable {
     public var _arg: Int32 {
-        _openSwiftUIUnimplementedFailure()
+        self
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension Int64: _FormatSpecifiable {
     public var _arg: Int64 {
-        _openSwiftUIUnimplementedFailure()
+        self
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension UInt: _FormatSpecifiable {
     public var _arg: UInt64 {
-        _openSwiftUIUnimplementedFailure()
+        UInt64(self)
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension UInt8: _FormatSpecifiable {
     public var _arg: UInt32 {
-        _openSwiftUIUnimplementedFailure()
+        UInt32(self)
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension UInt16: _FormatSpecifiable {
     public var _arg: UInt32 {
-        _openSwiftUIUnimplementedFailure()
+        UInt32(self)
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension UInt32: _FormatSpecifiable {
     public var _arg: UInt32 {
-        _openSwiftUIUnimplementedFailure()
+        self
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension UInt64: _FormatSpecifiable {
     public var _arg: UInt64 {
-        _openSwiftUIUnimplementedFailure()
+        self
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension Float: _FormatSpecifiable {
     public var _arg: Float {
-        _openSwiftUIUnimplementedFailure()
+        self
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension Double: _FormatSpecifiable {
     public var _arg: Double {
-        _openSwiftUIUnimplementedFailure()
+        self
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }
 
 @available(OpenSwiftUI_v1_0, *)
 extension CGFloat: _FormatSpecifiable {
     public var _arg: CGFloat {
-        _openSwiftUIUnimplementedFailure()
+        self
     }
 
     public var _specifier: String {
-        _openSwiftUIUnimplementedFailure()
+        formatSpecifier(Self.self)
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -69,10 +69,10 @@ extension Text {
     /// doesn't support line breaks, soft breaks, or any style of paragraph- or
     /// block-based formatting like lists, block quotes, code blocks, or tables.
     /// It also doesn't support the
-    /// [https://developer.apple.com/documentation/Foundation/AttributeScopes/FoundationAttributes/3796122-imageURL](imageURL)
+    /// [imageURL](https://developer.apple.com/documentation/Foundation/AttributeScopes/FoundationAttributes/3796122-imageURL)
     /// attribute. Parsing with OpenSwiftUI treats any whitespace in the Markdown
     /// string as described by the
-    /// [https://developer.apple.com/documentation/Foundation/AttributedString/MarkdownParsingOptions/InterpretedSyntax/inlineOnlyPreservingWhitespace](inlineOnlyPreservingWhitespace)
+    /// [inlineOnlyPreservingWhitespace](https://developer.apple.com/documentation/Foundation/AttributedString/MarkdownParsingOptions/InterpretedSyntax/inlineOnlyPreservingWhitespace)
     /// parsing option.
     ///
     /// - Parameters:
@@ -102,6 +102,57 @@ extension Text {
 
 // MARK: - LocalizedStringKey
 
+/// The key used to look up an entry in a strings file or strings dictionary
+/// file.
+///
+/// Initializers for several OpenSwiftUI types -- such as ``Text``,
+/// ``Toggle``, ``Picker`` and others --  implicitly look up a localized string
+/// when you provide a string literal. When you use the initializer
+/// `Text("Hello")`, OpenSwiftUI creates a `LocalizedStringKey` for you and
+/// uses that to look up a localization of the `Hello` string. This works
+/// because `LocalizedStringKey` conforms to
+/// [ExpressibleByStringLiteral](https://developer.apple.com/documentation/Swift/ExpressibleByStringLiteral).
+///
+/// Types whose initializers take a `LocalizedStringKey` usually have
+/// a corresponding initializer that accepts a parameter that conforms to
+/// [StringProtocol](https://developer.apple.com/documentation/Swift/StringProtocol).
+/// Passing a `String` variable to these initializers avoids localization,
+/// which is usually appropriate when the variable contains a user-provided
+/// value.
+///
+/// As a general rule, use a string literal argument when you want
+/// localization, and a string variable argument when you don't. In the case
+/// where you want to localize the value of a string variable, use the string to
+/// create a new `LocalizedStringKey` instance.
+///
+/// The following example shows how to create ``Text`` instances both
+/// with and without localization. The title parameter provided to the
+/// ``Section`` is a literal string, so OpenSwiftUI creates a
+/// `LocalizedStringKey` for it. However, the string entries in the
+/// `messageStore.today` array are `String` variables, so the ``Text`` views
+/// in the list use the string values verbatim.
+///
+///     List {
+///         Section(header: Text("Today")) {
+///             ForEach(messageStore.today) { message in
+///                 Text(message.title)
+///             }
+///         }
+///     }
+///
+/// If the app is localized into Japanese with the following
+/// translation of its `Localizable.strings` file:
+///
+///     "Today" = "今日";
+///
+/// When run in Japanese, the example produces a
+/// list like the following, localizing "Today" for the section header, but not
+/// the list items.
+///
+/// ![A list with a single section header displayed in Japanese.
+/// The items in the list are all in English: New for Monday, Account update,
+/// and Server
+/// maintenance.](OpenSwiftUI-LocalizedStringKey-Today-List-Japanese.png)
 @available(OpenSwiftUI_v1_0, *)
 @frozen
 public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
@@ -109,10 +160,16 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
     var hasFormatting: Bool = false
     private var arguments: [LocalizedStringKey.FormatArgument]
 
+    /// Creates a localized string key from the given string value.
+    ///
+    /// - Parameter value: The string to use as a localization key.
     public init(_ value: String) {
         self.init(stringLiteral: value)
     }
 
+    /// Creates a localized string key from the given string literal.
+    ///
+    /// - Parameter value: The string literal to use as a localization key.
     @_semantics("openswiftui.localized_string_key.init_literal")
     @_semantics("swiftui.localized_string_key.init_literal")
     public init(stringLiteral value: String) {
@@ -120,6 +177,35 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         self.arguments = []
     }
 
+    /// Creates a localized string key from the given string interpolation.
+    ///
+    /// To create a localized string key from a string interpolation, use
+    /// the `\()` string interpolation syntax. Swift matches the parameter
+    /// types in the expression to one of the `appendInterpolation` methods
+    /// in ``LocalizedStringKey/StringInterpolation``. The interpolated
+    /// types can include numeric values, Foundation types, and OpenSwiftUI
+    /// ``Text`` and ``Image`` instances.
+    ///
+    /// The following example uses a string interpolation with two arguments:
+    /// an unlabeled
+    /// [Date](https://developer.apple.com/documentation/Foundation/Date)
+    /// and a ``Text/DateStyle`` labeled `style`. The compiler maps these to the
+    /// method
+    /// ``LocalizedStringKey/StringInterpolation/appendInterpolation(_:style:)``
+    /// as it builds the string that it creates the
+    /// ``LocalizedStringKey`` with.
+    ///
+    ///     let key = LocalizedStringKey("Date is \(company.foundedDate, style: .offset)")
+    ///     let text = Text(key) // Text contains "Date is +45 years"
+    ///
+    /// You can write this example more concisely, implicitly creating a
+    /// ``LocalizedStringKey`` as the parameter to the ``Text``
+    /// initializer:
+    ///
+    ///     let text = Text("Date is \(company.foundedDate, style: .offset)")
+    ///
+    /// - Parameter stringInterpolation: The string interpolation to use as the
+    ///   localization key.
     @_semantics("openswiftui.localized_string_key.init_interpolation")
     @_semantics("swiftui.localized_string_key.init_interpolation")
     public init(stringInterpolation: LocalizedStringKey.StringInterpolation) {
@@ -531,11 +617,29 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
 
     // MARK: - LocalizedStringKey.StringInterpolation
 
+    /// Represents the contents of a string literal with interpolations
+    /// while it's being built, for use in creating a localized string key.
     public struct StringInterpolation: StringInterpolationProtocol {
         var key: String = ""
         var arguments: [FormatArgument]
         var seed: UniqueSeedGenerator = .init()
 
+        /// Creates an empty instance ready to be filled with string literal content.
+        ///
+        /// Don't call this initializer directly. Instead, initialize a variable or
+        /// constant using a string literal with interpolated expressions.
+        ///
+        /// Swift passes this initializer a pair of arguments specifying the size of
+        /// the literal segments and the number of interpolated segments. Use this
+        /// information to estimate the amount of storage you will need.
+        ///
+        /// - Parameter literalCapacity: The approximate size of all literal segments
+        ///   combined. This is meant to be passed to `String.reserveCapacity(_:)`;
+        ///   it may be slightly larger or smaller than the sum of the counts of each
+        ///   literal segment.
+        /// - Parameter interpolationCount: The number of interpolations which will be
+        ///   appended. Use this value to estimate how much additional capacity will
+        ///   be needed for the interpolated segments.
         @_semantics("openswiftui.localized.interpolation_init")
         @_semantics("swiftui.localized.interpolation_init")
         public init(literalCapacity: Int, interpolationCount: Int) {
@@ -544,12 +648,24 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             arguments.reserveCapacity(interpolationCount)
         }
 
+        /// Appends a literal string.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// - Parameter literal: The literal string to append.
         @_semantics("openswiftui.localized.appendLiteral")
         @_semantics("swiftui.localized.appendLiteral")
         public mutating func appendLiteral(_ literal: String) {
             key.append(literal.replacingOccurrences(of: "%", with: "%%"))
         }
 
+        /// Appends a literal string segment to a string interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// - Parameter string: The literal string to append.
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation(_ string: String) {
@@ -557,12 +673,51 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             arguments.append(.init(value: string))
         }
 
+        /// Appends an optionally-formatted instance of a Foundation type
+        /// to a string interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// - Parameters:
+        ///   - subject: The Foundation object to append.
+        ///   - formatter: A formatter to convert `subject` to a string
+        ///     representation.
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation<Subject>(_ subject: Subject, formatter: Formatter? = nil) where Subject: ReferenceConvertible {
             appendInterpolation(subject as! NSObject, formatter: formatter)
         }
 
+        /// Appends an optionally-formatted instance of an Objective-C subclass
+        /// to a string interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// The following example shows how to use a
+        /// [Measurement](https://developer.apple.com/documentation/Foundation/Measurement)
+        /// value and a
+        /// [MeasurementFormatter](https://developer.apple.com/documentation/Foundation/MeasurementFormatter)
+        /// to create a ``LocalizedStringKey`` that uses the formatter
+        /// style
+        /// [long](https://developer.apple.com/documentation/foundation/Formatter/UnitStyle/long)
+        /// when generating the measurement's string representation. Rather than
+        /// calling `appendInterpolation(_:formatter)` directly, the code
+        /// gets the formatting behavior implicitly by using the `\()`
+        /// string interpolation syntax.
+        ///
+        ///     let siResistance = Measurement(value: 640, unit: UnitElectricResistance.ohms)
+        ///     let formatter = MeasurementFormatter()
+        ///     formatter.unitStyle = .long
+        ///     let key = LocalizedStringKey("Resistance: \(siResistance, formatter: formatter)")
+        ///     let text1 = Text(key) // Text contains "Resistance: 640 ohms"
+        ///
+        /// - Parameters:
+        ///   - subject: An [NSObject](https://developer.apple.com/documentation/objectivec/NSObject)
+        ///     to append.
+        ///   - formatter: A formatter to convert `subject` to a string
+        ///     representation.
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation<Subject>(_ subject: Subject, formatter: Formatter? = nil) where Subject: NSObject {
@@ -571,6 +726,27 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             arguments.append(argument)
         }
 
+        /// Appends the formatted representation  of a nonstring type
+        /// supported by a corresponding format style.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// The following example shows how to use a string interpolation to
+        /// format a
+        /// [Date](https://developer.apple.com/documentation/Foundation/Date)
+        /// with a
+        /// [Date.FormatStyle](https://developer.apple.com/documentation/Foundation/Date/FormatStyle)
+        /// and append it to static text. The resulting interpolation implicitly
+        /// creates a ``LocalizedStringKey``, which a ``Text`` uses to provide
+        /// its content.
+        ///
+        ///     Text("The time is \(myDate, format: Date.FormatStyle(date: .omitted, time:.complete))")
+        ///
+        /// - Parameters:
+        ///   - input: The instance to format and append.
+        ///   - format: A format style to use when converting `input` into a string
+        ///   representation.
         @available(OpenSwiftUI_v3_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
@@ -578,6 +754,27 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             appendInterpolation(Text(input, format: format))
         }
 
+        /// Appends the formatted representation  of a nonstring type
+        /// supported by a corresponding format style.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// The following example shows how to use a string interpolation to
+        /// format a
+        /// [Date](https://developer.apple.com/documentation/Foundation/Date)
+        /// with a
+        /// [Date.FormatStyle](https://developer.apple.com/documentation/Foundation/Date/FormatStyle)
+        /// and append it to static text. The resulting interpolation implicitly
+        /// creates a ``LocalizedStringKey``, which a ``Text`` uses to provide
+        /// its content.
+        ///
+        ///     Text("The time is \(myDate, format: Date.FormatStyle(date: .omitted, time:.complete).attributedStyle)")
+        ///
+        /// - Parameters:
+        ///   - input: The instance to format and append.
+        ///   - format: A format style to use when converting `input` into an attributed
+        ///   string representation.
         @available(OpenSwiftUI_v6_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
@@ -585,11 +782,37 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             appendInterpolation(Text(input, format: format))
         }
 
+        /// Appends a type, convertible to a string by using a default format
+        /// specifier, to a string interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// - Parameters:
+        ///   - value: A primitive type to append, such as
+        ///     [Int](https://developer.apple.com/documentation/swift/Int),
+        ///     [UInt32](https://developer.apple.com/documentation/swift/UInt32), or
+        ///     [Double](https://developer.apple.com/documentation/swift/Double).
         @_transparent
         public mutating func appendInterpolation<T>(_ value: T) where T: _FormatSpecifiable {
             appendInterpolation(value, specifier: formatSpecifier(T.self))
         }
 
+        /// Appends a type, convertible to a string with a format specifier,
+        /// to a string interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// - Parameters:
+        ///   - value: The value to append.
+        ///   - specifier: A format specifier to convert `subject` to a string
+        ///     representation, like `%f` for a
+        ///     [Double](https://developer.apple.com/documentation/swift/Double), or
+        ///     `%x` to create a hexidecimal representation of a
+        ///     [UInt32](https://developer.apple.com/documentation/swift/UInt32). For a
+        ///     list of available specifier strings, see
+        ///     [String Format Specifers](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFStrings/formatSpecifiers.html#//apple_ref/doc/uid/TP40004265).
         @_semantics("openswiftui.localized.appendInterpolation_param_specifier")
         @_semantics("swiftui.localized.appendInterpolation_param_specifier")
         public mutating func appendInterpolation<T>(_ value: T, specifier: String) where T: _FormatSpecifiable {
@@ -597,6 +820,14 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             arguments.append(.init(storage: .value(value._arg, nil)))
         }
 
+        /// Appends the string displayed by a text view to a string
+        /// interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// - Parameters:
+        ///   - value: A ``Text`` instance to append.
         @available(OpenSwiftUI_v2_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
@@ -607,6 +838,55 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             arguments.append(argument)
         }
 
+        /// Appends an attributed string to a string interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// The following example shows how to use a string interpolation to
+        /// format an
+        /// [AttributedString](https://developer.apple.com/documentation/Foundation/AttributedString)
+        /// and append it to static text. The resulting interpolation implicitly
+        /// creates a ``LocalizedStringKey``, which a ``Text`` view uses to provide
+        /// its content.
+        ///
+        ///     struct ContentView: View {
+        ///
+        ///         var nextDate: AttributedString {
+        ///             var result = Calendar.current
+        ///                 .nextWeekend(startingAfter: Date.now)!
+        ///                 .start
+        ///                 .formatted(
+        ///                     .dateTime
+        ///                     .month(.wide)
+        ///                     .day()
+        ///                     .attributed
+        ///                 )
+        ///             result.backgroundColor = .green
+        ///             result.foregroundColor = .white
+        ///             return result
+        ///         }
+        ///
+        ///         var body: some View {
+        ///             Text("Our next catch-up is on \(nextDate)!")
+        ///         }
+        ///     }
+        ///
+        /// For this example, assume that the app runs on a device set to a
+        /// Russian locale, and has the following entry in a Russian-localized
+        /// `Localizable.strings` file:
+        ///
+        ///     "Our next catch-up is on %@!" = "Наша следующая встреча состоится %@!";
+        ///
+        /// The attributed string `nextDate` replaces the format specifier
+        /// `%@`,  maintaining its color and date-formatting attributes, when
+        /// the ``Text`` view renders its contents:
+        ///
+        /// ![A text view with Russian text, ending with a date that uses white
+        /// text on a green
+        /// background.](LocalizedStringKey-AttributedString-Russian)
+        ///
+        /// - Parameter attributedString: The attributed string to append.
         @available(OpenSwiftUI_v3_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
@@ -617,6 +897,13 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         }
 
         #if canImport(Darwin)
+        /// Appends the localized string resource to a string interpolation.
+        ///
+        /// Don't call this method directly; it's used by the compiler when
+        /// interpreting string interpolations.
+        ///
+        /// - Parameters:
+        ///   - value: The localized string resource to append.
         @available(OpenSwiftUI_v4_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
         @_semantics("swiftui.localized.appendInterpolation_@_specifier")
@@ -631,12 +918,6 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         public mutating func appendInterpolation<T>(_ view: T) where T: View {
             _openSwiftUIUnreachableCode()
         }
-    }
-
-    public static func == (a: LocalizedStringKey, b: LocalizedStringKey) -> Bool {
-        a.key == b.key &&
-        a.hasFormatting == b.hasFormatting &&
-        a.arguments == b.arguments
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -341,6 +341,8 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
     }
 }
 
+// MARK: - LocalizedTextStorage
+
 private final class LocalizedTextStorage: AnyTextStorage, @unchecked Sendable {
     let key: LocalizedStringKey
     let table: String?
@@ -350,6 +352,43 @@ private final class LocalizedTextStorage: AnyTextStorage, @unchecked Sendable {
         self.key = key
         self.table = table
         self.bundle = bundle
+    }
+
+    override func resolve<T>(
+        into result: inout T,
+        in environment: EnvironmentValues,
+        with options: Text.ResolveOptions
+    ) where T: ResolvedTextContainer {
+        key.resolve(into: &result, in: environment, options: options, table: table, bundle: bundle)
+    }
+
+    override func resolvesToEmpty(
+        in environment: EnvironmentValues,
+        with options: Text.ResolveOptions
+    ) -> Bool {
+        key.resolvesToEmpty(in: environment, options: options, table: table, bundle: bundle)
+    }
+
+    override func isEqual(to other: AnyTextStorage) -> Bool {
+        guard let other = other as? LocalizedTextStorage else {
+            return false
+        }
+        return key == other.key &&
+        table == other.table &&
+        bundle == other.bundle
+    }
+
+    override func isStyled(options: Text.ResolveOptions) -> Bool {
+        key.isStyled
+    }
+
+    override var localizationInfo: _LocalizationInfo {
+        .localized(
+            key: key.key,
+            tableName: table,
+            bundle: bundle,
+            hasFormatting: key.hasFormatting
+        )
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -225,42 +225,60 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         }
     }
 
+    // MARK: - LocalizedStringKey.StringInterpolation
+
     public struct StringInterpolation: StringInterpolationProtocol {
+        var key: String = ""
+        var arguments: [FormatArgument]
+        var seed: UniqueSeedGenerator = .init()
+
         @_semantics("openswiftui.localized.interpolation_init")
+        @_semantics("swiftui.localized.interpolation_init")
         public init(literalCapacity: Int, interpolationCount: Int) {
-            _openSwiftUIUnimplementedFailure()
+            key.reserveCapacity(literalCapacity + interpolationCount * 2)
+            arguments = []
+            arguments.reserveCapacity(interpolationCount)
         }
 
         @_semantics("openswiftui.localized.appendLiteral")
+        @_semantics("swiftui.localized.appendLiteral")
         public mutating func appendLiteral(_ literal: String) {
-            _openSwiftUIUnimplementedFailure()
+            key.append(literal.replacingOccurrences(of: "%", with: "%%"))
         }
 
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation(_ string: String) {
-            _openSwiftUIUnimplementedFailure()
+            key.append("%@")
+            arguments.append(.init(value: string))
         }
 
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation<Subject>(_ subject: Subject, formatter: Formatter? = nil) where Subject: ReferenceConvertible {
-            _openSwiftUIUnimplementedFailure()
+            appendInterpolation(subject as! NSObject, formatter: formatter)
         }
 
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation<Subject>(_ subject: Subject, formatter: Formatter? = nil) where Subject: NSObject {
-            _openSwiftUIUnimplementedFailure()
+            let argument = LocalizedStringKey.FormatArgument(value: subject, formatter: formatter)
+            key.append("%@")
+            arguments.append(argument)
         }
 
-//        @available(OpenSwiftUI_v2_5, *)
+        @available(OpenSwiftUI_v3_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation<F>(_ input: F.FormatInput, format: F) where F: FormatStyle, F.FormatInput: Equatable, F.FormatOutput == String {
-            _openSwiftUIUnimplementedFailure()
+            appendInterpolation(Text(input, format: format))
         }
 
         @available(OpenSwiftUI_v6_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation<F>(_ input: F.FormatInput, format: F) where F: FormatStyle, F.FormatInput: Equatable, F.FormatOutput == AttributedString {
-            _openSwiftUIUnimplementedFailure()
+            appendInterpolation(Text(input, format: format))
         }
 
         @_transparent
@@ -269,30 +287,57 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         }
 
         @_semantics("openswiftui.localized.appendInterpolation_param_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_param_specifier")
         public mutating func appendInterpolation<T>(_ value: T, specifier: String) where T: _FormatSpecifiable {
-            _openSwiftUIUnimplementedFailure()
+            key.append(specifier)
+            arguments.append(.init(storage: .value(value._arg, nil)))
         }
 
         @available(OpenSwiftUI_v2_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation(_ text: Text) {
-            _openSwiftUIUnimplementedFailure()
+            let token = LocalizedStringKey.FormatArgument.Token(id: seed.generate())
+            let argument = LocalizedStringKey.FormatArgument(storage: .text(text, token))
+            key.append("%@")
+            arguments.append(argument)
         }
 
-//        @available(OpenSwiftUI_v2_5, *)
+        @available(OpenSwiftUI_v3_0, *)
         @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
         public mutating func appendInterpolation(_ attributedString: AttributedString) {
-            _openSwiftUIUnimplementedFailure()
+            let argument = LocalizedStringKey.FormatArgument(storage: .attributedString(attributedString))
+            key.append("%@")
+            arguments.append(argument)
         }
+
+        #if canImport(Darwin)
+        @available(OpenSwiftUI_v4_0, *)
+        @_semantics("openswiftui.localized.appendInterpolation_@_specifier")
+        @_semantics("swiftui.localized.appendInterpolation_@_specifier")
+        public mutating func appendInterpolation(_ resource: LocalizedStringResource) {
+            let argument = LocalizedStringKey.FormatArgument(storage: .localizedStringResource(resource))
+            key.append("%@")
+            arguments.append(argument)
+        }
+        #endif
 
         @available(*, unavailable, message: "Unsupported type for interpolation, see LocalizedStringKey.StringInterpolation for supported types.")
         public mutating func appendInterpolation<T>(_ view: T) where T: View {
-            _openSwiftUIUnimplementedFailure()
+            _openSwiftUIUnreachableCode()
         }
     }
 
     public static func == (a: LocalizedStringKey, b: LocalizedStringKey) -> Bool {
-        _openSwiftUIUnimplementedFailure()
+        a.key == b.key &&
+        a.hasFormatting == b.hasFormatting &&
+        a.arguments == b.arguments
+    }
+
+    private func localizedFormat(table: String?, bundle: Bundle?) -> String {
+        let bundle = bundle ?? .main
+        return bundle.localizedString(forKey: key, value: nil, table: table)
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -7,6 +7,7 @@
 //  ID: 8C53218A357EE528547B0855666BD2E5 (SwiftUICore)
 
 public import Foundation
+import OpenAttributeGraphShims
 
 // MARK: - Text + LocalizedStringKey
 
@@ -103,8 +104,8 @@ extension Text {
 @available(OpenSwiftUI_v1_0, *)
 @frozen
 public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
-    internal var key: String
-    internal var hasFormatting: Bool = false
+    var key: String
+    var hasFormatting: Bool = false
     private var arguments: [LocalizedStringKey.FormatArgument]
 
     public init(_ value: String) {
@@ -136,11 +137,91 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         return resolved.string
     }
 
+    // MARK: - LocalizedStringKey.FormatArgument
+
     @usableFromInline
-    internal struct FormatArgument: Equatable {
+    struct FormatArgument: Equatable {
+        let storage: LocalizedStringKey.FormatArgument.Storage
+
+        init(value: CVarArg, formatter: Formatter? = nil) {
+            if let formatter {
+                self.storage = .value(value, formatter.copy() as? Formatter)
+            } else {
+                self.storage = .value(value, nil)
+            }
+        }
+
+        init(storage: LocalizedStringKey.FormatArgument.Storage) {
+            self.storage = storage
+        }
+
+        fileprivate func resolve(
+            in environment: EnvironmentValues,
+            idiom: AnyInterfaceIdiom?
+        ) -> (result: CVarArg, exact: Bool) {
+            let result: CVarArg
+            switch storage {
+            case let .value(value, formatter):
+                guard let formatter else {
+                    result = value
+                    break
+                }
+                (formatter as? EnvironmentConfigurableFormatter)?.configure(in: environment)
+                guard let string = formatter.string(for: value) else {
+                    Log.externalWarning("The supplied formatter \(formatter) returned `nil` when invoked with \(value). An empty string will be used instead.")
+                    result = ""
+                    break
+                }
+                result = string
+            case let .text(_, token):
+                result = "\u{FFFC}\(token.id.description)\u{FFFC}"
+            case let .attributedString(attributedString):
+                _ = environment.accessibilityEnabled
+                result = NSAttributedString(openSwiftUIAttributedString: attributedString)
+            case let .localizedStringResource(resource):
+                result = NSAttributedString(openSwiftUIAttributedString: resource.resolve(in: environment))
+            }
+            return (result, environment.textSizeVariant == .regular)
+        }
+
         @usableFromInline
         internal static func == (lhs: LocalizedStringKey.FormatArgument, rhs: LocalizedStringKey.FormatArgument) -> Bool {
-            _openSwiftUIUnimplementedFailure()
+            lhs.storage == rhs.storage
+        }
+
+        enum Storage: Equatable {
+            case value(CVarArg, Formatter?)
+            case text(Text, Token)
+            case attributedString(AttributedString)
+            #if canImport(Darwin)
+            // Only appleOS Foundation support LocalizedStringResource
+            case localizedStringResource(LocalizedStringResource)
+            #endif
+
+            static func == (lhs: Storage, rhs: Storage) -> Bool {
+                switch (lhs, rhs) {
+                case let (.value(lhsValue, lhsFormatter), .value(rhsValue, rhsFormatter)):
+                    return compareValues(lhsValue, rhsValue) && lhsFormatter == rhsFormatter
+                case let (.text(lhsText, lhsToken), .text(rhsText, rhsToken)):
+                    return lhsText == rhsText && lhsToken == rhsToken
+                case let (.attributedString(lhsString), .attributedString(rhsString)):
+                    return lhsString == rhsString
+                #if canImport(Darwin)
+                case let (.localizedStringResource(lhsResource), .localizedStringResource(rhsResource)):
+                    return lhsResource == rhsResource
+                #endif
+                default:
+                    return false
+                }
+            }
+        }
+
+        struct Token: Equatable, Hashable, Identifiable {
+            let id: Int
+
+            init(id: Int) {
+                self.id = id
+            }
         }
     }
 

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -270,6 +270,32 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         }
         return (resolvedArguments, isUniqueSizeVariant)
     }
+
+    func resolvesToEmpty(
+        in environment: EnvironmentValues,
+        options: Text.ResolveOptions,
+        table: String?,
+        bundle: Bundle?
+    ) -> Bool {
+        let bundle = bundle ?? .main
+        #if canImport(Darwin)
+        let localizedString = _LocalizeString(bundle, key, table, environment.locale)
+        #else
+        let localizedString = bundle.localizedString(forKey: key, value: nil, table: table)
+        #endif
+        guard hasFormatting else {
+            return localizedString.isEmpty
+        }
+        let resolvedArguments = arguments.map { argument -> CVarArg in
+            argument.resolve(in: environment, idiom: _GraphInputs.defaultInterfaceIdiom).result
+        }
+        let format = String(
+            format: localizedString,
+            locale: environment.locale,
+            arguments: resolvedArguments
+        )
+        return format.isEmpty
+    }
     // MARK: - LocalizedStringKey.FormatArgument
 
     @usableFromInline

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -3,7 +3,7 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: Complete
+//  Status: Complete (Blocked by AttributedStringTextStorage)
 //  ID: 8C53218A357EE528547B0855666BD2E5 (SwiftUICore)
 
 public import Foundation
@@ -296,6 +296,143 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         )
         return format.isEmpty
     }
+
+    func resolveArguments<T>(
+        from format: NSAttributedString,
+        into result: inout T,
+        in environment: EnvironmentValues,
+        options: Text.ResolveOptions,
+        isUniqueSizeVariant: Bool
+    ) where T: ResolvedTextContainer {
+        let textArgs = getTextArguments()
+        guard !textArgs.isEmpty else {
+            result.append(
+                format,
+                in: environment,
+                with: options,
+                isUniqueSizeVariant: isUniqueSizeVariant
+            )
+            return
+        }
+        let string = format.string
+        scan(
+            string: string,
+            in: environment,
+            options: options,
+            textArgs: textArgs
+        ) { _, range in
+            result.append(
+                format.attributedSubstring(from: NSRange(range, in: string)),
+                in: environment,
+                with: options,
+                isUniqueSizeVariant: isUniqueSizeVariant
+            )
+        } appendText: { text, _, environment in
+            text.resolve(into: &result, in: environment, with: options)
+        }
+    }
+
+    func resolveArguments<T>(
+        from format: String,
+        into result: inout T,
+        in environment: EnvironmentValues,
+        options: Text.ResolveOptions,
+        isUniqueSizeVariant: Bool
+    ) where T: ResolvedTextContainer {
+        let textArgs = getTextArguments()
+        guard !textArgs.isEmpty else {
+            result.append(
+                format,
+                in: environment,
+                with: options,
+                isUniqueSizeVariant: isUniqueSizeVariant
+            )
+            return
+        }
+        scan(
+            string: format,
+            in: environment,
+            options: options,
+            textArgs: textArgs
+        ) { string, range in
+            result.append(
+                string[range],
+                in: environment,
+                with: options,
+                isUniqueSizeVariant: isUniqueSizeVariant
+            )
+        } appendText: { text, _, environment in
+            text.resolve(into: &result, in: environment, with: options)
+        }
+
+    }
+
+    private func getTextArguments() -> [(Int, LocalizedStringKey.FormatArgument)] {
+        arguments.filter { argument in
+            guard case .text = argument.storage else {
+                return false
+            }
+            return true
+        }.map { argument in
+            guard case let .text(_, token) = argument.storage else {
+                _openSwiftUIUnreachableCode()
+            }
+            return (token.id, argument)
+        }
+    }
+
+    private func scan(
+        string: String,
+        in environment: EnvironmentValues,
+        options: Text.ResolveOptions,
+        textArgs: [(Int, LocalizedStringKey.FormatArgument)],
+        appendLiteral: (String, Range<String.Index>) -> Void,
+        appendText: (Text, Range<String.Index>, EnvironmentValues) -> Void
+    ) {
+        let argumentMap = Dictionary(uniqueKeysWithValues: textArgs)
+        let scanner = Scanner(string: string)
+        scanner.charactersToBeSkipped = nil
+        let replacement = CharacterSet(charactersIn: String(FormatArgument.Token.delimiter))
+        repeat {
+            let literalStart = scanner.currentIndex
+            if scanner.scanUpToCharacters(from: replacement) != nil {
+                appendLiteral(string, literalStart..<scanner.currentIndex)
+            }
+            let tokenStart = scanner.currentIndex
+            guard scanner.scanCharacter() == FormatArgument.Token.delimiter,
+                  let tokenID = scanner.scanInt(representation: .decimal),
+                  scanner.scanCharacter() == FormatArgument.Token.delimiter else {
+                continue
+            }
+            guard let argument = argumentMap[tokenID],
+                  case let .text(text, _) = argument.storage else {
+                Log.internalWarning("Text interpolation look up miss.\n    source: \(string)\n    id: \(tokenID)")
+                continue
+            }
+            let tokenEnd = scanner.currentIndex
+            let tokenRange = tokenStart..<tokenEnd
+            #if canImport(Darwin)
+            var textEnvironment = environment
+            if string[tokenRange].count != string.count {
+                let locale = environment.locale
+                let capitalizationContext = environment.capitalizationContext
+                if tokenStart == string.startIndex {
+                    textEnvironment.capitalizationContext = .lazy {
+                        .middleOfSentence == capitalizationContext.resolved ? .middleOfSentence : .beginningOfSentence
+                    }
+                } else {
+                    textEnvironment.capitalizationContext = .lazy {
+                        _isBeginningOfSentence(string, String(string[tokenRange]), locale) ? .beginningOfSentence : .middleOfSentence
+                    }
+                }
+            }
+            appendText(text, tokenRange, textEnvironment)
+            #else
+            appendText(text, tokenRange, environment)
+            #endif
+        } while !scanner.isAtEnd
+    }
+
     // MARK: - LocalizedStringKey.FormatArgument
 
     @usableFromInline
@@ -500,11 +637,6 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         a.key == b.key &&
         a.hasFormatting == b.hasFormatting &&
         a.arguments == b.arguments
-    }
-
-    private func localizedFormat(table: String?, bundle: Bundle?) -> String {
-        let bundle = bundle ?? .main
-        return bundle.localizedString(forKey: key, value: nil, table: table)
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -178,6 +178,23 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         return resolved.string
     }
 
+
+    func getArgumentsForInflection(
+        for attributedString: NSAttributedString,
+        in environment: EnvironmentValues,
+        idiom: AnyInterfaceIdiom?,
+        with options: Text.ResolveOptions,
+        including style: Text.Style
+    ) -> (arguments: [CVarArg], isUniqueSizeVariant: Bool) {
+        var isUniqueSizeVariant = environment.textSizeVariant == .regular
+        let resolvedArguments = arguments.map { argument -> CVarArg in
+            // TODO: AttributedStringTextStorage
+            let resolved = argument.resolve(in: environment, idiom: idiom)
+            isUniqueSizeVariant = isUniqueSizeVariant || resolved.exact
+            return resolved.result
+        }
+        return (resolvedArguments, isUniqueSizeVariant)
+    }
     // MARK: - LocalizedStringKey.FormatArgument
 
     @usableFromInline
@@ -226,7 +243,7 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         }
 
         @usableFromInline
-        internal static func == (lhs: LocalizedStringKey.FormatArgument, rhs: LocalizedStringKey.FormatArgument) -> Bool {
+        static func == (lhs: LocalizedStringKey.FormatArgument, rhs: LocalizedStringKey.FormatArgument) -> Bool {
             lhs.storage == rhs.storage
         }
 

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -127,6 +127,47 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         self.arguments = stringInterpolation.arguments
     }
 
+    var isStyled: Bool {
+        for argument in arguments {
+            switch argument.storage {
+            case .value:
+                continue
+            case let .text(text, _):
+                if text.isStyled() {
+                    return true
+                }
+            case let .attributedString(attributedString):
+                if attributedString.isStyled {
+                    return true
+                }
+            #if canImport(Darwin)
+            case let .localizedStringResource(resource):
+                if resource.resolve(in: .init()).isStyled {
+                    return true
+                }
+            #endif
+            }
+        }
+        let options = AttributedString.MarkdownParsingOptions(
+            allowsExtendedAttributes: false,
+            interpretedSyntax: .inlineOnlyPreservingWhitespace,
+            failurePolicy: .throwError
+        )
+        guard let attributedString = try? AttributedString(
+            markdown: key,
+            options: options,
+            baseURL: nil
+        ) else {
+            return false
+        }
+        return attributedString.runs[
+            AttributeScopes.FoundationAttributes.InlinePresentationIntentAttribute.self,
+            AttributeScopes.FoundationAttributes.LinkAttribute.self
+        ].contains { inlinePresentationIntent, link, _ in
+            inlinePresentationIntent != nil || link != nil
+        }
+    }
+
     package func resolve(
         in environment: EnvironmentValues,
         table: String?,
@@ -400,6 +441,17 @@ extension LocalizedStringKey: Sendable {}
 
 @available(*, unavailable)
 extension LocalizedStringKey.FormatArgument: Sendable {}
+
+#if canImport(Darwin)
+extension LocalizedStringResource {
+    // FIXME
+    func resolve(in environment: EnvironmentValues) -> AttributedString {
+        var resource = self
+        resource.locale = environment.locale
+        return AttributedString(localized: resource)
+    }
+}
+#endif
 
 @_alwaysEmitIntoClient
 internal var int64Specifier: String {

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -8,6 +8,7 @@
 
 public import Foundation
 import OpenAttributeGraphShims
+import OpenSwiftUI_SPI
 
 // MARK: - Text + LocalizedStringKey
 
@@ -178,6 +179,80 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         return resolved.string
     }
 
+    func resolve<T>(
+        into result: inout T,
+        in environment: EnvironmentValues,
+        options: Text.ResolveOptions,
+        table: String?,
+        bundle: Bundle?
+    ) where T: ResolvedTextContainer {
+        if Semantics.MarkdownSupportForLocalizedStringKey.isEnabled {
+            let bundle = bundle ?? .main
+            #if canImport(Darwin)
+            let format = _LocalizeAttributedString(bundle, key, table, environment.locale)
+            #else
+            let localizedString = bundle.localizedString(forKey: key, value: nil, table: table)
+            let format = NSAttributedString(
+                string: localizedString
+            )
+            #endif
+            guard hasFormatting else {
+                result.append(format, in: environment, with: options)
+                return
+            }
+            let inflectionArguments = getArgumentsForInflection(
+                for: format,
+                in: environment,
+                idiom: result.idiom,
+                with: options,
+                including: result.style
+            )
+            let formattedFormat = withVaList(inflectionArguments.arguments) { arguments in
+                NSAttributedString(
+                    openSwiftUIAttributedStringWithFormat: format,
+                    options: [],
+                    locale: environment.locale,
+                    arguments: arguments
+                )
+            }
+            resolveArguments(
+                from: formattedFormat,
+                into: &result,
+                in: environment,
+                options: options,
+                isUniqueSizeVariant: inflectionArguments.isUniqueSizeVariant
+            )
+        } else {
+            let bundle = bundle ?? .main
+            #if canImport(Darwin)
+            let localizedString = _LocalizeString(bundle, key, table, environment.locale)
+            #else
+            let localizedString = bundle.localizedString(forKey: key, value: nil, table: table)
+            #endif
+            guard hasFormatting else {
+                result.append(localizedString, in: environment, with: options)
+                return
+            }
+            var isUniqueSizeVariant = environment.textSizeVariant == .regular
+            let resolvedArguments = arguments.map { argument -> CVarArg in
+                let resolved = argument.resolve(in: environment, idiom: result.idiom)
+                isUniqueSizeVariant = isUniqueSizeVariant || resolved.exact
+                return resolved.result
+            }
+            let format = String(
+                format: localizedString,
+                locale: environment.locale,
+                arguments: resolvedArguments
+            )
+            resolveArguments(
+                from: format,
+                into: &result,
+                in: environment,
+                options: options,
+                isUniqueSizeVariant: isUniqueSizeVariant
+            )
+        }
+    }
 
     func getArgumentsForInflection(
         for attributedString: NSAttributedString,

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Localized.swift
@@ -235,6 +235,7 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             #endif
             }
         }
+        #if canImport(Darwin)
         let options = AttributedString.MarkdownParsingOptions(
             allowsExtendedAttributes: false,
             interpretedSyntax: .inlineOnlyPreservingWhitespace,
@@ -253,6 +254,9 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         ].contains { inlinePresentationIntent, link, _ in
             inlinePresentationIntent != nil || link != nil
         }
+        #else
+        return false
+        #endif
     }
 
     package func resolve(
@@ -272,16 +276,10 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         table: String?,
         bundle: Bundle?
     ) where T: ResolvedTextContainer {
+        #if canImport(Darwin)
         if Semantics.MarkdownSupportForLocalizedStringKey.isEnabled {
             let bundle = bundle ?? .main
-            #if canImport(Darwin)
             let format = _LocalizeAttributedString(bundle, key, table, environment.locale)
-            #else
-            let localizedString = bundle.localizedString(forKey: key, value: nil, table: table)
-            let format = NSAttributedString(
-                string: localizedString
-            )
-            #endif
             guard hasFormatting else {
                 result.append(format, in: environment, with: options)
                 return
@@ -310,11 +308,7 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             )
         } else {
             let bundle = bundle ?? .main
-            #if canImport(Darwin)
             let localizedString = _LocalizeString(bundle, key, table, environment.locale)
-            #else
-            let localizedString = bundle.localizedString(forKey: key, value: nil, table: table)
-            #endif
             guard hasFormatting else {
                 result.append(localizedString, in: environment, with: options)
                 return
@@ -338,6 +332,32 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
                 isUniqueSizeVariant: isUniqueSizeVariant
             )
         }
+        #else
+        let bundle = bundle ?? .main
+        let localizedString = _LocalizeString(bundle, key, table, environment.locale)
+        guard hasFormatting else {
+            result.append(localizedString, in: environment, with: options)
+            return
+        }
+        var isUniqueSizeVariant = environment.textSizeVariant == .regular
+        let resolvedArguments = arguments.map { argument -> CVarArg in
+            let resolved = argument.resolve(in: environment, idiom: result.idiom)
+            isUniqueSizeVariant = isUniqueSizeVariant || resolved.exact
+            return resolved.result
+        }
+        let format = String(
+            format: localizedString,
+            locale: environment.locale,
+            arguments: resolvedArguments
+        )
+        resolveArguments(
+            from: format,
+            into: &result,
+            in: environment,
+            options: options,
+            isUniqueSizeVariant: isUniqueSizeVariant
+        )
+        #endif
     }
 
     func getArgumentsForInflection(
@@ -364,11 +384,7 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
         bundle: Bundle?
     ) -> Bool {
         let bundle = bundle ?? .main
-        #if canImport(Darwin)
         let localizedString = _LocalizeString(bundle, key, table, environment.locale)
-        #else
-        let localizedString = bundle.localizedString(forKey: key, value: nil, table: table)
-        #endif
         guard hasFormatting else {
             return localizedString.isEmpty
         }
@@ -560,8 +576,10 @@ public struct LocalizedStringKey: Equatable, ExpressibleByStringInterpolation {
             case let .attributedString(attributedString):
                 _ = environment.accessibilityEnabled
                 result = NSAttributedString(openSwiftUIAttributedString: attributedString)
+            #if canImport(Darwin)
             case let .localizedStringResource(resource):
                 result = NSAttributedString(openSwiftUIAttributedString: resource.resolve(in: environment))
+            #endif
             }
             return (result, environment.textSizeVariant == .regular)
         }
@@ -1206,3 +1224,23 @@ extension CGFloat: _FormatSpecifiable {
         formatSpecifier(Self.self)
     }
 }
+
+// Non-Darwin compatibility layer
+#if !canImport(Darwin)
+package func _LocalizeString(_ bundle: Bundle, _ key: String, _ table: String?, _ locale: Locale?) -> String {
+    bundle.localizedString(forKey: key, value: nil, table: table)
+}
+
+package func _LocalizeAttributedString(_ bundle: Bundle, _ key: String, _ table: String?, _ locale: Locale?) -> NSAttributedString {
+    NSAttributedString(string: bundle.localizedString(forKey: key, value: nil, table: table))
+}
+
+// Linux Foundation does not provide libswiftObjectiveC's NSObject CVarArg conformance yet.
+// Traced on swift-corelibs-foundation#5487
+extension NSObject: @retroactive CVarArg {
+    public var _cVarArgEncoding: [Int] {
+        _encodeBitsAsWords(self)
+    }
+}
+
+#endif

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text.swift
@@ -414,7 +414,12 @@ extension _LocalizationInfo: Sendable {}
 @available(OpenSwiftUI_v2_0, *)
 extension Text {
     public var _localizationInfo: _LocalizationInfo {
-        _openSwiftUIUnimplementedFailure()
+        switch storage {
+        case let .verbatim(string):
+            .verbatim(string)
+        case let .anyTextStorage(storage):
+            storage.localizationInfo
+        }
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Util/String+Extension.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/String+Extension.swift
@@ -9,7 +9,7 @@ package import Foundation
 
 extension String {
     package static var nsAttachment: String {
-        String("￼")
+        "\u{FFFC}"
     }
 
     package init(_ attributedString: AttributedString) {
@@ -19,7 +19,7 @@ extension String {
 
 extension Character {
     package static var nsAttachment: Character {
-        Character("￼")
+        Character(.nsAttachment)
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Util/String+Extension.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/String+Extension.swift
@@ -37,6 +37,10 @@ extension AttributedString {
 }
 
 extension NSAttributedString {
+    convenience package init(openSwiftUIAttributedString attributedString: AttributedString) {
+        _openSwiftUIUnimplementedFailure()
+    }
+
     package var isDynamic: Bool {
         guard length >= 1 else { return false }
         let value = attribute(

--- a/Sources/OpenSwiftUI_SPI/Overlay/Foundation/Localization.h
+++ b/Sources/OpenSwiftUI_SPI/Overlay/Foundation/Localization.h
@@ -1,0 +1,29 @@
+//
+//  Localization.h
+//  OpenSwiftUI_SPI
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+#pragma once
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#import <Foundation/Foundation.h>
+
+OPENSWIFTUI_ASSUME_NONNULL_BEGIN
+
+OPENSWIFTUI_EXPORT
+NSString *_LocalizeString(NSBundle *bundle, NSString *key, NSString * _Nullable table, NSLocale * _Nullable locale);
+
+OPENSWIFTUI_EXPORT
+NSAttributedString *_LocalizeAttributedString(NSBundle *bundle, NSString *key, NSString * _Nullable table, NSLocale * _Nullable locale);
+
+OPENSWIFTUI_EXPORT
+BOOL _isBeginningOfSentence(NSString *string, NSString *substring, NSLocale * _Nullable locale);
+
+OPENSWIFTUI_ASSUME_NONNULL_END
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN */

--- a/Sources/OpenSwiftUI_SPI/Overlay/Foundation/Localization.m
+++ b/Sources/OpenSwiftUI_SPI/Overlay/Foundation/Localization.m
@@ -1,0 +1,111 @@
+//
+//  Localization.m
+//  OpenSwiftUI_SPI
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+#include "Localization.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <os/lock.h>
+
+@interface NSBundle (OpenSwiftUILocalizationPrivate)
+- (NSString *)localizedStringForKey:(NSString *)key value:(NSString *)value table:(NSString *)table localization:(NSString *)localization;
+- (NSAttributedString *)localizedAttributedStringForKey:(NSString *)key value:(NSString *)value table:(NSString *)table;
+- (NSAttributedString *)localizedAttributedStringForKey:(NSString *)key value:(NSString *)value table:(NSString *)table localization:(NSString *)localization;
+@end
+
+static NSString * _Nullable _getBestLocalization(NSBundle *bundle, NSLocale * _Nullable locale) {
+    static NSMapTable<NSBundle *, NSMutableDictionary<NSString *, NSString *> *> *cache;
+    static os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
+
+    if (locale == nil) {
+        return nil;
+    }
+    if ([locale isEqual:NSLocale.currentLocale] || locale.languageIdentifier == nil) {
+        return nil;
+    }
+
+    os_unfair_lock_lock(&lock);
+    if (cache == nil) {
+        cache = NSMapTable.weakToStrongObjectsMapTable;
+    }
+    NSMutableDictionary<NSString *, NSString *> *bundleCache = [cache objectForKey:bundle];
+    NSString *localeIdentifier = locale.localeIdentifier;
+    NSString *bestLocalization = [bundleCache objectForKey:localeIdentifier];
+    os_unfair_lock_unlock(&lock);
+
+    if (bestLocalization != nil) {
+        return bestLocalization;
+    }
+
+    NSArray<NSString *> *localizations = bundle.localizations;
+    NSString *languageIdentifier = locale.languageIdentifier;
+    NSArray<NSString *> *preferences = [NSArray arrayWithObjects:&languageIdentifier count:1];
+    NSArray<NSString *> *preferredLocalizations = [NSBundle preferredLocalizationsFromArray:localizations forPreferences:preferences];
+    bestLocalization = preferredLocalizations.firstObject;
+
+    os_unfair_lock_lock(&lock);
+    if (bundleCache == nil) {
+        bundleCache = [NSMutableDictionary new];
+        [cache setObject:bundleCache forKey:bundle];
+    }
+    bundleCache[locale.localeIdentifier] = bestLocalization;
+    os_unfair_lock_unlock(&lock);
+
+    return bestLocalization;
+}
+
+NSString *_LocalizeString(NSBundle *bundle, NSString *key, NSString * _Nullable table, NSLocale * _Nullable locale) {
+    NSString *localization = _getBestLocalization(bundle, locale);
+    if (localization != nil) {
+        return [bundle localizedStringForKey:key value:nil table:table localization:localization];
+    } else {
+        return [bundle localizedStringForKey:key value:nil table:table];
+    }
+}
+
+NSAttributedString *_LocalizeAttributedString(NSBundle *bundle, NSString *key, NSString * _Nullable table, NSLocale * _Nullable locale) {
+    NSString *localization = _getBestLocalization(bundle, locale);
+    if (localization != nil) {
+        return [bundle localizedAttributedStringForKey:key value:nil table:table localization:localization];
+    } else {
+        return [bundle localizedAttributedStringForKey:key value:nil table:table];
+    }
+}
+
+BOOL _isBeginningOfSentence(NSString * __unsafe_unretained string, NSString * __unsafe_unretained substring, NSLocale * __unsafe_unretained _Nullable locale) {
+    CFStringRef source = (__bridge CFStringRef)string;
+    CFStringRef searchString = (__bridge CFStringRef)substring;
+    CFLocaleRef tokenizerLocale = (__bridge CFLocaleRef)locale;
+    CFMutableStringRef uppercaseMutableString = CFStringCreateMutableCopy(NULL, 0, source);
+    CFStringUppercase(uppercaseMutableString, NULL);
+    CFStringRef uppercaseString = CFStringCreateCopy(NULL, uppercaseMutableString);
+    CFRelease(uppercaseMutableString);
+    CFStringTokenizerRef tokenizer = CFStringTokenizerCreate(kCFAllocatorDefault,
+                                                             uppercaseString,
+                                                             CFRangeMake(0, CFStringGetLength(uppercaseString)),
+                                                             kCFStringTokenizerUnitSentence,
+                                                             tokenizerLocale);
+    while (CFStringTokenizerAdvanceToNextToken(tokenizer) != kCFStringTokenizerTokenNone) {
+        CFRange tokenRange = CFStringTokenizerGetCurrentTokenRange(tokenizer);
+        CFStringRef token = CFStringCreateWithSubstring(NULL, uppercaseString, tokenRange);
+        CFRange matchRange = CFStringFind(token, searchString, 0);
+        if (matchRange.location != kCFNotFound) {
+            BOOL result = matchRange.location == 0;
+            CFRelease(token);
+            CFRelease(uppercaseString);
+            CFRelease(tokenizer);
+            return result;
+        }
+        CFRelease(token);
+    }
+    CFRelease(uppercaseString);
+    CFRelease(tokenizer);
+    return NO;
+}
+
+#endif /* OPENSWIFTUI_TARGET_OS_DARWIN */

--- a/Sources/OpenSwiftUI_SPI/Overlay/QuartzCore/CANullAction.h
+++ b/Sources/OpenSwiftUI_SPI/Overlay/QuartzCore/CANullAction.h
@@ -2,6 +2,7 @@
 //  CANullAction.h
 //  OpenSwiftUI_SPI
 //
+//  Audited for 6.5.4
 //  Status: Complete
 
 #ifndef CANullAction_h

--- a/Sources/OpenSwiftUI_SPI/Overlay/QuartzCore/CANullAction.m
+++ b/Sources/OpenSwiftUI_SPI/Overlay/QuartzCore/CANullAction.m
@@ -2,6 +2,7 @@
 //  CANullAction.m
 //  OpenSwiftUI_SPI
 //
+//  Audited for 6.5.4
 //  Status: Complete
 
 #import "CANullAction.h"

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAttributedString.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAttributedString.h
@@ -32,6 +32,7 @@ typedef OPENSWIFTUI_OPTIONS(NSInteger, NSUnderlineStyle) {
 OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 
 @interface NSAttributedString (OpenSwiftUI_SPI)
+- (instancetype)initOpenSwiftUIAttributedStringWithFormat:(NSAttributedString *)format options:(NSAttributedStringFormattingOptions)options locale:(NSLocale * _Nullable)locale arguments:(va_list)arguments;
 - (NSAttributedString *)_ui_attributedSubstringFromRange_openswiftui_safe_wrapper:(NSRange)range scaledByScaleFactor:(CGFloat)factor OPENSWIFTUI_SWIFT_NAME(_ui_attributedSubstring(from:scaledBy:));
 @end
 

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAttributedString.m
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAttributedString.m
@@ -14,6 +14,13 @@ OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 
 @implementation NSAttributedString (OpenSwiftUI_SPI)
 
+- (instancetype)initOpenSwiftUIAttributedStringWithFormat:(NSAttributedString *)format
+                                                  options:(NSAttributedStringFormattingOptions)options
+                                                   locale:(NSLocale * _Nullable)locale
+                                                arguments:(va_list)arguments {
+    return [self initWithFormat:format options:options locale:locale arguments:arguments];
+}
+
 - (NSAttributedString *)_ui_attributedSubstringFromRange_openswiftui_safe_wrapper:(NSRange)range scaledByScaleFactor:(CGFloat)factor {
     OPENSWIFTUI_SAFE_WRAPPER_IMP(NSAttributedString *, @"_ui_attributedSubstringFromRange:scaledByScaleFactor", nil, NSRange, CGFloat);
     return func(self, selector, range, factor);
@@ -33,4 +40,3 @@ OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 OPENSWIFTUI_ASSUME_NONNULL_END
 
 #endif
-

--- a/Tests/OpenSwiftUI_SPITests/Overlay/Foundation/LocalizationTests.swift
+++ b/Tests/OpenSwiftUI_SPITests/Overlay/Foundation/LocalizationTests.swift
@@ -1,0 +1,22 @@
+//
+//  LocalizationTests.swift
+//  OpenSwiftUI_SPITests
+//
+
+#if canImport(Darwin)
+import Foundation
+import OpenSwiftUI_SPI
+import Testing
+
+struct LocalizationTests {
+    @Test
+    func isBeginningOfSentence() {
+        let string = "Hello world. Second sentence."
+        let locale = Locale(identifier: "en_US")
+        #expect(_isBeginningOfSentence(string, "HELLO", locale) == true)
+        #expect(_isBeginningOfSentence(string, "WORLD", locale) == false)
+        #expect(_isBeginningOfSentence(string, "SECOND", locale) == true)
+        #expect(_isBeginningOfSentence(string, "MISSING", locale) == false)
+    }
+}
+#endif


### PR DESCRIPTION
## Agent Summary

- Add localized `Text` storage backed by `LocalizedStringKey`.
- Support bundle, table, and locale-aware lookup for localized strings and attributed strings.
- Resolve localized string interpolation for primitive values, Foundation formatters, format styles, `Text`, `AttributedString`, and localized string resources.
- Preserve sentence-boundary capitalization behavior for interpolated text.
- Add SPI coverage for sentence-boundary localization behavior.
- Document the public localized text APIs.