### PR TITLE
Fix NSHostingView async rendering cycle on macOS

### DIFF
--- a/Sources/OpenSwiftUI/Integration/Hosting/AppKit/View/NSHostingView.swift
+++ b/Sources/OpenSwiftUI/Integration/Hosting/AppKit/View/NSHostingView.swift
@@ -421,28 +421,22 @@ open class NSHostingView<Content>: NSView, XcodeViewDebugDataProvider where Cont
         // TODO
         NSAnimationContext.runAnimationGroup { context in
             context.allowsImplicitAnimation = false
-            isUpdating = true
-            // TODO
-            render(targetTimestamp: nil)
-            // TODO
-            isUpdating = false
-            // TODO
-            if needsDeferredUpdate {
-                if !viewGraph.updateRequiredMainThread {
-                    if isLinkedOnOrAfter(.v3) {
-                        if startAsyncRendering() {
-                            needsDeferredUpdate = false
-                        }
+            var iteration = 0
+            repeat {
+                needsDeferredUpdate = false
+                isUpdating = true
+                render(targetTimestamp: nil)
+                isUpdating = false
+                if needsDeferredUpdate,
+                   !viewGraph.updateRequiredMainThread,
+                   isLinkedOnOrAfter(.v3),
+                   !viewGraph.mayDeferUpdate {
+                    if startAsyncRendering() {
+                        needsDeferredUpdate = false
                     }
                 }
-            }
-            if needsDeferredUpdate {
-                onNextMainRunLoop { [weak self] in
-                    guard let self else { return }
-                    setNeedsUpdate()
-                }
-                needsDeferredUpdate = false
-            }
+                iteration += 1
+            } while needsDeferredUpdate && iteration < 8
         }
     }
 
@@ -782,8 +776,12 @@ open class NSHostingView<Content>: NSView, XcodeViewDebugDataProvider where Cont
     static func defaultViewGraphOutputs() -> ViewGraph.Outputs { .defaults }
 
     func setNeedsUpdate() {
-        needsUpdateConstraints = true
-        needsLayout = true
+        if isUpdating {
+            needsDeferredUpdate = true
+        } else {
+            needsUpdateConstraints = true
+            needsLayout = true
+        }
     }
 
     // MARK: - Window Notification Handlers
@@ -954,10 +952,13 @@ extension NSHostingView: ViewRendererHost {
 
             if adjustedDelay >= 0.25 {
                 setUpdateTimer(delay: adjustedDelay)
-            } else if isUpdating {
-                needsDeferredUpdate = true
-            } else {
+            } else if adjustedDelay == 0 || !isUpdating {
                 setNeedsUpdate()
+            } else {
+                onNextMainRunLoop { [weak self] in
+                    guard let self else { return }
+                    setNeedsUpdate()
+                }
             }
 
             // TODO: Notify delegate


### PR DESCRIPTION
## Summary

Fixes a cross-start/stop async rendering loop in `NSHostingView` triggered by `TimelineView(.animation)` on macOS.

```
struct BreathingColorView: View {
    var body: some View {
        TimelineView(.animation) { timeline in
            let time = timeline.date.timeIntervalSince1970
            let breathe = (sin(time) + 1) / 2 // Oscillates between 0 and 1
            
            VStack(spacing: 40) {
                Text(verbatim: "Breathing Colors")
                    .font(.title)
                    .fontWeight(.bold)

                Color.blue.opacity(0.3 + breathe * 0.7)
                    .frame(width: 200, height: 200)
                    .scaleEffect(0.8 + breathe * 0.4)
                
                Color.blue
                    .frame(width: 200, height: 20)
                    .opacity(0.3 + breathe * 0.7)
                    .cornerRadius(10)
            }
            .padding()
        }
    }
}
```

### Root cause

When `requestUpdate(after:)` is called during `render()` (`isUpdating == true`) with a non-zero delay — e.g. ~16 ms from `TimelineView`'s next-frame schedule — OpenSwiftUI directly set `needsDeferredUpdate = true`, which caused the `layout()` closure to call `startAsyncRendering()` and spin up a `CoreDisplayLink`. `renderAsync` typically returned `nil` (e.g. due to pending transactions or incomplete `updateOutputsAsync`), destroying the display link and queuing another `requestUpdate(after: 0)` — repeating every layout pass.

### Changes

- `requestUpdate(after:)`: match SwiftUI's `delay == 0 || !isUpdating` branch.
- `setNeedsUpdate()`: when `isUpdating`, set `needsDeferredUpdate = true` instead of calling `setNeedsLayout` reentrantly.
- `layout()` inner closure: repeat-while (max 8 iterations) with `!viewGraph.mayDeferUpdate` guard before `startAsyncRendering()`. Drop the OSUI-only `onNextMainRunLoop { setNeedsUpdate() }` fallback (not present in SwiftUI).

iOS / visionOS hosting paths (`UIHostingViewBase`) are unaffected — this change is `#if os(macOS)` only.