### PR TITLE
Add stdout renderer support

### DIFF
--- a/.github/workflows/stdout_renderer.yml
+++ b/.github/workflows/stdout_renderer.yml
@@ -1,0 +1,54 @@
+name: Stdout Renderer
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  stdout_renderer_linux:
+    name: Run stdout renderer on Linux
+    runs-on: ubuntu-22.04
+    container: swift:6.1.0-jammy
+    env:
+      OPENSWIFTUI_WERROR: 0
+      OPENSWIFTUI_SWIFT_LOG: 1
+      OPENSWIFTUI_SWIFT_CRYPTO: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Toolchain fix patch
+        run: |
+          # Fix swift-corelibs-foundation#5211
+          .github/scripts/fix-toolchain.sh
+      - name: Run stdout renderer example
+        run: Renderer/Stdout/run-example.sh
+
+  stdout_renderer_macos:
+    name: Run stdout renderer on macOS
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15]
+        xcode-version: ["16.4"]
+        release: [2024]
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
+    env:
+      OPENSWIFTUI_WERROR: 0
+      OPENSWIFTUI_TARGET_RELEASE: ${{ matrix.release }}
+      OPENSWIFTUI_USE_LOCAL_DEPS: 1
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Xcode
+        uses: OpenSwiftUIProject/setup-xcode@v2
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+      - name: Set up build environment
+        run: Scripts/CI/darwin_setup_build.sh
+        shell: bash
+      - name: Run stdout renderer example
+        run: Renderer/Stdout/run-example.sh

--- a/.github/workflows/stdout_renderer.yml
+++ b/.github/workflows/stdout_renderer.yml
@@ -8,22 +8,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  stdout_renderer_linux:
-    name: Run stdout renderer on Linux
-    runs-on: ubuntu-22.04
-    container: swift:6.1.0-jammy
-    env:
-      OPENSWIFTUI_WERROR: 0
-      OPENSWIFTUI_SWIFT_LOG: 1
-      OPENSWIFTUI_SWIFT_CRYPTO: 1
-    steps:
-      - uses: actions/checkout@v4
-      - name: Toolchain fix patch
-        run: |
-          # Fix swift-corelibs-foundation#5211
-          .github/scripts/fix-toolchain.sh
-      - name: Run stdout renderer example
-        run: Renderer/Stdout/run-example.sh
+  # Disable on Linux for now
+  # stdout_renderer_linux:
+  #   name: Run stdout renderer on Linux
+  #   runs-on: ubuntu-22.04
+  #   container: swift:6.1.0-jammy
+  #   env:
+  #     OPENSWIFTUI_WERROR: 0
+  #     OPENSWIFTUI_SWIFT_LOG: 1
+  #     OPENSWIFTUI_SWIFT_CRYPTO: 1
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Toolchain fix patch
+  #       run: |
+  #         # Fix swift-corelibs-foundation#5211
+  #         .github/scripts/fix-toolchain.sh
+  #     - name: Run stdout renderer example
+  #       run: Renderer/Stdout/run-example.sh
 
   stdout_renderer_macos:
     name: Run stdout renderer on macOS

--- a/Renderer/README.md
+++ b/Renderer/README.md
@@ -13,5 +13,7 @@ Run it from this repository:
 
 ```sh
 cd Renderer/Stdout
-swift run ExampleApp
+./run-example.sh
 ```
+
+On macOS, use the Stdout Tuist project for Xcode runs.

--- a/Renderer/README.md
+++ b/Renderer/README.md
@@ -1,0 +1,17 @@
+# Renderers
+
+This directory contains renderer-specific examples and helper packages that are
+kept outside the main OpenSwiftUI package manifest.
+
+## Stdout
+
+`Stdout/` contains a small executable package that launches an OpenSwiftUI app
+with the stdout renderer enabled. It is useful for checking display-list output
+without adding demo targets to the main package.
+
+Run it from this repository:
+
+```sh
+cd Renderer/Stdout
+swift run ExampleApp
+```

