### PR TITLE
Implement tint adjustment mode support

### DIFF
--- a/Sources/OpenSwiftUICore/Graphic/Color/AccentColor.swift
+++ b/Sources/OpenSwiftUICore/Graphic/Color/AccentColor.swift
@@ -203,25 +203,3 @@ package protocol SystemAccentValueProvider {
     static func accentColorName(value: SystemAccentValue) -> CoreUISystemCatalogColorName
     #endif
 }
-
-// FIXME: TintAdjustmentMode
-package extension EnvironmentValues {
-    var effectiveTintAdjustmentMode: TintAdjustmentMode {
-        .normal
-    }
-}
-
-package enum TintAdjustmentMode {
-    case normal
-    case desaturated
-}
-
-extension Color {
-    package func tintAdjustmentMode(_ mode: TintAdjustmentMode) -> Color {
-        self
-    }
-
-    package var tintAdjusted: Color {
-        self
-    }
-}

--- a/Sources/OpenSwiftUICore/Graphic/Color/ControlTintedColor.swift
+++ b/Sources/OpenSwiftUICore/Graphic/Color/ControlTintedColor.swift
@@ -1,0 +1,81 @@
+//
+//  ControlTintedColor.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+//  ID: EC06E65D3EE8D18E3FBCB8910A79AF01 (SwiftUICore)
+
+// MARK: - Color + TintAdjustment
+
+extension Color {
+    package func tintAdjustmentMode(_ mode: TintAdjustmentMode) -> Color {
+        switch mode {
+        case .normal:
+            self
+        case .desaturated:
+            Color(provider: DesaturatedColor(base: self))
+        }
+    }
+
+    package var tintAdjusted: Color {
+        Color(provider: TintAdjustmentProvider(base: self))
+    }
+
+    private struct TintAdjustmentProvider: ColorProvider {
+        var base: Color
+
+        func resolve(in environment: EnvironmentValues) -> Color.Resolved {
+            base.tintAdjustmentMode(environment.effectiveTintAdjustmentMode)
+                .resolve(in: environment)
+        }
+    }
+
+    private struct DesaturatedColor: ColorProvider, CustomStringConvertible {
+        var base: Color
+
+        func resolve(in environment: EnvironmentValues) -> Color.Resolved {
+            let resolved = base.resolve(in: environment)
+            return Color.Resolved(
+                linearWhite: resolved.linearWhite,
+                opacity: resolved.opacity * 0.8
+            )
+        }
+
+        var description: String {
+            "Desaturated(\(base))"
+        }
+    }
+}
+
+// MARK: - View + TintAdjustmentMode
+
+extension View {
+    package func tintAdjustmentMode(_ tintAdjustmentMode: TintAdjustmentMode?) -> some View {
+        environment(\.tintAdjustmentMode, tintAdjustmentMode)
+    }
+}
+
+// MARK: - EnvironmentValues + TintAdjustmentMode
+
+extension EnvironmentValues {
+    package var tintAdjustmentMode: TintAdjustmentMode? {
+        get { self[TintAdjustmentModeKey.self] }
+        set { self[TintAdjustmentModeKey.self] = newValue }
+    }
+
+    package var effectiveTintAdjustmentMode: TintAdjustmentMode {
+        tintAdjustmentMode ?? (isEnabled ? .normal : .desaturated)
+    }
+}
+
+private struct TintAdjustmentModeKey: EnvironmentKey {
+    static var defaultValue: TintAdjustmentMode? { nil }
+}
+
+// MARK: - TintAdjustmentMode
+
+package enum TintAdjustmentMode: Equatable, Hashable {
+    case normal
+    case desaturated
+}

--- a/Tests/OpenSwiftUICoreTests/Graphics/Color/ControlTintedColorTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Graphics/Color/ControlTintedColorTests.swift
@@ -1,0 +1,64 @@
+//
+//  ControlTintedColorTests.swift
+//  OpenSwiftUICoreTests
+
+@testable import OpenSwiftUICore
+import Testing
+
+struct ControlTintedColorTests {
+    @Test
+    func effectiveTintAdjustmentModeUsesExplicitValueThenEnabledFallback() {
+        var environment = EnvironmentValues()
+
+        #expect(environment.tintAdjustmentMode == nil)
+        #expect(environment.effectiveTintAdjustmentMode == .normal)
+
+        environment.isEnabled = false
+        #expect(environment.effectiveTintAdjustmentMode == .desaturated)
+
+        environment.tintAdjustmentMode = .normal
+        #expect(environment.effectiveTintAdjustmentMode == .normal)
+
+        environment.tintAdjustmentMode = .desaturated
+        environment.isEnabled = true
+        #expect(environment.effectiveTintAdjustmentMode == .desaturated)
+    }
+
+    @Test
+    func tintAdjustmentModeDesaturatesResolvedColor() {
+        let base = Color(Color.Resolved(
+            linearRed: 0.25,
+            linearGreen: 0.5,
+            linearBlue: 0.75,
+            opacity: 0.6
+        ))
+        let resolved = base.tintAdjustmentMode(.desaturated).resolve(in: .init())
+        let expectedLuminance = base.resolve(in: .init()).linearWhite
+
+        #expect(resolved.linearRed.isApproximatelyEqual(to: expectedLuminance))
+        #expect(resolved.linearGreen.isApproximatelyEqual(to: expectedLuminance))
+        #expect(resolved.linearBlue.isApproximatelyEqual(to: expectedLuminance))
+        #expect(resolved.opacity.isApproximatelyEqual(to: 0.48))
+    }
+
+    @Test
+    func tintAdjustedUsesEffectiveEnvironmentMode() {
+        let base = Color(Color.Resolved(
+            linearRed: 1.0,
+            linearGreen: 0.0,
+            linearBlue: 0.0,
+            opacity: 0.5
+        ))
+
+        #expect(base.tintAdjusted.resolve(in: .init()) == base.resolve(in: .init()))
+
+        var disabledEnvironment = EnvironmentValues()
+        disabledEnvironment.isEnabled = false
+        let resolved = base.tintAdjusted.resolve(in: disabledEnvironment)
+
+        #expect(resolved.linearRed.isApproximatelyEqual(to: 0.2126))
+        #expect(resolved.linearGreen.isApproximatelyEqual(to: 0.2126))
+        #expect(resolved.linearBlue.isApproximatelyEqual(to: 0.2126))
+        #expect(resolved.opacity.isApproximatelyEqual(to: 0.4))
+    }
+}


### PR DESCRIPTION
## Summary
- Add tint adjustment support for `Color`, `View`, `EnvironmentValues`, and `TintAdjustmentMode`.
- Implement desaturated tint resolution using linear luminance with reduced opacity.
- Move tint adjustment implementation and coverage into the Graphics/Color area.

## Testing
- `swift build --target OpenSwiftUICoreTests`