### PR TITLE
Fix App renderer configuration default visibility

### DIFF
--- a/Sources/OpenSwiftUI/App/App/App.swift
+++ b/Sources/OpenSwiftUI/App/App/App.swift
@@ -160,7 +160,6 @@ extension App {
     }
 
     /* OpenSwiftUI Addition Begin */
-    @_spi(StdoutRenderer)
     nonisolated public static var rendererConfiguration: _RendererConfiguration? {
         nil
     }


### PR DESCRIPTION
## Agent Summary

Make the default `App.rendererConfiguration` implementation visible to regular OpenSwiftUI imports so `TestingHostApp` can satisfy `App` without adding a local override.

The stdout renderer configuration requirement remains SPI-gated, while the default `nil` witness is available for conforming app types. This fixes the UI test host build regression after #893 when `OSUI_UITests` imports `TestingHost`.

## Validation

- `./setup.sh` from `Example`
- `xcodebuild -workspace Example/Example.xcworkspace -scheme OSUI_UITests -destination 'generic/platform=iOS Simulator' -configuration OpenSwiftUIDebug build CODE_SIGNING_ALLOWED=NO`