--- a/Renderer/README.md
+++ b/Renderer/README.md
@@ -17,3 +17,8 @@ cd Renderer/Stdout
 ```
 
 On macOS, use the Stdout Tuist project for Xcode runs.
+
+```sh
+cd Renderer/Stdout
+./open-xcode.sh
+```

--- a/Renderer/Stdout/.gitignore
+++ b/Renderer/Stdout/.gitignore
@@ -1,0 +1,3 @@
+.build
+.swiftpm
+Package.resolved

--- a/Renderer/Stdout/.gitignore
+++ b/Renderer/Stdout/.gitignore
@@ -1,3 +1,9 @@
 .build
 .swiftpm
+Derived
 Package.resolved
+*.xcodeproj
+*.xcworkspace
+Tuist/.build
+Tuist/.swiftpm
+Tuist/Dependencies

--- a/Renderer/Stdout/.gitignore
+++ b/Renderer/Stdout/.gitignore
@@ -1,7 +1,9 @@
 .build
 .swiftpm
+.xcodebuild
 Derived
 Package.resolved
+xcodebuild.log
 *.xcodeproj
 *.xcworkspace
 Tuist/.build

--- a/Renderer/Stdout/ExampleApp/ExampleApp.swift
+++ b/Renderer/Stdout/ExampleApp/ExampleApp.swift
@@ -1,0 +1,15 @@
+@_spi(StdoutRenderer) import OpenSwiftUI
+
+@main
+struct ExampleApp: App {
+    static var _rendererConfiguration: _RendererConfiguration? { .stdout() }
+
+    var body: some Scene {
+        WindowGroup {
+            VStack(spacing: 10.0) {
+                Color.red
+                Color.blue
+            }
+        }
+    }
+}

--- a/Renderer/Stdout/ExampleApp/ExampleApp.swift
+++ b/Renderer/Stdout/ExampleApp/ExampleApp.swift
@@ -2,7 +2,7 @@
 
 @main
 struct ExampleApp: App {
-    static var _rendererConfiguration: _RendererConfiguration? { .stdout() }
+    static var rendererConfiguration: _RendererConfiguration? { .stdout() }
 
     var body: some Scene {
         WindowGroup {

--- a/Renderer/Stdout/Package.swift
+++ b/Renderer/Stdout/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "StdoutRenderer",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "ExampleApp", targets: ["ExampleApp"]),
+    ],
+    dependencies: [
+        .package(path: "../.."),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ExampleApp",
+            dependencies: [
+                .product(name: "OpenSwiftUI", package: "OpenSwiftUI"),
+            ],
+            path: "ExampleApp"
+        ),
+    ]
+)

--- a/Renderer/Stdout/Project.swift
+++ b/Renderer/Stdout/Project.swift
@@ -1,0 +1,100 @@
+import ProjectDescription
+
+let appName = "StdoutRendererDemo"
+
+let appSettings: SettingsDictionary = [
+    "CODE_SIGN_STYLE": "Automatic",
+    "DEVELOPMENT_TEAM": "",
+    "ENABLE_HARDENED_RUNTIME": "YES",
+    "FRAMEWORK_SEARCH_PATHS": [
+        "$(inherited)",
+        "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)",
+        "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+    ],
+    "GENERATE_INFOPLIST_FILE": "YES",
+    "LD_RUNPATH_SEARCH_PATHS": [
+        "$(inherited)",
+        "@executable_path/../Frameworks",
+    ],
+    "LIBRARY_SEARCH_PATHS": [
+        "$(inherited)",
+        "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)",
+        "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+    ],
+    "PRODUCT_BUNDLE_IDENTIFIER": "org.OpenSwiftUIProject.OpenSwiftUI.StdoutRendererDemo",
+    "SWIFT_VERSION": "5.0",
+]
+
+let privateFrameworkDependencies: [TargetDependency] = [
+    .external(name: "AttributeGraph"),
+    .external(name: "RenderBox"),
+    .external(name: "CoreUI"),
+    .external(name: "CoreSVG"),
+    .external(name: "SFSymbols"),
+]
+
+let target = Target.target(
+    name: appName,
+    destinations: [.mac],
+    product: .app,
+    bundleId: "org.OpenSwiftUIProject.OpenSwiftUI.StdoutRendererDemo",
+    deploymentTargets: .macOS("15.0"),
+    infoPlist: .extendingDefault(with: [:]),
+    sources: [
+        "ExampleApp/**/*.swift",
+    ],
+    dependencies: [
+        .external(name: "OpenSwiftUI"),
+    ] + privateFrameworkDependencies,
+    settings: .settings(
+        base: appSettings,
+        configurations: [
+            .debug(name: "Debug"),
+            .release(name: "Release"),
+        ],
+        defaultSettings: .none
+    )
+)
+
+let scheme = Scheme.scheme(
+    name: appName,
+    shared: true,
+    buildAction: .buildAction(targets: [.target(appName)]),
+    runAction: .runAction(
+        configuration: "Debug",
+        executable: .executable(.target(appName))
+    ),
+    archiveAction: .archiveAction(configuration: "Release"),
+    profileAction: .profileAction(
+        configuration: "Release",
+        executable: .executable(.target(appName))
+    ),
+    analyzeAction: .analyzeAction(configuration: "Debug")
+)
+
+let project = Project(
+    name: "StdoutRenderer",
+    options: .options(
+        automaticSchemesOptions: .disabled,
+        developmentRegion: "en"
+    ),
+    settings: .settings(
+        configurations: [
+            .debug(name: "Debug"),
+            .release(name: "Release"),
+        ],
+        defaultSettings: .none,
+        defaultConfiguration: "Debug"
+    ),
+    targets: [
+        target,
+    ],
+    schemes: [
+        scheme,
+    ],
+    additionalFiles: [
+        "README.md",
+        "Package.swift",
+        "run-example.sh",
+    ]
+)

--- a/Renderer/Stdout/Project.swift
+++ b/Renderer/Stdout/Project.swift
@@ -2,6 +2,19 @@ import ProjectDescription
 
 let appName = "StdoutRendererDemo"
 
+let debugBuildSettings: SettingsDictionary = [
+    "ALWAYS_SEARCH_USER_PATHS": "NO",
+    "GCC_OPTIMIZATION_LEVEL": "0",
+    "ONLY_ACTIVE_ARCH": "YES",
+    "SWIFT_COMPILATION_MODE": "singlefile",
+    "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+]
+
+let releaseBuildSettings: SettingsDictionary = [
+    "SWIFT_COMPILATION_MODE": "wholemodule",
+    "SWIFT_OPTIMIZATION_LEVEL": "-O",
+]
+
 let appSettings: SettingsDictionary = [
     "CODE_SIGN_STYLE": "Automatic",
     "DEVELOPMENT_TEAM": "",
@@ -49,8 +62,8 @@ let target = Target.target(
     settings: .settings(
         base: appSettings,
         configurations: [
-            .debug(name: "Debug"),
-            .release(name: "Release"),
+            .debug(name: "Debug", settings: debugBuildSettings),
+            .release(name: "Release", settings: releaseBuildSettings),
         ],
         defaultSettings: .none
     )
@@ -80,8 +93,8 @@ let project = Project(
     ),
     settings: .settings(
         configurations: [
-            .debug(name: "Debug"),
-            .release(name: "Release"),
+            .debug(name: "Debug", settings: debugBuildSettings),
+            .release(name: "Release", settings: releaseBuildSettings),
         ],
         defaultSettings: .none,
         defaultConfiguration: "Debug"

--- a/Renderer/Stdout/README.md
+++ b/Renderer/Stdout/README.md
@@ -1,0 +1,18 @@
+# Stdout Renderer
+
+This package runs a minimal OpenSwiftUI app with the stdout renderer enabled.
+The package depends on the local OpenSwiftUI checkout at `../..`.
+
+## Run
+
+```sh
+swift run ExampleApp
+```
+
+The example configures the app renderer with:
+
+```swift
+@_spi(StdoutRenderer) import OpenSwiftUI
+
+static var _rendererConfiguration: _RendererConfiguration? { .stdout() }
+```

--- a/Renderer/Stdout/README.md
+++ b/Renderer/Stdout/README.md
@@ -21,11 +21,14 @@ Use the Tuist project when running the demo from Xcode on macOS:
 ```
 
 The script runs `tuist install`, generates the workspace without opening during
-generation, then opens `StdoutRenderer.xcworkspace`.
+generation, then opens `StdoutRenderer.xcworkspace`. If `mise` is available, the
+script uses the repository-pinned Tuist version.
 
 The Tuist project uses local OpenSwiftUI, OpenAttributeGraph, OpenRenderBox,
 and DarwinPrivateFrameworks dependencies so Xcode does not need to open the
-Swift package directly.
+Swift package directly. Its package settings mirror the generated Example
+project's local OpenSwiftUI product destinations, keeping AttributeGraph
+enabled on macOS while preserving valid generated target platforms.
 
 The example configures the app renderer with:
 

--- a/Renderer/Stdout/README.md
+++ b/Renderer/Stdout/README.md
@@ -6,8 +6,11 @@ The package depends on the local OpenSwiftUI checkout at `../..`.
 ## Run
 
 ```sh
-swift run ExampleApp
+./run-example.sh
 ```
+
+The script selects AttributeGraph on macOS and Compute on other platforms,
+then runs `swift run ExampleApp`.
 
 The example configures the app renderer with:
 

--- a/Renderer/Stdout/README.md
+++ b/Renderer/Stdout/README.md
@@ -20,6 +20,9 @@ Use the Tuist project when running the demo from Xcode on macOS:
 ./open-xcode.sh
 ```
 
+The script runs `tuist install`, generates the workspace without opening during
+generation, then opens `StdoutRenderer.xcworkspace`.
+
 The Tuist project uses local OpenSwiftUI, OpenAttributeGraph, OpenRenderBox,
 and DarwinPrivateFrameworks dependencies so Xcode does not need to open the
 Swift package directly.

--- a/Renderer/Stdout/README.md
+++ b/Renderer/Stdout/README.md
@@ -17,5 +17,5 @@ The example configures the app renderer with:
 ```swift
 @_spi(StdoutRenderer) import OpenSwiftUI
 
-static var _rendererConfiguration: _RendererConfiguration? { .stdout() }
+static var rendererConfiguration: _RendererConfiguration? { .stdout() }
 ```

--- a/Renderer/Stdout/README.md
+++ b/Renderer/Stdout/README.md
@@ -1,9 +1,9 @@
 # Stdout Renderer
 
-This package runs a minimal OpenSwiftUI app with the stdout renderer enabled.
-The package depends on the local OpenSwiftUI checkout at `../..`.
+This directory contains a minimal OpenSwiftUI app with the stdout renderer
+enabled. The Swift package depends on the local OpenSwiftUI checkout at `../..`.
 
-## Run
+## CLI
 
 ```sh
 ./run-example.sh
@@ -11,6 +11,18 @@ The package depends on the local OpenSwiftUI checkout at `../..`.
 
 The script selects AttributeGraph on macOS and Compute on other platforms,
 then runs `swift run ExampleApp`.
+
+## macOS Xcode
+
+Use the Tuist project when running the demo from Xcode on macOS:
+
+```sh
+./open-xcode.sh
+```
+
+The Tuist project uses local OpenSwiftUI, OpenAttributeGraph, OpenRenderBox,
+and DarwinPrivateFrameworks dependencies so Xcode does not need to open the
+Swift package directly.
 
 The example configures the app renderer with:
 

--- a/Renderer/Stdout/Tuist.swift
+++ b/Renderer/Stdout/Tuist.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let tuist = Tuist(
+    project: .tuist(
+        generationOptions: .options(
+            defaultConfiguration: "Debug"
+        )
+    )
+)

--- a/Renderer/Stdout/Tuist.swift
+++ b/Renderer/Stdout/Tuist.swift
@@ -3,7 +3,13 @@ import ProjectDescription
 let tuist = Tuist(
     project: .tuist(
         generationOptions: .options(
-            defaultConfiguration: "Debug"
+            defaultConfiguration: "Debug",
+            manifestEnvironment: [
+                "DARWINPRIVATEFRAMEWORKS_*",
+                "OPENATTRIBUTEGRAPH_*",
+                "OPENRENDERBOX_*",
+                "OPENSWIFTUI_*",
+            ]
         )
     )
 )

--- a/Renderer/Stdout/Tuist/Package.swift
+++ b/Renderer/Stdout/Tuist/Package.swift
@@ -1,0 +1,76 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "StdoutRendererDependencies",
+    dependencies: [
+        .package(path: "../../.."),
+        .package(path: "../../../../OpenAttributeGraph"),
+        .package(path: "../../../../OpenRenderBox"),
+        .package(path: "../../../../DarwinPrivateFrameworks"),
+        .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.3"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0"),
+    ]
+)
+
+#if TUIST
+import ProjectDescription
+
+let packageDestinations: Destinations = [.mac]
+
+let packageProductTypes: [String: ProjectDescription.Product] = [
+    "OpenSwiftUI": .framework,
+    "OpenSwiftUICore": .staticFramework,
+    "OpenSwiftUI_SPI": .staticFramework,
+    "COpenSwiftUI": .staticFramework,
+    "OpenSwiftUIMacros": .macro,
+    "OpenAttributeGraphShims": .staticFramework,
+    "OpenCoreGraphicsShims": .staticFramework,
+    "OpenObservation": .staticFramework,
+    "OpenQuartzCoreShims": .staticFramework,
+    "OpenRenderBoxShims": .staticFramework,
+    "AttributeGraph": .framework,
+    "RenderBox": .framework,
+    "CoreUI": .framework,
+    "CoreSVG": .framework,
+    "SFSymbols": .framework,
+    "BacklightServices": .framework,
+]
+
+let packageProductDestinations: [String: Destinations] = [
+    "OpenSwiftUI": packageDestinations,
+    "OpenSwiftUICore": packageDestinations,
+    "OpenSwiftUI_SPI": packageDestinations,
+    "OpenAttributeGraph": packageDestinations,
+    "OpenAttributeGraphShims": packageDestinations,
+    "OpenRenderBox": packageDestinations,
+    "OpenRenderBoxShims": packageDestinations,
+    "AttributeGraph": packageDestinations,
+    "RenderBox": packageDestinations,
+    "CoreUI": packageDestinations,
+    "CoreSVG": packageDestinations,
+    "SFSymbols": packageDestinations,
+]
+
+let packageSettings = PackageSettings(
+    productTypes: packageProductTypes,
+    productDestinations: packageProductDestinations,
+    baseSettings: .settings(
+        configurations: [
+            .debug(name: "Debug"),
+            .release(name: "Release"),
+        ],
+        defaultSettings: .none,
+        defaultConfiguration: "Debug"
+    ),
+    targetSettings: [
+        "OpenSwiftUI": .settings(
+            base: [
+                "DYLIB_INSTALL_NAME_BASE": "@rpath",
+            ]
+        ),
+    ]
+)
+#endif

--- a/Renderer/Stdout/Tuist/Package.swift
+++ b/Renderer/Stdout/Tuist/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
         .package(path: "../../../../OpenAttributeGraph"),
         .package(path: "../../../../OpenRenderBox"),
         .package(path: "../../../../DarwinPrivateFrameworks"),
+        .package(url: "https://github.com/OpenSwiftUIProject/SymbolLocator.git", from: "0.2.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-numerics", from: "1.0.3"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0"),
@@ -26,6 +27,8 @@ let packageProductTypes: [String: ProjectDescription.Product] = [
     "OpenSwiftUI_SPI": .staticFramework,
     "COpenSwiftUI": .staticFramework,
     "OpenSwiftUIMacros": .macro,
+    "OpenSwiftUITestsSupport": .staticFramework,
+    "OpenSwiftUISymbolDualTestsSupport": .staticFramework,
     "OpenAttributeGraphShims": .staticFramework,
     "OpenCoreGraphicsShims": .staticFramework,
     "OpenObservation": .staticFramework,
@@ -37,12 +40,15 @@ let packageProductTypes: [String: ProjectDescription.Product] = [
     "CoreSVG": .framework,
     "SFSymbols": .framework,
     "BacklightServices": .framework,
+    "SymbolLocator": .staticFramework,
 ]
 
 let packageProductDestinations: [String: Destinations] = [
     "OpenSwiftUI": packageDestinations,
     "OpenSwiftUICore": packageDestinations,
     "OpenSwiftUI_SPI": packageDestinations,
+    "OpenSwiftUITestsSupport": packageDestinations,
+    "OpenSwiftUISymbolDualTestsSupport": packageDestinations,
     "OpenAttributeGraph": packageDestinations,
     "OpenAttributeGraphShims": packageDestinations,
     "OpenRenderBox": packageDestinations,
@@ -52,6 +58,20 @@ let packageProductDestinations: [String: Destinations] = [
     "CoreUI": packageDestinations,
     "CoreSVG": packageDestinations,
     "SFSymbols": packageDestinations,
+    "SymbolLocator": packageDestinations,
+]
+
+let debugBuildSettings: SettingsDictionary = [
+    "ALWAYS_SEARCH_USER_PATHS": "NO",
+    "GCC_OPTIMIZATION_LEVEL": "0",
+    "ONLY_ACTIVE_ARCH": "YES",
+    "SWIFT_COMPILATION_MODE": "singlefile",
+    "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+]
+
+let releaseBuildSettings: SettingsDictionary = [
+    "SWIFT_COMPILATION_MODE": "wholemodule",
+    "SWIFT_OPTIMIZATION_LEVEL": "-O",
 ]
 
 let packageSettings = PackageSettings(
@@ -59,8 +79,8 @@ let packageSettings = PackageSettings(
     productDestinations: packageProductDestinations,
     baseSettings: .settings(
         configurations: [
-            .debug(name: "Debug"),
-            .release(name: "Release"),
+            .debug(name: "Debug", settings: debugBuildSettings),
+            .release(name: "Release", settings: releaseBuildSettings),
         ],
         defaultSettings: .none,
         defaultConfiguration: "Debug"

--- a/Renderer/Stdout/Tuist/Package.swift
+++ b/Renderer/Stdout/Tuist/Package.swift
@@ -47,6 +47,8 @@ let packageProductDestinations: [String: Destinations] = [
     "OpenSwiftUI": packageDestinations,
     "OpenSwiftUICore": packageDestinations,
     "OpenSwiftUI_SPI": packageDestinations,
+    "OpenSwiftUIExtension": packageDestinations,
+    "OpenSwiftUIBridge": packageDestinations,
     "OpenSwiftUITestsSupport": packageDestinations,
     "OpenSwiftUISymbolDualTestsSupport": packageDestinations,
     "OpenAttributeGraph": packageDestinations,
@@ -84,13 +86,6 @@ let packageSettings = PackageSettings(
         ],
         defaultSettings: .none,
         defaultConfiguration: "Debug"
-    ),
-    targetSettings: [
-        "OpenSwiftUI": .settings(
-            base: [
-                "DYLIB_INSTALL_NAME_BASE": "@rpath",
-            ]
-        ),
-    ]
+    )
 )
 #endif

--- a/Renderer/Stdout/open-xcode.sh
+++ b/Renderer/Stdout/open-xcode.sh
@@ -10,5 +10,5 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
 fi
 
 tuist install
-tuist generate
+tuist generate --no-open
 open StdoutRenderer.xcworkspace

--- a/Renderer/Stdout/open-xcode.sh
+++ b/Renderer/Stdout/open-xcode.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "The Tuist Xcode workflow is only available on macOS." >&2
+    exit 1
+fi
+
+tuist install
+tuist generate
+open StdoutRenderer.xcworkspace

--- a/Renderer/Stdout/run-example.sh
+++ b/Renderer/Stdout/run-example.sh
@@ -12,6 +12,7 @@ Darwin)
 *)
     export OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH=0
     export OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE=1
+    export OPENSWIFTUI_LIB_SWIFT_PATH="$(swiftly use --print-location)/usr/lib/swift"
     ;;
 esac
 

--- a/Renderer/Stdout/run-example.sh
+++ b/Renderer/Stdout/run-example.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+case "$(uname -s)" in
+Darwin)
+    export OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH=1
+    export OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE=0
+    ;;
+*)
+    export OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH=0
+    export OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE=1
+    ;;
+esac
+
+exec swift run ExampleApp "$@"

--- a/Sources/OpenSwiftUI/App/App/App.swift
+++ b/Sources/OpenSwiftUI/App/App/App.swift
@@ -134,7 +134,7 @@ public protocol App {
     /// If set, OpenSwiftUI applies this configuration to renderers that it
     /// creates for the app.
     @_spi(StdoutRenderer)
-    nonisolated static var _rendererConfiguration: _RendererConfiguration? { get }
+    nonisolated static var rendererConfiguration: _RendererConfiguration? { get }
     /* OpenSwiftUI Addition End */
 }
 
@@ -151,7 +151,7 @@ extension App {
     public static func main() {
         let app = Self()
         /* OpenSwiftUI Addition Begin */
-        if let rendererConfiguration = Self._rendererConfiguration,
+        if let rendererConfiguration = Self.rendererConfiguration,
            case let .stdout(options) = rendererConfiguration.renderer {
             runStdoutApp(app, options: options)
         }
@@ -161,7 +161,7 @@ extension App {
 
     /* OpenSwiftUI Addition Begin */
     @_spi(StdoutRenderer)
-    nonisolated public static var _rendererConfiguration: _RendererConfiguration? {
+    nonisolated public static var rendererConfiguration: _RendererConfiguration? {
         nil
     }
     /* OpenSwiftUI Addition End */
@@ -211,7 +211,7 @@ typealias PlatformApplication = NSObject
 typealias PlatformApplicationDelegate = AnyObject
 
 func runApp<Application>(_ app: Application) -> Never where Application: App {
-    let rendererConfiguration = Application._rendererConfiguration ?? .stdout()
+    let rendererConfiguration = Application.rendererConfiguration ?? .stdout()
     guard case let .stdout(options) = rendererConfiguration.renderer else {
         print("OpenSwiftUI currently supports only the stdout renderer on this platform.")
         exit(1)

--- a/Sources/OpenSwiftUI/App/App/App.swift
+++ b/Sources/OpenSwiftUI/App/App/App.swift
@@ -150,6 +150,12 @@ extension App {
     /// a platform-appropriate way.
     public static func main() {
         let app = Self()
+        /* OpenSwiftUI Addition Begin */
+        if let rendererConfiguration = Self._rendererConfiguration,
+           case let .stdout(options) = rendererConfiguration.renderer {
+            runStdoutApp(app, options: options)
+        }
+        /* OpenSwiftUI Addition End */
         runApp(app)
     }
 
@@ -191,6 +197,13 @@ typealias DelegateBaseClass = NSResponder
 typealias PlatformApplication = NSApplication
 typealias PlatformApplicationDelegate = NSApplicationDelegate
 #else
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif os(WASI)
+import WASILibc
+#endif
 import Foundation
 // FIXME: Temporarily use NSObject as a placeholder
 typealias DelegateBaseClass = NSObject

--- a/Sources/OpenSwiftUI/App/App/App.swift
+++ b/Sources/OpenSwiftUI/App/App/App.swift
@@ -197,8 +197,13 @@ typealias DelegateBaseClass = NSObject
 typealias PlatformApplication = NSObject
 typealias PlatformApplicationDelegate = AnyObject
 
-func runApp(_ app: some App) -> Never {
-    _openSwiftUIPlatformUnimplementedFailure()
+func runApp<Application>(_ app: Application) -> Never where Application: App {
+    let rendererConfiguration = Application._rendererConfiguration ?? .stdout()
+    guard case let .stdout(options) = rendererConfiguration.renderer else {
+        print("OpenSwiftUI currently supports only the stdout renderer on this platform.")
+        exit(1)
+    }
+    runStdoutApp(app, options: options)
 }
 
 func runTestingApp<V1, V2>(rootView: V1, comparisonView: V2, didLaunch: @escaping (any TestHost, any TestHost) -> ()) -> Never where V1: View, V2: View {

--- a/Sources/OpenSwiftUI/App/App/App.swift
+++ b/Sources/OpenSwiftUI/App/App/App.swift
@@ -6,7 +6,8 @@
 //  Status: Complete
 //  ID: 20E520D074F8AF54E6253E3E22B86490 (SwiftUI)
 
-import OpenSwiftUICore
+@_spi(StdoutRenderer)
+public import OpenSwiftUICore
 
 // MARK: - App
 
@@ -126,6 +127,15 @@ public protocol App {
     /// provide one. You typically rely on the default initializer for
     /// your app.
     init()
+
+    /* OpenSwiftUI Addition Begin */
+    /// The global default renderer configuration used by the app lifecycle.
+    ///
+    /// If set, OpenSwiftUI applies this configuration to renderers that it
+    /// creates for the app.
+    @_spi(StdoutRenderer)
+    nonisolated static var _rendererConfiguration: _RendererConfiguration? { get }
+    /* OpenSwiftUI Addition End */
 }
 
 extension App {
@@ -142,6 +152,13 @@ extension App {
         let app = Self()
         runApp(app)
     }
+
+    /* OpenSwiftUI Addition Begin */
+    @_spi(StdoutRenderer)
+    nonisolated public static var _rendererConfiguration: _RendererConfiguration? {
+        nil
+    }
+    /* OpenSwiftUI Addition End */
 }
 
 // MARK: - AppRootModifier

--- a/Sources/OpenSwiftUI/App/App/AppGraph.swift
+++ b/Sources/OpenSwiftUI/App/App/AppGraph.swift
@@ -74,7 +74,7 @@ package final class AppGraph: GraphHost {
 
     init<Application>(app: Application) where Application: App {
         /* OpenSwiftUI Addition Begin */
-        rendererConfiguration = Application._rendererConfiguration
+        rendererConfiguration = Application.rendererConfiguration
         /* OpenSwiftUI Addition End */
         makeRootScene = { inputs in
             let fields = DynamicPropertyCache.fields(of: Application.self)

--- a/Sources/OpenSwiftUI/App/App/AppGraph.swift
+++ b/Sources/OpenSwiftUI/App/App/AppGraph.swift
@@ -26,6 +26,11 @@ package final class AppGraph: GraphHost {
 
     static var delegateBox: AnyFallbackDelegateBox? = nil
 
+    /* OpenSwiftUI Addition Begin */
+    /// The global default renderer configuration declared by the launched app.
+    let rendererConfiguration: _RendererConfiguration?
+    /* OpenSwiftUI Addition End */
+
     private var makeRootScene: (_SceneInputs) -> _SceneOutputs
 
     private var observers: Set<HashableWeakBox<AnyObject>> = .init()
@@ -68,6 +73,9 @@ package final class AppGraph: GraphHost {
     private var rootCommandsList: CommandsList?
 
     init<Application>(app: Application) where Application: App {
+        /* OpenSwiftUI Addition Begin */
+        rendererConfiguration = Application._rendererConfiguration
+        /* OpenSwiftUI Addition End */
         makeRootScene = { inputs in
             let fields = DynamicPropertyCache.fields(of: Application.self)
             var inputs = inputs

--- a/Sources/OpenSwiftUI/App/App/AppKit/AppKitAppDelegate.swift
+++ b/Sources/OpenSwiftUI/App/App/AppKit/AppKitAppDelegate.swift
@@ -60,6 +60,11 @@ class AppDelegate: NSResponder, NSApplicationDelegate {
         let items = AppGraph.shared?.rootSceneList?.items ?? []
         let view = items[0].value.view
         let hostingVC = NSHostingController(rootView: view.frame(width: 500, height: 300).rootEnvironment())
+        /* OpenSwiftUI Addition Begin */
+        if let rendererConfiguration = graph.rendererConfiguration {
+            hostingVC._rendererConfiguration = rendererConfiguration
+        }
+        /* OpenSwiftUI Addition End */
         let windowVC = WindowController(hostingVC)
         windowVC.showWindow(nil)
         self.windowVC = windowVC

--- a/Sources/OpenSwiftUI/App/App/Stdout/StdoutApp.swift
+++ b/Sources/OpenSwiftUI/App/App/Stdout/StdoutApp.swift
@@ -1,0 +1,47 @@
+//
+//  StdoutApp.swift
+//  OpenSwiftUI
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif os(WASI)
+import WASILibc
+#endif
+import Foundation
+@_spi(ForOpenSwiftUIOnly)
+@_spi(StdoutRenderer)
+import OpenSwiftUICore
+
+// MARK: - runStdoutApp
+
+func runStdoutApp(
+    _ app: some App,
+    options: _RendererConfiguration.StdoutOptions
+) -> Never {
+    Update.dispatchImmediately(reason: nil) {
+        let graph = AppGraph(app: app)
+        graph.instantiate()
+        AppGraph.shared = graph
+        guard let item = graph.rootSceneList?.items.first else {
+            print("OpenSwiftUI stdout renderer: no scene to render")
+            return
+        }
+        #if os(macOS) || os(iOS) || os(visionOS)
+        let rootView = item.value.view
+            .frame(width: options.surface.width, height: options.surface.height)
+            .rootEnvironment(scenePhase: .active, sceneID: item.id)
+        #else
+        let rootView = item.value.view
+            .frame(width: options.surface.width, height: options.surface.height)
+        #endif
+        let host = StdoutRendererHost(
+            rootView: rootView,
+            environment: item.environment,
+            options: options
+        )
+        host.renderOnce()
+    }
+    exit(0)
+}

--- a/Sources/OpenSwiftUI/App/App/UIKit/UIKitAppDelegate.swift
+++ b/Sources/OpenSwiftUI/App/App/UIKit/UIKitAppDelegate.swift
@@ -338,6 +338,11 @@ final class AppSceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.sceneItemID = item.id
         let rootView = self.makeRootView(item.value.view)
         let hostingController = UIHostingController(rootView: rootView)
+        /* OpenSwiftUI Addition Begin */
+        if let rendererConfiguration = appGraph.rendererConfiguration {
+            hostingController._rendererConfiguration = rendererConfiguration
+        }
+        /* OpenSwiftUI Addition End */
         hostingController.host.delegate = self
         hostingController.host.inheritedEnvironment = item.environment
         let window = UIWindow(windowScene: windowScene)

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
@@ -1,0 +1,207 @@
+//
+//  DisplayListStdoutRenderer.swift
+//  OpenSwiftUICore
+//
+//  Status: WIP
+
+package import Foundation
+import OpenSwiftUI_SPI
+
+// MARK: - DisplayList + stdout rendering
+
+extension DisplayList {
+    package func stdoutDescription(
+        surface: CGSize,
+        version: DisplayList.Version
+    ) -> String {
+        var lines = [
+            "OpenSwiftUI backend: stdout",
+            "surface: \(stdoutFormat(surface.width))x\(stdoutFormat(surface.height))",
+            "display-list-version: \(version.value)",
+            "rendered:",
+        ]
+        for command in stdoutRenderCommands() {
+            lines.append("  - \(command.description)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func stdoutRenderCommands() -> [StdoutRenderCommand] {
+        var visitor = StdoutRenderCommandVisitor()
+        visitor.append(list: self)
+        return visitor.commands
+    }
+}
+
+private enum StdoutRenderCommand {
+    case fill(frame: CGRect, color: Color.Resolved)
+
+    var description: String {
+        switch self {
+        case let .fill(frame, color):
+            "fill x:\(stdoutFormat(frame.minX)) y:\(stdoutFormat(frame.minY)) w:\(stdoutFormat(frame.width)) h:\(stdoutFormat(frame.height)) \(color.description)"
+        }
+    }
+}
+
+private struct StdoutRenderCommandVisitor {
+    var commands: [StdoutRenderCommand] = []
+
+    mutating func append(
+        list: DisplayList,
+        transform: CGAffineTransform = .identity,
+        opacity: Float = 1.0
+    ) {
+        for item in list.items {
+            append(item: item, transform: transform, opacity: opacity)
+        }
+    }
+
+    private mutating func append(
+        item: DisplayList.Item,
+        transform: CGAffineTransform,
+        opacity: Float
+    ) {
+        switch item.value {
+        case let .content(content):
+            append(
+                content: content,
+                frame: item.frame.applying(transform),
+                transform: transform,
+                opacity: opacity
+            )
+        case let .effect(effect, list):
+            append(effect: effect, list: list, transform: transform, opacity: opacity)
+        case let .states(states):
+            for (_, list) in states {
+                append(list: list, transform: transform, opacity: opacity)
+            }
+        case .empty:
+            break
+        }
+    }
+
+    private mutating func append(
+        content: DisplayList.Content,
+        frame: CGRect,
+        transform: CGAffineTransform,
+        opacity: Float
+    ) {
+        switch content.value {
+        case let .color(color):
+            commands.append(.fill(frame: frame, color: color.multiplyingOpacity(by: opacity)))
+        case let .shape(_, paint, _):
+            if let color = paint.stdoutResolvedColor {
+                commands.append(.fill(frame: frame, color: color.multiplyingOpacity(by: opacity)))
+            }
+        case let .flattened(list, offset, _):
+            append(
+                list: list,
+                transform: transform.concatenating(
+                    CGAffineTransform(translationX: frame.minX + offset.x, y: frame.minY + offset.y)
+                ),
+                opacity: opacity
+            )
+        default:
+            break
+        }
+    }
+
+    private mutating func append(
+        effect: DisplayList.Effect,
+        list: DisplayList,
+        transform: CGAffineTransform,
+        opacity: Float
+    ) {
+        switch effect {
+        case let .opacity(alpha):
+            append(list: list, transform: transform, opacity: opacity * alpha)
+        case let .transform(.affine(affine)):
+            append(list: list, transform: transform.concatenating(affine), opacity: opacity)
+        default:
+            append(list: list, transform: transform, opacity: opacity)
+        }
+    }
+}
+
+private struct StdoutColorPaintVisitor: ResolvedPaintVisitor {
+    var color: Color.Resolved?
+
+    mutating func visitPaint<P>(_ paint: P) where P: ResolvedPaint {
+        color = paint as? Color.Resolved
+    }
+}
+
+private extension AnyResolvedPaint {
+    var stdoutResolvedColor: Color.Resolved? {
+        var visitor = StdoutColorPaintVisitor()
+        visit(&visitor)
+        return visitor.color
+    }
+}
+
+private func stdoutFormat(_ value: CGFloat) -> String {
+    let number = Double(value)
+    return String(format: "%.1f", number == -0.0 ? 0.0 : number)
+}
+
+// MARK: - StdoutDisplayListRenderer
+
+final class StdoutDisplayListRenderer: ViewRendererBase {
+    let platform: DisplayList.ViewUpdater.Platform
+    weak var host: (any ViewRendererHost)?
+    var options: _RendererConfiguration.StdoutOptions
+    private var seed: DisplayList.Seed = .init()
+    private var hasRendered = false
+
+    init(
+        platform: DisplayList.ViewUpdater.Platform,
+        host: (any ViewRendererHost)?,
+        options: _RendererConfiguration.StdoutOptions
+    ) {
+        self.platform = platform
+        self.host = host
+        self.options = options
+    }
+
+    var exportedObject: AnyObject? {
+        nil
+    }
+
+    func render(
+        rootView: AnyObject,
+        from list: DisplayList,
+        time: Time,
+        version: DisplayList.Version,
+        maxVersion: DisplayList.Version,
+        environment: DisplayList.ViewRenderer.Environment
+    ) -> Time {
+        let nextSeed = DisplayList.Seed(version)
+        guard !hasRendered || nextSeed != seed else {
+            return .infinity
+        }
+        hasRendered = true
+        seed = nextSeed
+        print(list.stdoutDescription(surface: options.surface, version: version))
+        if let host, let observer = host.as(ViewGraphRenderObserver.self) {
+            observer.didRender()
+        }
+        return .infinity
+    }
+
+    func renderAsync(
+        to list: DisplayList,
+        time: Time,
+        targetTimestamp: Time?,
+        version: DisplayList.Version,
+        maxVersion: DisplayList.Version
+    ) -> Time? {
+        nil
+    }
+
+    func destroy(rootView: AnyObject) {}
+
+    var viewCacheIsEmpty: Bool {
+        true
+    }
+}

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
@@ -5,6 +5,7 @@
 //  Status: WIP
 
 package import Foundation
+package import OpenCoreGraphicsShims
 import OpenSwiftUI_SPI
 
 // MARK: - DisplayList + stdout rendering

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
@@ -74,6 +74,9 @@ extension DisplayList {
             case none
             case updating
             case rasterizing
+            /* OpenSwiftUI Addition Begin */
+            case stdout
+            /* OpenSwiftUI Addition End */
         }
 
         private var state: State = .none
@@ -94,6 +97,9 @@ extension DisplayList {
             let isValid = switch configuration.renderer {
             case .default: state == .updating
             case .rasterized: state == .rasterizing
+            /* OpenSwiftUI Addition Begin */
+            case .stdout: state == .stdout
+            /* OpenSwiftUI Addition End */
             }
             if !isValid {
                 if let renderer {
@@ -110,6 +116,12 @@ extension DisplayList {
                     rasterizer.options = options
                     rasterizer.renderer.platformViewMode = options.drawsPlatformViews ? .rendered(update: true) : .unsupported
                     rasterizer.host = host
+                /* OpenSwiftUI Addition Begin */
+                case let .stdout(options):
+                    let stdoutRenderer = renderer as! StdoutDisplayListRenderer
+                    stdoutRenderer.options = options
+                    stdoutRenderer.host = host
+                /* OpenSwiftUI Addition End */
                 }
             } else {
                 switch configuration.renderer {
@@ -126,6 +138,15 @@ extension DisplayList {
                     )
                     renderer = rasterizer
                     state = .rasterizing
+                /* OpenSwiftUI Addition Begin */
+                case let .stdout(options):
+                    renderer = StdoutDisplayListRenderer(
+                        platform: platform,
+                        host: host,
+                        options: options
+                    )
+                    state = .stdout
+                /* OpenSwiftUI Addition End */
                 }
             }
             return renderer!

--- a/Sources/OpenSwiftUICore/Render/DisplayList/StdoutRendererHost.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/StdoutRendererHost.swift
@@ -1,0 +1,105 @@
+//
+//  StdoutRendererHost.swift
+//  OpenSwiftUICore
+
+import Foundation
+
+// MARK: - StdoutRendererHost
+
+final package class StdoutRendererHost<Content>: ViewRendererHost, ViewGraphRenderDelegate where Content: View {
+    typealias RootView = ModifiedContent<Content, HitTestBindingModifier>
+
+    package let viewGraph: ViewGraph
+    package let renderer: DisplayList.ViewRenderer
+    package let rootView: Content
+    package let environment: EnvironmentValues
+    package let options: _RendererConfiguration.StdoutOptions
+
+    package var currentTimestamp: Time = .zero
+    package var propertiesNeedingUpdate: ViewRendererHostProperties = .all
+    package var renderingPhase: ViewRenderingPhase = .none
+    package var externalUpdateCount: Int = .zero
+
+    package init(
+        rootView: Content,
+        environment: EnvironmentValues,
+        options: _RendererConfiguration.StdoutOptions
+    ) {
+        self.rootView = rootView
+        self.environment = environment
+        self.options = options
+        Update.begin()
+        // The stdout renderer only needs layout and display list output.
+        viewGraph = ViewGraph(rootViewType: RootView.self, requestedOutputs: [.displayList, .layout])
+        renderer = DisplayList.ViewRenderer(
+            platform: .init(definition: StdoutPlatformViewDefinition.self)
+        )
+        renderer.configuration = .stdout(options)
+        renderer.host = self
+        initializeViewGraph()
+        Update.end()
+    }
+
+    package func renderOnce() {
+        render(interval: .zero, targetTimestamp: nil)
+    }
+
+    package func updateRootView() {
+        viewGraph.setRootView(Self.makeRootView(rootView))
+    }
+
+    package func updateEnvironment() {
+        viewGraph.setEnvironment(environment)
+    }
+
+    package func updateTransform() {
+        viewGraph.invalidateTransform()
+    }
+
+    package func updateSize() {
+        viewGraph.setProposedSize(options.surface)
+    }
+
+    package func updateSafeArea() {
+        viewGraph.setSafeAreaInsets(.zero)
+    }
+
+    package func updateContainerSize() {
+        viewGraph.setContainerSize(.fixed(options.surface))
+    }
+
+    package func updateFocusStore() {}
+
+    package func updateFocusedItem() {}
+
+    package func updateFocusedValues() {}
+
+    package func updateAccessibilityEnvironment() {}
+
+    package func `as`<T>(_ type: T.Type) -> T? {
+        if ViewGraphRenderDelegate.self == T.self {
+            return unsafeBitCast(self as any ViewGraphRenderDelegate, to: T.self)
+        } else if DisplayList.ViewRenderer.self == T.self {
+            return unsafeBitCast(renderer, to: T.self)
+        } else {
+            return nil
+        }
+    }
+
+    package func requestUpdate(after delay: Double) {}
+
+    package var renderingRootView: AnyObject {
+        self
+    }
+
+    package func updateRenderContext(_ context: inout ViewGraphRenderContext) {
+        context.contentsScale = 1.0
+        context.opaqueBackground = false
+    }
+
+    package func withMainThreadRender(wasAsync: Bool, _ body: () -> Time) -> Time {
+        body()
+    }
+}
+
+private final class StdoutPlatformViewDefinition: PlatformViewDefinition, @unchecked Sendable {}

--- a/Sources/OpenSwiftUICore/Render/RendererConfiguration.swift
+++ b/Sources/OpenSwiftUICore/Render/RendererConfiguration.swift
@@ -5,6 +5,8 @@
 //  Audited for 6.5.4
 //  Status: Complete
 
+public import Foundation
+
 // MARK: - _RendererConfiguration
 
 /// Renderer configuration for a hosting view.
@@ -19,6 +21,13 @@ public struct _RendererConfiguration {
         /// An alternative renderer that rasterizes everything in the
         /// local process.
         indirect case rasterized(_ options: _RendererConfiguration.RasterizationOptions = .init())
+
+        /* OpenSwiftUI Addition Begin */
+        /// A renderer that writes a textual representation of the display list
+        /// to standard output.
+        @_spi(StdoutRenderer)
+        indirect case stdout(_ options: _RendererConfiguration.StdoutOptions = .init())
+        /* OpenSwiftUI Addition End */
     }
 
     /// The renderer kind and its specific configuration.
@@ -39,6 +48,34 @@ public struct _RendererConfiguration {
     public static func rasterized(_ options: _RendererConfiguration.RasterizationOptions = .init()) -> _RendererConfiguration {
         _RendererConfiguration(renderer: .rasterized(options))
     }
+
+    /* OpenSwiftUI Addition Begin */
+
+    /// Returns a configuration to render the display list to standard output.
+    @_spi(StdoutRenderer)
+    public static func stdout(_ options: _RendererConfiguration.StdoutOptions = .init()) -> _RendererConfiguration {
+        _RendererConfiguration(renderer: .stdout(options))
+    }
+
+    /* OpenSwiftUI Addition End */
+
+    /* OpenSwiftUI Addition Begin */
+
+    // MARK: - _RendererConfiguration.StdoutOptions
+
+    /// Options for the `stdout` renderer.
+    @_spi(StdoutRenderer)
+    public struct StdoutOptions {
+        /// The surface size reported by the stdout renderer.
+        public var surface: CGSize = defaultSurfaceSize
+
+        // TODO: Get from host platform API
+        private static let defaultSurfaceSize = CGSize(width: 640.0, height: 480.0)
+
+        public init() {}
+    }
+
+    /* OpenSwiftUI Addition End */
 
     // MARK: - _RendererConfiguration.RasterizationOptions
 
@@ -89,6 +126,12 @@ extension _RendererConfiguration.Renderer: Sendable {}
 
 @available(*, unavailable)
 extension _RendererConfiguration.RasterizationOptions: Sendable {}
+
+/* OpenSwiftUI Addition Begin */
+@_spi(StdoutRenderer)
+@available(*, unavailable)
+extension _RendererConfiguration.StdoutOptions: Sendable {}
+/* OpenSwiftUI Addition End */
 
 // MARK: - RasterizationOptions + _RendererConfiguration.RasterizationOptions
 

--- a/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListStdoutRendererTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListStdoutRendererTests.swift
@@ -3,6 +3,7 @@
 //  OpenSwiftUICoreTests
 
 import Foundation
+import OpenCoreGraphicsShims
 import OpenSwiftUICore
 import Testing
 

--- a/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListStdoutRendererTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListStdoutRendererTests.swift
@@ -1,0 +1,153 @@
+//
+//  DisplayListStdoutRendererTests.swift
+//  OpenSwiftUICoreTests
+
+import Foundation
+import OpenSwiftUICore
+import Testing
+
+struct DisplayListStdoutRendererTests {
+    @Test
+    func emptyListDescription() {
+        let list = DisplayList()
+
+        #expect(list.stdoutDescription(
+            surface: CGSize(width: 64.0, height: 32.0),
+            version: .init(decodedValue: 7)
+        ) == """
+        OpenSwiftUI backend: stdout
+        surface: 64.0x32.0
+        display-list-version: 7
+        rendered:
+        """)
+    }
+
+    @Test
+    func colorContentDescription() {
+        let item = item(
+            .content(.init(
+                .color(.init(colorSpace: .sRGBLinear, red: 1.0, green: 0.0, blue: 0.0)),
+                seed: .init(decodedValue: 2)
+            )),
+            frame: CGRect(x: 1.0, y: 2.0, width: 30.0, height: 40.0)
+        )
+
+        #expect(DisplayList(item).stdoutDescription(
+            surface: CGSize(width: 100.0, height: 80.0),
+            version: .init(decodedValue: 4)
+        ) == """
+        OpenSwiftUI backend: stdout
+        surface: 100.0x80.0
+        display-list-version: 4
+        rendered:
+          - fill x:1.0 y:2.0 w:30.0 h:40.0 #FF0000FF
+        """)
+    }
+
+    @Test
+    func shapeContentDescription() {
+        let color = Color.Resolved(colorSpace: .sRGBLinear, red: 0.0, green: 1.0, blue: 0.0)
+        let item = item(
+            .content(.init(
+                .shape(Path(CGRect(x: 0.0, y: 0.0, width: 10.0, height: 10.0)), _AnyResolvedPaint(color), FillStyle()),
+                seed: .init(decodedValue: 3)
+            )),
+            frame: CGRect(x: 5.0, y: 6.0, width: 70.0, height: 80.0)
+        )
+
+        #expect(DisplayList(item).stdoutDescription(
+            surface: CGSize(width: 120.0, height: 90.0),
+            version: .init(decodedValue: 5)
+        ) == """
+        OpenSwiftUI backend: stdout
+        surface: 120.0x90.0
+        display-list-version: 5
+        rendered:
+          - fill x:5.0 y:6.0 w:70.0 h:80.0 #00FF00FF
+        """)
+    }
+
+    @Test
+    func opacityAndTransformDescription() {
+        let child = item(
+            .content(.init(
+                .color(.init(colorSpace: .sRGBLinear, red: 0.0, green: 0.0, blue: 1.0)),
+                seed: .init(decodedValue: 2)
+            )),
+            frame: CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0)
+        )
+        let transformed = item(
+            .effect(
+                .transform(.affine(CGAffineTransform(translationX: 10.0, y: 20.0))),
+                DisplayList(child)
+            ),
+            frame: .zero
+        )
+        let faded = item(
+            .effect(.opacity(0.5), DisplayList(transformed)),
+            frame: .zero
+        )
+
+        #expect(DisplayList(faded).stdoutDescription(
+            surface: CGSize(width: 100.0, height: 100.0),
+            version: .init(decodedValue: 6)
+        ) == """
+        OpenSwiftUI backend: stdout
+        surface: 100.0x100.0
+        display-list-version: 6
+        rendered:
+          - fill x:11.0 y:22.0 w:3.0 h:4.0 #0000FF80
+        """)
+    }
+
+    @Test
+    func statesDescription() {
+        let redItem = item(
+            .content(.init(
+                .color(.init(colorSpace: .sRGBLinear, red: 1.0, green: 0.0, blue: 0.0)),
+                seed: .init(decodedValue: 1)
+            )),
+            frame: CGRect(x: 0.0, y: 0.0, width: 10.0, height: 20.0)
+        )
+        let blueItem = item(
+            .content(.init(
+                .color(.init(colorSpace: .sRGBLinear, red: 0.0, green: 0.0, blue: 1.0)),
+                seed: .init(decodedValue: 2)
+            )),
+            frame: CGRect(x: 30.0, y: 40.0, width: 50.0, height: 60.0)
+        )
+        let states = item(
+            .states([
+                (StrongHash(of: 1), DisplayList(redItem)),
+                (StrongHash(of: 2), DisplayList(blueItem)),
+            ]),
+            frame: .zero
+        )
+
+        #expect(DisplayList(states).stdoutDescription(
+            surface: CGSize(width: 200.0, height: 150.0),
+            version: .init(decodedValue: 8)
+        ) == """
+        OpenSwiftUI backend: stdout
+        surface: 200.0x150.0
+        display-list-version: 8
+        rendered:
+          - fill x:0.0 y:0.0 w:10.0 h:20.0 #FF0000FF
+          - fill x:30.0 y:40.0 w:50.0 h:60.0 #0000FFFF
+        """)
+    }
+
+    private func item(
+        _ value: DisplayList.Item.Value,
+        frame: CGRect,
+        identity: DisplayList.Identity = .init(decodedValue: 1),
+        version: DisplayList.Version = .init(decodedValue: 0)
+    ) -> DisplayList.Item {
+        DisplayList.Item(
+            value,
+            frame: frame,
+            identity: identity,
+            version: version
+        )
+    }
+}


### PR DESCRIPTION
## Agent Summary

Adds stdout renderer support for OpenSwiftUI apps, including renderer configuration plumbing, a display-list stdout renderer, and a small example package under `Renderer/Stdout`.

This also adds a Tuist-backed macOS Xcode workflow for the stdout example, documentation under `Renderer/`, focused stdout renderer unit coverage, and a macOS CI workflow that runs the example script. The Linux workflow entry is left disabled for now so the remaining Linux runtime work can be handled in a follow-up change.

Validation:
- Confirmed the PR diff against the merge-base with `main` contains only stdout renderer, example, documentation, tests, and CI workflow changes.
- Did not run a fresh macOS build in this step after stashing the Linux follow-up work.