### PR TITLE
Complete gesture view modifier support

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -33,6 +33,8 @@ jobs:
       OPENSWIFTUI_SUPPORT_MULTI_PRODUCTS: 0
       OPENSWIFTUI_USE_LOCAL_DEPS: 1
       OPENSWIFTUI_LINK_TESTING: 1
+      # Match Xcode's test launcher so OSLogStore can read current-process debug messages.
+      OS_ACTIVITY_DT_MODE: "YES"
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,6 +28,8 @@ jobs:
       OPENSWIFTUI_TARGET_RELEASE: ${{ matrix.release }}
       OPENSWIFTUI_USE_LOCAL_DEPS: 1
       OPENSWIFTUI_LINK_TESTING: 1
+      # Match Xcode's test launcher so OSLogStore can read current-process debug messages.
+      OS_ACTIVITY_DT_MODE: "YES"
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "57f62f1d8483f61ad08ac4c46692ec2e13644d24831e5e9f8248974cee905784",
+  "originHash" : "9646970ccc24a2bec27adf297824b75c0f9fcd7974245ade131018c97dfae28b",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -929,6 +929,8 @@ if swiftLogCondition {
     )
     openSwiftUICoreTarget.addSwiftLogSettings()
     openSwiftUITarget.addSwiftLogSettings()
+    openSwiftUICoreTestTarget.addSwiftLogSettings()
+    openSwiftUISymbolDualTestsTarget.addSwiftLogSettings()
 }
 
 if swiftCryptoCondition {

--- a/Sources/OpenSwiftUICore/Event/Gesture/GestureDebug.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/GestureDebug.swift
@@ -10,10 +10,12 @@ package import Foundation
 package import OpenAttributeGraphShims
 import OpenSwiftUI_SPI
 
+// MARK: - GestureDebug
+
 package enum GestureDebug {
     package typealias Properties = ArrayWith2Inline<(String, String)>
 
-    package enum Kind {
+    package enum Kind: Hashable {
         case empty
         case primitive
         case modifier
@@ -38,11 +40,19 @@ package enum GestureDebug {
         package typealias Children = ArrayWith2Inline<GestureDebug.Data>
 
         package var children: GestureDebug.Data.Children {
-            get { _openSwiftUIUnimplementedFailure() }
-            set { _openSwiftUIUnimplementedFailure() }
+            get {
+                switch childrenBox {
+                case let .value(children):
+                    children
+                }
+            }
+            set {
+                childrenBox = .value(newValue)
+            }
         }
 
         package init() {
+            let box: ChildrenBox = .value(ArrayWith2Inline())
             kind = .empty
             type = EmptyGesture<()>.self
             phase = .failed
@@ -50,7 +60,7 @@ package enum GestureDebug {
             resetSeed = 0
             frame = .zero
             properties = .init()
-            childrenBox = .value([]) // FIXME
+            childrenBox = box
         }
 
         package init(
@@ -63,12 +73,61 @@ package enum GestureDebug {
             frame: CGRect,
             properties: GestureDebug.Properties
         ) {
-            _openSwiftUIUnimplementedFailure()
+            let box: ChildrenBox = .value(children)
+            self.kind = kind
+            self.type = type
+            self.phase = phase
+            self.attribute = AnyOptionalAttribute(attribute)
+            self.resetSeed = resetSeed
+            self.frame = frame
+            self.properties = properties
+            self.childrenBox = box
+        }
+    }
+
+    fileprivate struct Value<PhaseValue>: Rule {
+        var kind: GestureDebug.Kind
+        var type: any Any.Type
+        @OptionalAttribute var properties: GestureDebug.Properties?
+        @Attribute var phase: GesturePhase<PhaseValue>
+        @Attribute var resetSeed: UInt32
+        @Attribute var position: ViewOrigin
+        @Attribute var size: ViewSize
+        @Attribute var transform: ViewTransform
+        @OptionalAttribute var debugData1: GestureDebug.Data?
+        @OptionalAttribute var debugData2: GestureDebug.Data?
+
+        var childData: GestureDebug.Data.Children {
+            switch (debugData1, debugData2) {
+            case (.none, .none):
+                GestureDebug.Data.Children()
+            case let (.some(debugData), .none), let (.none, .some(debugData)):
+                GestureDebug.Data.Children(debugData)
+            case let (.some(debugData1), .some(debugData2)):
+                GestureDebug.Data.Children(debugData1, debugData2)
+            }
+        }
+
+        var value: GestureDebug.Data {
+            let origin = transform.convert(.localToSpace(.global), point: position)
+            let frame = CGRect(origin: origin, size: size.value)
+            return GestureDebug.Data(
+                kind: kind,
+                type: type,
+                children: childData,
+                phase: phase.withValue(()),
+                attribute: $phase.identifier,
+                resetSeed: resetSeed,
+                frame: frame,
+                properties: properties ?? .init()
+            )
         }
     }
 }
 
 extension GestureDebug.Data: Defaultable {
+    package typealias Value = GestureDebug.Data
+
     package static let defaultValue: GestureDebug.Data = .init()
 }
 
@@ -90,6 +149,8 @@ extension Attribute where Value: DebuggableGesturePhase {
     }
 }
 
+// MARK: - makeDebuggableGesture
+
 extension Gesture {
     @inline(__always)
     nonisolated package static func makeDebuggableGesture(
@@ -98,8 +159,7 @@ extension Gesture {
     ) -> _GestureOutputs<Self.Value> {
         var outputs = _makeGesture(gesture: gesture, inputs: inputs)
         guard inputs.options.contains(.includeDebugOutput),
-              // FIXME
-              !(self is PrimitiveDebuggableGesture) else {
+              !(self is PrimitiveDebuggableGesture.Type) else {
             return outputs
         }
         outputs.wrapDebugOutputs(Self.self, inputs: inputs)
@@ -116,8 +176,7 @@ extension GestureModifier {
     ) -> _GestureOutputs<Self.Value> {
         var outputs = _makeGesture(modifier: modifier, inputs: inputs, body: body)
         guard inputs.options.contains(.includeDebugOutput),
-              // FIXME
-              !(self is PrimitiveDebuggableGesture) else {
+              !(self is PrimitiveDebuggableGesture.Type) else {
             return outputs
         }
         outputs.wrapDebugOutputs(Self.self, inputs: inputs)
@@ -164,16 +223,29 @@ extension _GestureOutputs {
         )
     }
 
-    private func reallyWrap<T>(
+    private mutating func reallyWrap<T>(
         _ type: T.Type,
         kind: GestureDebug.Kind,
         properties: Attribute<GestureDebug.Properties>?,
         inputs: _GestureInputs,
         data: (Attribute<GestureDebug.Data>?, Attribute<GestureDebug.Data>?)
     ) {
-        _openSwiftUIUnimplementedFailure()
+        debugData = Attribute(GestureDebug.Value<Value>(
+            kind: kind,
+            type: type,
+            properties: OptionalAttribute(properties),
+            phase: phase,
+            resetSeed: inputs.resetSeed,
+            position: inputs.animatedPosition(),
+            size: inputs.viewInputs.size,
+            transform: inputs.transform,
+            debugData1: OptionalAttribute(data.0),
+            debugData2: OptionalAttribute(data.1)
+        ))
     }
 }
+
+// MARK: - GesturePhase + descriptionWithoutValue
 
 @_spi(ForOpenSwiftUIOnly)
 extension GesturePhase {
@@ -187,14 +259,87 @@ extension GesturePhase {
     }
 }
 
+// MARK: - GestureDebug.Data + printTree [TBA]
+
 extension GestureDebug.Data {
     package func printTree() {
-        _openSwiftUIUnimplementedFailure()
+        printSubtree(parent: nil, indent: Indent(kind: kind))
     }
 
-    private typealias Indent = String
+    private struct Indent {
+        var text: String
+        var kind: GestureDebug.Kind
+
+        init(_ text: String = "", kind: GestureDebug.Kind = .empty) {
+            self.text = text
+            self.kind = kind
+        }
+
+        var linePrefix: String {
+            switch kind {
+            case .gesture:
+                text + "* "
+            case .combiner:
+                text + "+ "
+            default:
+                text
+            }
+        }
+
+        var childText: String {
+            switch kind {
+            case .gesture:
+                text + "* "
+            case .combiner:
+                text + "| "
+            default:
+                text
+            }
+        }
+    }
 
     private func printSubtree(parent: GestureDebug.Data?, indent: Indent) {
-        _openSwiftUIUnimplementedFailure()
+        var line = indent.linePrefix
+        let typeDescription = Metadata(type).description
+        switch kind {
+        case .empty:
+            line += "(empty)"
+        case .modifier:
+            line += ".(\(typeDescription))"
+        default:
+            line += typeDescription
+        }
+        if let attribute = attribute.attribute {
+            line += " \(attribute.description)"
+        }
+        line += " (\(phase.descriptionWithoutValue))"
+        if resetSeed != 0, parent?.resetSeed != resetSeed {
+            line += " reset:\(resetSeed)"
+        }
+        line += frameDescription(relativeTo: parent)
+        if !properties.isEmpty {
+            let items = properties.map { "\($0.0): \($0.1)" }
+            line += " [\(items.joined(separator: ", "))]"
+        }
+        Log.eventDebug(line)
+
+        let childIndent = Indent(indent.childText, kind: kind)
+        for child in children {
+            child.printSubtree(parent: self, indent: childIndent)
+        }
+    }
+
+    private func frameDescription(relativeTo parent: GestureDebug.Data?) -> String {
+        var items: [String] = []
+        let size = frame.size
+        if parent?.frame.size != size, size != .zero {
+            items.append("{\((size.width, size.height))}")
+        }
+
+        let origin = frame.origin
+        if parent?.frame.origin != origin, origin != .zero {
+            items.append("@\((origin.x, origin.y))")
+        }
+        return items.isEmpty ? "" : " " + items.joined(separator: " ")
     }
 }

--- a/Sources/OpenSwiftUICore/Event/Gesture/GestureDependency.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/GestureDependency.swift
@@ -75,6 +75,7 @@ private struct DependentPhase<V>: Rule {
     }
 }
 
+@_spi(ForOpenSwiftUIOnly)
 extension GesturePhase {
     func paused() -> GesturePhase {
         switch self {

--- a/Sources/OpenSwiftUICore/Event/Gesture/GestureMask.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/GestureMask.swift
@@ -5,6 +5,528 @@
 //  Audited for 6.5.4
 //  Status: Complete
 
+// MARK: - View + Gesture
+
+@available(OpenSwiftUI_v1_0, *)
+extension View {
+    /// Attaches a gesture to the view with a lower precedence than gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to attach a gesture to a view. The
+    /// example below defines a custom gesture that prints a message to the
+    /// console and attaches it to the view's ``VStack``. Inside the ``VStack``
+    /// a red heart ``Image`` defines its own ``TapGesture``
+    /// handler that also prints a message to the console, and blue rectangle
+    /// with no custom gesture handlers. Tapping or clicking the image
+    /// prints a message to the console from the tap gesture handler on the
+    /// image, while tapping or clicking  the rectangle inside the ``VStack``
+    /// prints a message in the console from the enclosing vertical stack
+    /// gesture handler.
+    ///
+    ///     struct GestureExample: View {
+    ///         @State private var message = "Message"
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Tap on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Tap on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .gesture(newGesture)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - mask: A value that controls how adding this gesture to the view
+    ///      affects other gestures recognized by the view and its subviews.
+    ///      Defaults to ``OpenSwiftUI/GestureMask/all``.
+    nonisolated public func gesture<T>(
+        _ gesture: T,
+        including mask: GestureMask = .all
+    ) -> some View where T: Gesture {
+        modifier(AddGestureModifier(gesture, gestureMask: mask))
+    }
+
+    /// Attaches a gesture to the view with a higher precedence than gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to define a high priority gesture
+    /// to take precedence over the view's existing gestures. The
+    /// example below defines a custom gesture that prints a message to the
+    /// console and attaches it to the view's ``VStack``. Inside the ``VStack``
+    /// a red heart ``Image`` defines its own ``TapGesture`` handler that
+    /// also prints a message to the console, and a blue rectangle
+    /// with no custom gesture handlers. Tapping or clicking any of the
+    /// views results in a console message from the high priority gesture
+    /// attached to the enclosing ``VStack``.
+    ///
+    ///     struct HighPriorityGestureExample: View {
+    ///         @State private var message = "Message"
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Tap on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Tap on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .highPriorityGesture(newGesture)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - mask: A value that controls how adding this gesture to the view
+    ///      affects other gestures recognized by the view and its subviews.
+    ///      Defaults to ``OpenSwiftUI/GestureMask/all``.
+    nonisolated public func highPriorityGesture<T>(
+        _ gesture: T,
+        including mask: GestureMask = .all
+    ) -> some View where T: Gesture {
+        modifier(HighPriorityGestureModifier(gesture, name: nil, gestureMask: mask))
+    }
+
+    /// Attaches a gesture to the view to process simultaneously with gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to define and process  a view specific
+    /// gesture simultaneously with the same priority as the
+    /// view's existing gestures. The example below defines a custom gesture
+    /// that prints a message to the console and attaches it to the view's
+    /// ``VStack``. Inside the ``VStack`` is a red heart ``Image`` defines its
+    /// own ``TapGesture`` handler that also prints a message to the console
+    /// and a blue rectangle with no custom gesture handlers.
+    ///
+    /// Tapping or clicking the "heart" image sends two messages to the
+    /// console: one for the image's tap gesture handler, and the other from a
+    /// custom gesture handler attached to the enclosing vertical stack.
+    /// Tapping or clicking on the blue rectangle results only in the single
+    /// message to the console from the tap recognizer attached to the
+    /// ``VStack``:
+    ///
+    ///     struct SimultaneousGestureExample: View {
+    ///         @State private var message = "Message"
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Gesture on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Gesture on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .simultaneousGesture(newGesture)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - mask: A value that controls how adding this gesture to the view
+    ///      affects other gestures recognized by the view and its subviews.
+    ///      Defaults to ``OpenSwiftUI/GestureMask/all``.
+    nonisolated public func simultaneousGesture<T>(
+        _ gesture: T,
+        including mask: GestureMask = .all
+    ) -> some View where T: Gesture {
+        modifier(SimultaneousGestureModifier(gesture, name: nil, gestureMask: mask))
+    }
+
+    /// Attaches a gesture to the view with a lower precedence than gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to attach a gesture to a view. The
+    /// example below defines a custom gesture that prints a message to the
+    /// console and attaches it to the view's ``VStack``. Inside the ``VStack``
+    /// a red heart ``Image`` defines its own ``TapGesture``
+    /// handler that also prints a message to the console, and blue rectangle
+    /// with no custom gesture handlers. Tapping or clicking the image
+    /// prints a message to the console from the tap gesture handler on the
+    /// image, while tapping or clicking  the rectangle inside the ``VStack``
+    /// prints a message in the console from the enclosing vertical stack
+    /// gesture handler.
+    ///
+    /// You can also use the ``isEnabled`` parameter to conditionally disable
+    /// the gesture.
+    ///
+    ///     struct GestureExample: View {
+    ///         @State private var message = "Message"
+    ///         var isGestureEnabled: Bool
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Tap on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Tap on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .gesture(newGesture, isEnabled: isGestureEnabled)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - isEnabled: Whether the added gesture is enabled.
+    @_alwaysEmitIntoClient
+    nonisolated public func gesture<T>(
+        _ gesture: T,
+        isEnabled: Bool
+    ) -> some View where T: Gesture {
+        self.gesture(gesture, including: isEnabled ? .all : .subviews)
+    }
+
+    /// Attaches a gesture to the view with a higher precedence than gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to define a high priority gesture
+    /// to take precedence over the view's existing gestures. The
+    /// example below defines a custom gesture that prints a message to the
+    /// console and attaches it to the view's ``VStack``. Inside the ``VStack``
+    /// a red heart ``Image`` defines its own ``TapGesture`` handler that
+    /// also prints a message to the console, and a blue rectangle
+    /// with no custom gesture handlers. Tapping or clicking any of the
+    /// views results in a console message from the high priority gesture
+    /// attached to the enclosing ``VStack``.
+    ///
+    /// You can also use the ``isEnabled`` parameter to conditionally disable
+    /// the gesture.
+    ///
+    ///     struct HighPriorityGestureExample: View {
+    ///         @State private var message = "Message"
+    ///         var isGestureEnabled: Bool
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Tap on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Tap on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .highPriorityGesture(
+    ///                 newGesture, isEnabled: isGestureEnabled)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - isEnabled: Whether the added gesture is enabled.
+    @_alwaysEmitIntoClient
+    nonisolated public func highPriorityGesture<T>(
+        _ gesture: T,
+        isEnabled: Bool
+    ) -> some View where T: Gesture {
+        highPriorityGesture(gesture, including: isEnabled ? .all : .subviews)
+    }
+
+    /// Attaches a gesture to the view to process simultaneously with gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to define and process  a view specific
+    /// gesture simultaneously with the same priority as the
+    /// view's existing gestures. The example below defines a custom gesture
+    /// that prints a message to the console and attaches it to the view's
+    /// ``VStack``. Inside the ``VStack`` is a red heart ``Image`` defines its
+    /// own ``TapGesture`` handler that also prints a message to the console
+    /// and a blue rectangle with no custom gesture handlers.
+    ///
+    /// You can also use the ``isEnabled`` parameter to conditionally disable
+    /// the gesture.
+    ///
+    /// Tapping or clicking the "heart" image sends two messages to the
+    /// console: one for the image's tap gesture handler, and the other from a
+    /// custom gesture handler attached to the enclosing vertical stack.
+    /// Tapping or clicking on the blue rectangle results only in the single
+    /// message to the console from the tap recognizer attached to the
+    /// ``VStack``:
+    ///
+    ///     struct SimultaneousGestureExample: View {
+    ///         @State private var message = "Message"
+    ///         var isGestureEnabled: Bool
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Gesture on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Gesture on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .simultaneousGesture(
+    ///                 newGesture, isEnabled: isGestureEnabled)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - isEnabled: Whether the added gesture is enabled.
+    @_alwaysEmitIntoClient
+    nonisolated public func simultaneousGesture<T>(
+        _ gesture: T,
+        isEnabled: Bool
+    ) -> some View where T: Gesture {
+        simultaneousGesture(gesture, including: isEnabled ? .all : .subviews)
+    }
+}
+
+@available(OpenSwiftUI_v6_0, *)
+extension View {
+    /// Attaches a gesture to the view with a lower precedence than gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to attach a gesture to a view. The
+    /// example below defines a custom gesture that prints a message to the
+    /// console and attaches it to the view's ``VStack``. Inside the ``VStack``
+    /// a red heart ``Image`` defines its own ``TapGesture``
+    /// handler that also prints a message to the console, and blue rectangle
+    /// with no custom gesture handlers. Tapping or clicking the image
+    /// prints a message to the console from the tap gesture handler on the
+    /// image, while tapping or clicking  the rectangle inside the ``VStack``
+    /// prints a message in the console from the enclosing vertical stack
+    /// gesture handler.
+    ///
+    /// You can also use the ``isEnabled`` parameter to conditionally disable
+    /// the gesture.
+    ///
+    ///     struct GestureExample: View {
+    ///         @State private var message = "Message"
+    ///         var isGestureEnabled: Bool
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Tap on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Tap on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .gesture(newGesture, isEnabled: isGestureEnabled)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - name: A string that identifies the gesture. In iOS, the name can be
+    ///      used to set up failure relationships between UIKit gesture
+    ///      recognizers and this gesture.
+    ///    - isEnabled: Whether the added gesture is enabled. The default value
+    ///      is `true`.
+    nonisolated public func gesture<T>(
+        _ gesture: T,
+        name: String,
+        isEnabled: Bool = true
+    ) -> some View where T: Gesture {
+        modifier(AddGestureModifier(
+            gesture,
+            name: name,
+            gestureMask: isEnabled ? .all : .subviews
+        ))
+    }
+
+    /// Attaches a gesture to the view with a higher precedence than gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to define a high priority gesture
+    /// to take precedence over the view's existing gestures. The
+    /// example below defines a custom gesture that prints a message to the
+    /// console and attaches it to the view's ``VStack``. Inside the ``VStack``
+    /// a red heart ``Image`` defines its own ``TapGesture`` handler that
+    /// also prints a message to the console, and a blue rectangle
+    /// with no custom gesture handlers. Tapping or clicking any of the
+    /// views results in a console message from the high priority gesture
+    /// attached to the enclosing ``VStack``.
+    ///
+    /// You can also use the ``isEnabled`` parameter to conditionally disable
+    /// the gesture.
+    ///
+    ///     struct HighPriorityGestureExample: View {
+    ///         @State private var message = "Message"
+    ///         var isGestureEnabled: Bool
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Tap on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Tap on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .highPriorityGesture(
+    ///                 newGesture, isEnabled: isGestureEnabled)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - name: A string that identifies the gesture. In iOS, the name can be
+    ///      used to set up failure relationships between UIKit gesture
+    ///      recognizers and this gesture.
+    ///    - isEnabled: Whether the added gesture is enabled. The default value
+    ///      is `true`.
+    nonisolated public func highPriorityGesture<T>(
+        _ gesture: T,
+        name: String,
+        isEnabled: Bool = true
+    ) -> some View where T: Gesture {
+        modifier(HighPriorityGestureModifier(
+            gesture,
+            name: name,
+            gestureMask: isEnabled ? .all : .subviews
+        ))
+    }
+
+    /// Attaches a gesture to the view to process simultaneously with gestures
+    /// defined by the view.
+    ///
+    /// Use this method when you need to define and process  a view specific
+    /// gesture simultaneously with the same priority as the
+    /// view's existing gestures. The example below defines a custom gesture
+    /// that prints a message to the console and attaches it to the view's
+    /// ``VStack``. Inside the ``VStack`` is a red heart ``Image`` defines its
+    /// own ``TapGesture`` handler that also prints a message to the console
+    /// and a blue rectangle with no custom gesture handlers.
+    ///
+    /// You can also use the ``isEnabled`` parameter to conditionally disable
+    /// the gesture.
+    ///
+    /// Tapping or clicking the "heart" image sends two messages to the
+    /// console: one for the image's tap gesture handler, and the other from a
+    /// custom gesture handler attached to the enclosing vertical stack.
+    /// Tapping or clicking on the blue rectangle results only in the single
+    /// message to the console from the tap recognizer attached to the
+    /// ``VStack``:
+    ///
+    ///     struct SimultaneousGestureExample: View {
+    ///         @State private var message = "Message"
+    ///         var isGestureEnabled: Bool
+    ///         let newGesture = TapGesture().onEnded {
+    ///             print("Gesture on VStack.")
+    ///         }
+    ///
+    ///         var body: some View {
+    ///             VStack(spacing:25) {
+    ///                 Image(systemName: "heart.fill")
+    ///                     .resizable()
+    ///                     .frame(width: 75, height: 75)
+    ///                     .padding()
+    ///                     .foregroundColor(.red)
+    ///                     .onTapGesture {
+    ///                         print("Gesture on image.")
+    ///                     }
+    ///                 Rectangle()
+    ///                     .fill(Color.blue)
+    ///             }
+    ///             .simultaneousGesture(
+    ///                 newGesture, isEnabled: isGestureEnabled)
+    ///             .frame(width: 200, height: 200)
+    ///             .border(Color.purple)
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - gesture: A gesture to attach to the view.
+    ///    - name: A string that identifies the gesture. In iOS, the name can be
+    ///      used to set up failure relationships between UIKit gesture
+    ///      recognizers and this gesture.
+    ///    - isEnabled: Whether the added gesture is enabled. The default value
+    ///      is `true`.
+    nonisolated public func simultaneousGesture<T>(
+        _ gesture: T,
+        name: String,
+        isEnabled: Bool = true
+    ) -> some View where T: Gesture {
+        modifier(SimultaneousGestureModifier(
+            gesture,
+            name: name,
+            gestureMask: isEnabled ? .all : .subviews
+        ))
+    }
+}
+
 // MARK: - GestureMask
 
 /// Options that control how adding a gesture to a view affects other gestures

--- a/Sources/OpenSwiftUICore/Event/Gesture/GestureViewModifier.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/GestureViewModifier.swift
@@ -651,20 +651,3 @@ private struct ContentPhase<Value>: ResettableGestureRule {
         value = phase.withValue(())
     }
 }
-
-// MARK: - Optional: Gesture [WIP]
-
-extension Optional: Gesture where Wrapped: Gesture {
-    public typealias Value = Wrapped.Value
-    
-    nonisolated public static func _makeGesture(
-        gesture: _GraphValue<Optional<Wrapped>>,
-        inputs: _GestureInputs
-    ) -> _GestureOutputs<Wrapped.Value> {
-        _openSwiftUIUnimplementedFailure()
-    }
-
-    public typealias Body = Never
-}
-
-extension Optional: PrimitiveGesture where Wrapped: Gesture {}

--- a/Sources/OpenSwiftUICore/Event/Gesture/GestureViewModifier.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/GestureViewModifier.swift
@@ -3,7 +3,7 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: WIP
+//  Status: Complete
 //  ID: 9DF46B4E935FF03A55FF3DDFB0B1FF2B (SwiftUICore)
 
 package import OpenAttributeGraphShims
@@ -272,7 +272,7 @@ extension AnyGestureResponder {
     }
 }
 
-// MARK: - GestureResponder [WIP]
+// MARK: - GestureResponder
 
 private class GestureResponder<Modifier>: DefaultLayoutViewResponder, AnyGestureResponder where Modifier: GestureViewModifier {
     let modifier: Attribute<Modifier>
@@ -332,7 +332,7 @@ private class GestureResponder<Modifier>: DefaultLayoutViewResponder, AnyGesture
     }
 
     func makeSubviewsGesture(inputs: _GestureInputs) -> _GestureOutputs<Void> {
-        makeGesture(inputs: inputs)
+        super.makeGesture(inputs: inputs)
     }
 
     override var gestureContainer: AnyObject? {
@@ -351,7 +351,11 @@ private class GestureResponder<Modifier>: DefaultLayoutViewResponder, AnyGesture
         cacheKey: UInt32?,
         options: ViewResponder.ContainsPointsOptions
     ) -> ViewResponder.ContainsPointsResult {
-        _openSwiftUIUnimplementedFailure()
+        var result = super.containsGlobalPoints(points, cacheKey: cacheKey, options: options)
+        if options.contains(.useZDistanceAsPriority) {
+            result.priority = ViewResponder.gestureContainmentPriority
+        }
+        return result
     }
 
     override func bindEvent(_ event: any EventType) -> ResponderNode? {
@@ -369,31 +373,40 @@ private class GestureResponder<Modifier>: DefaultLayoutViewResponder, AnyGesture
 
     override func makeGesture(inputs: _GestureInputs) -> _GestureOutputs<Void> {
         makeWrappedGesture(inputs: inputs) { childInputs in
-//            let childViewInputs = childInputs.viewInputs
-//            let closure: () -> _GestureOutputs<Void> = { [self] in
-//                if inputs.options.contains(.skipCombiners) {
-//                    let childGesture = Attribute(GestureViewChild(
-//                        modifier: modifier,
-//                        isEnabled: childViewInputs.isEnabled,
-//                        viewPhase: childViewInputs.viewPhase
-//                    ))
-//                    return AnyGesture<Void>.makeDebuggableGesture(gesture: _GraphValue(childGesture), inputs: childInputs)
-//                } else {
-//                    let childGesture = Attribute(CombiningGestureViewChild(
-//                        modifier: modifier,
-//                        isEnabled: childViewInputs.isEnabled,
-//                        viewPhase: childViewInputs.viewPhase,
-//                        node: self
-//                    ))
-//                    return Modifier.Combiner.Result.makeDebuggableGesture(gesture: _GraphValue(childGesture), inputs: childInputs)
-//                }
-//            }
-//            guard inputs.options.contains(.includeDebugOutput) else {
-//                return closure()
-//            }
-//            // TODO: GestureViewDebug
-//            return closure()
-            _openSwiftUIUnimplementedFailure()
+            let childViewInputs = childInputs.viewInputs
+            let outputs: _GestureOutputs<Void> = {
+                if childInputs.options.contains(.skipCombiners) {
+                    let childGesture = Attribute(GestureViewChild(
+                        modifier: modifier,
+                        isEnabled: childViewInputs.isEnabled,
+                        viewPhase: childViewInputs.viewPhase
+                    ))
+                    return AnyGesture<Void>.makeDebuggableGesture(
+                        gesture: _GraphValue(childGesture),
+                        inputs: childInputs
+                    )
+                } else {
+                    let childGesture = Attribute(CombiningGestureViewChild(
+                        modifier: modifier,
+                        isEnabled: childViewInputs.isEnabled,
+                        viewPhase: childViewInputs.viewPhase,
+                        node: self
+                    ))
+                    return Modifier.Combiner.Result.makeDebuggableGesture(
+                        gesture: _GraphValue(childGesture),
+                        inputs: childInputs
+                    )
+                }
+            }()
+            guard childInputs.options.contains(.includeDebugOutput) else {
+                return outputs
+            }
+            var wrappedOutputs = outputs
+            wrappedOutputs.debugData = Attribute(GestureViewDebug(
+                modifier: modifier,
+                debugData: OptionalAttribute(outputs.debugData)
+            ))
+            return wrappedOutputs
         }
     }
 
@@ -406,6 +419,58 @@ private class GestureResponder<Modifier>: DefaultLayoutViewResponder, AnyGesture
     override func extendPrintTree(string: inout String) {
         string.append("\(Modifier.ContentGesture.self)")
     }
+}
+
+// MARK: - GestureAccessibilityProvider
+
+package protocol GestureAccessibilityProvider {
+    nonisolated static func makeGesture(
+        mask: @autoclosure () -> Attribute<GestureMask>,
+        inputs: _ViewInputs,
+        outputs: inout _ViewOutputs
+    )
+}
+
+// MARK: - SimultaneousGestureModifier
+
+struct SimultaneousGestureModifier<T>: GestureViewModifier where T: Gesture {
+    var gesture: T
+    var name: String?
+    var gestureMask: GestureMask
+
+    init(
+        _ gesture: T,
+        name: String?,
+        gestureMask: GestureMask
+    ) {
+        self.gesture = gesture
+        self.name = name
+        self.gestureMask = gestureMask
+    }
+
+    typealias ContentGesture = T
+    typealias Combiner = SimultaneousGestureCombiner
+}
+
+// MARK: - HighPriorityGestureModifier
+
+struct HighPriorityGestureModifier<T>: GestureViewModifier where T: Gesture {
+    var gesture: T
+    var name: String?
+    var gestureMask: GestureMask
+
+    init(
+        _ gesture: T,
+        name: String?,
+        gestureMask: GestureMask
+    ) {
+        self.gesture = gesture
+        self.name = name
+        self.gestureMask = gestureMask
+    }
+
+    typealias ContentGesture = T
+    typealias Combiner = HighPriorityGestureCombiner
 }
 
 // MARK: - GestureFilter
@@ -442,15 +507,7 @@ private struct GestureFilter<Modifier>: StatefulRule where Modifier: GestureView
     }
 }
 
-// MARK: - GestureAccessibilityProvider
-
-package protocol GestureAccessibilityProvider {
-    nonisolated static func makeGesture(
-        mask: @autoclosure () -> Attribute<GestureMask>,
-        inputs: _ViewInputs,
-        outputs: inout _ViewOutputs
-    )
-}
+// MARK: - EmptyGestureAccessibilityProvider
 
 struct EmptyGestureAccessibilityProvider: GestureAccessibilityProvider {
     nonisolated static func makeGesture(
@@ -458,8 +515,11 @@ struct EmptyGestureAccessibilityProvider: GestureAccessibilityProvider {
         inputs: _ViewInputs,
         outputs: inout _ViewOutputs
     ) {
+        _openSwiftUIEmptyStub()
     }
 }
+
+// MARK: - Inputs + gestureAccessibilityProvider
 
 extension _GraphInputs {
     private struct GestureAccessibilityProviderKey: GraphInput {
@@ -543,9 +603,29 @@ private struct CombiningGestureViewChild<Modifier>: Rule where Modifier: Gesture
     }
 }
 
-// MARK: - GestureViewDebug [WIP]
+// MARK: - GestureViewDebug
 
-private struct GestureViewDebug<Modifier> where Modifier: GestureViewModifier {
+private struct GestureViewDebug<Modifier>: Rule where Modifier: GestureViewModifier {
+    @Attribute var modifier: Modifier
+    @OptionalAttribute var debugData: GestureDebug.Data?
+
+    typealias Value = GestureDebug.Data
+
+    var value: GestureDebug.Data {
+        guard let debugData else {
+            return GestureDebug.Data()
+        }
+        return GestureDebug.Data(
+            kind: .gesture,
+            type: Modifier.ContentGesture.self,
+            children: [debugData],
+            phase: debugData.phase,
+            attribute: $modifier.identifier,
+            resetSeed: debugData.resetSeed,
+            frame: debugData.frame,
+            properties: .init()
+        )
+    }
 }
 
 // MARK: - SubviewsGesture
@@ -577,15 +657,41 @@ private struct SubviewsGesture: PrimitiveGesture, PrimitiveDebuggableGesture {
     }
 }
 
-// MARK: - SimultaneousGestureCombiner [WIP]
+// MARK: - SimultaneousGestureCombiner
 
-struct SimultaneousGestureCombiner {}
+struct SimultaneousGestureCombiner: GestureCombiner {
+    typealias Base = SimultaneousGesture<AnyGesture<Void>, AnyGesture<Void>>
 
-// MARK: - HighPriorityGestureCombiner [WIP]
+    typealias Result = _MapGesture<Base, Void>
 
-struct HighPriorityGestureCombiner {}
+    static func combine(
+        _ first: AnyGesture<Void>,
+        _ second: AnyGesture<Void>
+    ) -> Result {
+        first.simultaneously(with: second).map { _ in }
+    }
 
-// MARK: - SubviewsPhase [WIP]
+    static var exclusionPolicy: GestureResponderExclusionPolicy { .simultaneous }
+}
+
+// MARK: - HighPriorityGestureCombiner
+
+struct HighPriorityGestureCombiner: GestureCombiner {
+    typealias Base = ExclusiveGesture<AnyGesture<Void>, AnyGesture<Void>>
+
+    typealias Result = _MapGesture<Base, Void>
+
+    static func combine(
+        _ first: AnyGesture<Void>,
+        _ second: AnyGesture<Void>
+    ) -> Result {
+        second.exclusively(before: first).map { _ in }
+    }
+
+    static var exclusionPolicy: GestureResponderExclusionPolicy { .highPriority }
+}
+
+// MARK: - SubviewsPhase
 
 private struct SubviewsPhase: StatefulRule, ObservedAttribute {
     struct Value {
@@ -605,11 +711,57 @@ private struct SubviewsPhase: StatefulRule, ObservedAttribute {
     @OptionalAttribute var childDebugData: GestureDebug.Data?
 
     mutating func updateValue() {
-        _openSwiftUIUnimplementedFailure()
+        let node = gesture.node
+        if resetSeed != oldSeed || childSubgraph == nil || oldNode !== node {
+            if let childSubgraph {
+                outputs.detachIndirectOutputs()
+                self.childSubgraph = nil
+                _childPhase = .init()
+                childSubgraph.willInvalidate(isInserted: true)
+                childSubgraph.invalidate()
+            }
+            oldNode?.resetGesture()
+
+            let newSubgraph = Subgraph(graph: parentSubgraph.graph)
+            childSubgraph = newSubgraph
+            parentSubgraph.addChild(newSubgraph)
+            let childOutputs = newSubgraph.apply {
+                var childInputs = inputs
+                childInputs.copyCaches()
+                let childOutputs = node.makeSubviewsGesture(inputs: childInputs)
+                outputs.attachIndirectOutputs(childOutputs)
+                return childOutputs
+            }
+            _childPhase = OptionalAttribute(childOutputs.phase)
+            _childDebugData = OptionalAttribute(childOutputs.debugData)
+            oldSeed = resetSeed
+            oldNode = node
+        }
+        value = Value(
+            phase: childPhase ?? .failed,
+            debugData: childDebugData ?? GestureDebug.Data()
+        )
     }
 
     func destroy() {
         oldNode?.resetGesture()
+    }
+}
+
+// MARK: - ContentPhase
+
+private struct ContentPhase<Value>: ResettableGestureRule {
+    @Attribute var phase: GesturePhase<Value>
+    @Attribute var resetSeed: UInt32
+    var lastResetSeed: UInt32
+
+    typealias Value = GesturePhase<Void>
+
+    mutating func updateValue() {
+        guard resetIfNeeded() else {
+            return
+        }
+        value = phase.withValue(())
     }
 }
 
@@ -632,22 +784,5 @@ private struct ContentGesture<V>: GestureModifier {
             lastResetSeed: 0
         ))
         return outputs.withPhase(phase)
-    }
-}
-
-// MARK: - ContentPhase
-
-private struct ContentPhase<Value>: ResettableGestureRule {
-    @Attribute var phase: GesturePhase<Value>
-    @Attribute var resetSeed: UInt32
-    var lastResetSeed: UInt32
-
-    typealias Value = GesturePhase<Void>
-
-    mutating func updateValue() {
-        guard resetIfNeeded() else {
-            return
-        }
-        value = phase.withValue(())
     }
 }

--- a/Sources/OpenSwiftUICore/Event/Gesture/Map2Gesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/Map2Gesture.swift
@@ -80,9 +80,8 @@ extension Gesture {
 
 // MARK: - GesturePhase + combining
 
-@_spi(ForSwiftUIOnly)
+@_spi(ForOpenSwiftUIOnly)
 extension GesturePhase {
-    @_spi(ForSwiftUIOnly)
     package func and<Other, Result>(
         _ phase: GesturePhase<Other>,
         value transform: (Wrapped, Other) -> Result
@@ -101,14 +100,12 @@ extension GesturePhase {
         }
     }
 
-    @_spi(ForSwiftUIOnly)
     package func and<Other>(
         _ phase: GesturePhase<Other>
     ) -> GesturePhase<(Wrapped, Other)> {
         and(phase) { ($0, $1) }
     }
 
-    @_spi(ForSwiftUIOnly)
     package func and<Other>(
         _ phase: GesturePhase<Other>
     ) -> GesturePhase<Void> {

--- a/Sources/OpenSwiftUICore/Event/Gesture/OptionalGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/OptionalGesture.swift
@@ -1,0 +1,55 @@
+//
+//  OptionalGesture.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+//  ID: AA5A5D08CE822AD3F841F82D9B77CD0F (SwiftUICore)
+
+import OpenAttributeGraphShims
+
+// MARK: - Optional + Gesture
+
+@available(OpenSwiftUI_v1_0, *)
+extension Optional: Gesture where Wrapped: Gesture {
+    private struct Child: Rule {
+        @Attribute var gesture: Wrapped?
+
+        typealias Value = AnyGesture<Wrapped.Value>
+
+        var value: AnyGesture<Wrapped.Value> {
+            gesture.map { AnyGesture($0) } ?? AnyGesture(Empty())
+        }
+    }
+
+    private struct Empty: PrimitiveGesture {
+        typealias Value = Wrapped.Value
+
+        nonisolated static func _makeGesture(
+            gesture: _GraphValue<Self>,
+            inputs: _GestureInputs
+        ) -> _GestureOutputs<Wrapped.Value> {
+            _GestureOutputs(phase: Attribute(value: GesturePhase<Wrapped.Value>.failed))
+        }
+
+        typealias Body = Never
+    }
+
+    public typealias Value = Wrapped.Value
+
+    nonisolated public static func _makeGesture(
+        gesture: _GraphValue<Optional<Wrapped>>,
+        inputs: _GestureInputs
+    ) -> _GestureOutputs<Wrapped.Value> {
+        let child = Attribute(Child(gesture: gesture.value))
+        return AnyGesture<Wrapped.Value>.makeDebuggableGesture(
+            gesture: _GraphValue(child),
+            inputs: inputs
+        )
+    }
+
+    public typealias Body = Never
+}
+
+@available(OpenSwiftUI_v1_0, *)
+extension Optional: PrimitiveGesture where Wrapped: Gesture {}

--- a/Sources/OpenSwiftUICore/Util/AnyAttributeFix.swift
+++ b/Sources/OpenSwiftUICore/Util/AnyAttributeFix.swift
@@ -58,6 +58,8 @@ package struct AttributeType {
 }
 
 extension AnyAttribute {
+    package var description: String { "#\(rawValue)" }
+
     package static var `nil`: AnyAttribute { AnyAttribute(rawValue: 0x2) }
 
     package static var currentWasModified: Bool { false }

--- a/Sources/OpenSwiftUICore/Util/AnyAttributeFix.swift
+++ b/Sources/OpenSwiftUICore/Util/AnyAttributeFix.swift
@@ -197,7 +197,11 @@ extension AnyOptionalAttribute {
     }
 
     package init(_ attribute: AnyAttribute?) {
-        preconditionFailure("#39")
+        if let attribute {
+            self = Swift.unsafeBitCast(attribute.rawValue, to: AnyOptionalAttribute.self)
+        } else {
+            self = AnyOptionalAttribute()
+        }
     }
 }
 

--- a/Sources/OpenSwiftUISymbolDualTestsSupport/Event/Gesture/GestureDebugTestsStub.c
+++ b/Sources/OpenSwiftUISymbolDualTestsSupport/Event/Gesture/GestureDebugTestsStub.c
@@ -1,0 +1,13 @@
+//
+//  GestureDebugTestsStub.c
+//  OpenSwiftUISymbolDualTestsSupport
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#import <SymbolLocator.h>
+
+DEFINE_SL_STUB_SLF(OpenSwiftUITestStub_GestureDebugDataPrintTree, SwiftUICore, $s7SwiftUI12GestureDebugO4DataV9printTreeyyF);
+
+#endif

--- a/Tests/OpenSwiftUICoreTests/Event/Gesture/GestureDebugTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Event/Gesture/GestureDebugTests.swift
@@ -1,0 +1,305 @@
+//
+//  GestureDebugTests.swift
+//  OpenSwiftUICoreTests
+//
+
+import Foundation
+import OpenAttributeGraphShims
+#if !OPENSWIFTUI_SWIFT_LOG
+import OSLog
+#endif
+@_spi(ForOpenSwiftUIOnly)
+@testable
+#if OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS
+@_private(sourceFile: "GestureDebug.swift")
+#endif
+import OpenSwiftUICore
+import Testing
+
+#if arch(x86_64)
+private let isX86_64 = true
+#else
+private let isX86_64 = false
+#endif
+
+struct PrintTreeCase: @unchecked Sendable {
+    var root: GestureDebug.Data
+    var expected: [String]
+}
+
+private let printTreeCases: [PrintTreeCase] = [
+    .gestureWithModifierChild,
+    .gestureWithZeroFrameChild,
+    .emptyRoot,
+    .combinerWithSameFrameChild,
+    .primitiveWithFrameDeltaChildren,
+]
+
+private extension PrintTreeCase {
+    static var gestureWithModifierChild: PrintTreeCase {
+        var properties = GestureDebug.Properties()
+        properties.append(("trackingID", "touch#7"))
+        properties.append(("state", "active"))
+
+        let child = makeData(
+            kind: .modifier,
+            phase: .ended(()),
+            resetSeed: 2,
+            frame: CGRect(x: 4, y: 5, width: 6, height: 7),
+            properties: properties
+        )
+        let root = makeData(
+            kind: .gesture,
+            children: GestureDebug.Data.Children(child),
+            phase: .active(()),
+            resetSeed: 1,
+            frame: CGRect(x: 1, y: 2, width: 3, height: 4)
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "* EmptyGesture<Void> (active) reset:1 {(3.0, 4.0)} @(1.0, 2.0)",
+                "* * .(EmptyGesture<Void>) (ended) reset:2 {(6.0, 7.0)} @(4.0, 5.0) [trackingID: touch#7, state: active]",
+            ]
+        )
+    }
+
+    static var gestureWithZeroFrameChild: PrintTreeCase {
+        let child = makeData(
+            kind: .primitive,
+            phase: .failed,
+            frame: .zero
+        )
+        let root = makeData(
+            kind: .gesture,
+            children: GestureDebug.Data.Children(child),
+            phase: .failed,
+            frame: CGRect(x: 1, y: 2, width: 3, height: 4)
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "* EmptyGesture<Void> (failed) {(3.0, 4.0)} @(1.0, 2.0)",
+                "* * EmptyGesture<Void> (failed)",
+            ]
+        )
+    }
+
+    static var emptyRoot: PrintTreeCase {
+        let root = makeData(
+            kind: .empty,
+            phase: .possible(nil),
+            frame: .zero
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "(empty) ()",
+            ]
+        )
+    }
+
+    static var combinerWithSameFrameChild: PrintTreeCase {
+        let frame = CGRect(x: 1, y: 2, width: 3, height: 4)
+        let child = makeData(
+            kind: .primitive,
+            phase: .failed,
+            resetSeed: 3,
+            frame: frame
+        )
+        let root = makeData(
+            kind: .combiner,
+            children: GestureDebug.Data.Children(child),
+            phase: .possible(()),
+            resetSeed: 3,
+            frame: frame
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "+ EmptyGesture<Void> (possible(some)) reset:3 {(3.0, 4.0)} @(1.0, 2.0)",
+                "| + EmptyGesture<Void> (failed)",
+            ]
+        )
+    }
+
+    static var primitiveWithFrameDeltaChildren: PrintTreeCase {
+        let parentFrame = CGRect(x: 1, y: 2, width: 3, height: 4)
+        let sizeChangedChild = makeData(
+            kind: .primitive,
+            phase: .active(()),
+            frame: CGRect(x: 1, y: 2, width: 5, height: 6)
+        )
+        let originChangedChild = makeData(
+            kind: .modifier,
+            phase: .ended(()),
+            frame: CGRect(x: 7, y: 8, width: 3, height: 4)
+        )
+        let root = makeData(
+            kind: .primitive,
+            children: GestureDebug.Data.Children(sizeChangedChild, originChangedChild),
+            phase: .failed,
+            frame: parentFrame
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "EmptyGesture<Void> (failed) {(3.0, 4.0)} @(1.0, 2.0)",
+                "EmptyGesture<Void> (active) {(5.0, 6.0)}",
+                ".(EmptyGesture<Void>) (ended) @(7.0, 8.0)",
+            ]
+        )
+    }
+}
+
+private func makeData(
+    kind: GestureDebug.Kind = .primitive,
+    type: any Any.Type = EmptyGesture<Void>.self,
+    children: GestureDebug.Data.Children = GestureDebug.Data.Children(),
+    phase: GesturePhase<()> = .failed,
+    resetSeed: UInt32 = 0,
+    frame: CGRect = .zero,
+    properties: GestureDebug.Properties = GestureDebug.Properties()
+) -> GestureDebug.Data {
+    GestureDebug.Data(
+        kind: kind,
+        type: type,
+        children: children,
+        phase: phase,
+        attribute: nil,
+        resetSeed: resetSeed,
+        frame: frame,
+        properties: properties
+    )
+}
+
+#if !OPENSWIFTUI_SWIFT_LOG
+@MainActor
+@Suite(.disabled(if: isX86_64, "OSLogStore does not reliably return current-process log entries on x86_64 simulator."))
+struct GestureDebugLogTests {
+    // NOTE: entry.date has some range diff. So we can't use $0.date > date. Use count instead.
+    @available(iOS 15, macOS 12, *)
+    private func getLogEntries(count: Int) throws -> [String] {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let entries = try store
+            .getEntries() // NOTE: options and position are not respected consistently.
+            .lazy
+            .compactMap {
+                $0 as? OSLogEntryLog
+            }
+            .filter {
+                $0.subsystem == "com.apple.diagnostics.events" && $0.category == "OpenSwiftUI"
+            }
+            .reversed()
+            .prefix(count)
+            .reversed()
+        return Array(entries.map { $0.composedMessage })
+    }
+
+    @available(iOS 15, macOS 12, *)
+    @Test(arguments: printTreeCases)
+    func printTreeEmitsExpectedLines(_ testCase: PrintTreeCase) throws {
+        testCase.root.printTree()
+        let logs = try getLogEntries(count: testCase.expected.count)
+        #expect(logs == testCase.expected)
+    }
+
+    #if OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS
+    @available(iOS 15, macOS 12, *)
+    @Test
+    func printSubtreeEmitsOneFormattedLine() throws {
+        let parent = makeData(
+            kind: .gesture,
+            phase: .active(()),
+            resetSeed: 1,
+            frame: CGRect(x: 1, y: 2, width: 3, height: 4)
+        )
+        let child = makeData(
+            kind: .modifier,
+            phase: .ended(()),
+            resetSeed: 2,
+            frame: CGRect(x: 4, y: 5, width: 6, height: 7)
+        )
+
+        child.printSubtree(parent: parent, indent: GestureDebug.Data.Indent("* ", kind: .gesture))
+        let logs = try getLogEntries(count: 1)
+        #expect(logs == [
+            "* * .(EmptyGesture<Void>) (ended) reset:2 {(6.0, 7.0)} @(4.0, 5.0)",
+        ])
+    }
+    #endif
+}
+#endif
+
+#if OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS
+struct GestureDebugTests {
+    @Test
+    func frameDescriptionWithoutParent() {
+        #expect(
+            makeData(frame: .zero).frameDescription(relativeTo: nil) == ""
+        )
+
+        let sizeOnlyFrame = CGRect(origin: .zero, size: CGSize(width: 10, height: 20))
+        #expect(
+            makeData(frame: sizeOnlyFrame).frameDescription(relativeTo: nil) ==
+            " {\((sizeOnlyFrame.size.width, sizeOnlyFrame.size.height))}"
+        )
+
+        let originOnlyFrame = CGRect(origin: CGPoint(x: 3, y: 4), size: .zero)
+        #expect(
+            makeData(frame: originOnlyFrame).frameDescription(relativeTo: nil) ==
+            " @\((originOnlyFrame.origin.x, originOnlyFrame.origin.y))"
+        )
+
+        let fullFrame = CGRect(x: 3, y: 4, width: 10, height: 20)
+        #expect(
+            makeData(frame: fullFrame).frameDescription(relativeTo: nil) ==
+            " {\((fullFrame.size.width, fullFrame.size.height))} @\((fullFrame.origin.x, fullFrame.origin.y))"
+        )
+    }
+
+    @Test
+    func frameDescriptionRelativeToParent() {
+        let parentFrame = CGRect(x: 3, y: 4, width: 10, height: 20)
+        let parent = makeData(frame: parentFrame)
+
+        #expect(
+            makeData(frame: parentFrame).frameDescription(relativeTo: parent) == ""
+        )
+
+        let changedSizeFrame = CGRect(x: 3, y: 4, width: 11, height: 22)
+        #expect(
+            makeData(frame: changedSizeFrame).frameDescription(relativeTo: parent) ==
+            " {\((changedSizeFrame.size.width, changedSizeFrame.size.height))}"
+        )
+
+        let changedOriginFrame = CGRect(x: 5, y: 7, width: 10, height: 20)
+        #expect(
+            makeData(frame: changedOriginFrame).frameDescription(relativeTo: parent) ==
+            " @\((changedOriginFrame.origin.x, changedOriginFrame.origin.y))"
+        )
+
+        let changedFrame = CGRect(x: 5, y: 7, width: 11, height: 22)
+        #expect(
+            makeData(frame: changedFrame).frameDescription(relativeTo: parent) ==
+            " {\((changedFrame.size.width, changedFrame.size.height))} @\((changedFrame.origin.x, changedFrame.origin.y))"
+        )
+
+        #expect(
+            makeData(frame: .zero).frameDescription(relativeTo: parent) == ""
+        )
+    }
+
+    @Test
+    func indentPrefixesFollowKind() {
+        #expect(GestureDebug.Data.Indent(kind: .gesture).linePrefix == "* ")
+        #expect(GestureDebug.Data.Indent(kind: .gesture).childText == "* ")
+
+        #expect(GestureDebug.Data.Indent(kind: .combiner).linePrefix == "+ ")
+        #expect(GestureDebug.Data.Indent(kind: .combiner).childText == "| ")
+
+        #expect(GestureDebug.Data.Indent(kind: .modifier).linePrefix == "")
+        #expect(GestureDebug.Data.Indent(kind: .modifier).childText == "")
+    }
+}
+#endif

--- a/Tests/OpenSwiftUISymbolDualTests/Event/Gesture/GestureDebugDualTests.swift
+++ b/Tests/OpenSwiftUISymbolDualTests/Event/Gesture/GestureDebugDualTests.swift
@@ -1,0 +1,204 @@
+//
+//  GestureDebugDualTests.swift
+//  OpenSwiftUISymbolDualTests
+
+#if canImport(SwiftUI, _underlyingVersion: 6.5.4)
+import Foundation
+import OSLog
+@_spi(ForOpenSwiftUIOnly)
+import OpenSwiftUICore
+import Testing
+
+extension GestureDebug.Data {
+    @_silgen_name("OpenSwiftUITestStub_GestureDebugDataPrintTree")
+    func swiftUI_printTree()
+}
+
+#if arch(x86_64)
+private let isX86_64 = true
+#else
+private let isX86_64 = false
+#endif
+
+struct PrintTreeCase: @unchecked Sendable {
+    var root: GestureDebug.Data
+    var expected: [String]
+}
+
+private let printTreeCases: [PrintTreeCase] = [
+    .gestureWithModifierChild,
+    .gestureWithZeroFrameChild,
+    .emptyRoot,
+    .combinerWithSameFrameChild,
+    .primitiveWithFrameDeltaChildren,
+]
+
+private extension PrintTreeCase {
+    static var gestureWithModifierChild: PrintTreeCase {
+        var properties = GestureDebug.Properties()
+        properties.append(("trackingID", "touch#7"))
+        properties.append(("state", "active"))
+
+        let child = makeData(
+            kind: .modifier,
+            phase: .ended(()),
+            resetSeed: 2,
+            frame: CGRect(x: 4, y: 5, width: 6, height: 7),
+            properties: properties
+        )
+        let root = makeData(
+            kind: .gesture,
+            children: GestureDebug.Data.Children(child),
+            phase: .active(()),
+            resetSeed: 1,
+            frame: CGRect(x: 1, y: 2, width: 3, height: 4)
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "* EmptyGesture<Void> (active) reset:1 {(3.0, 4.0)} @(1.0, 2.0)",
+                "* * .(EmptyGesture<Void>) (ended) reset:2 {(6.0, 7.0)} @(4.0, 5.0) [trackingID: touch#7, state: active]",
+            ]
+        )
+    }
+
+    static var gestureWithZeroFrameChild: PrintTreeCase {
+        let child = makeData(
+            kind: .primitive,
+            phase: .failed,
+            frame: .zero
+        )
+        let root = makeData(
+            kind: .gesture,
+            children: GestureDebug.Data.Children(child),
+            phase: .failed,
+            frame: CGRect(x: 1, y: 2, width: 3, height: 4)
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "* EmptyGesture<Void> (failed) {(3.0, 4.0)} @(1.0, 2.0)",
+                "* * EmptyGesture<Void> (failed)",
+            ]
+        )
+    }
+
+    static var emptyRoot: PrintTreeCase {
+        let root = makeData(
+            kind: .empty,
+            phase: .possible(nil),
+            frame: .zero
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "(empty) ()",
+            ]
+        )
+    }
+
+    static var combinerWithSameFrameChild: PrintTreeCase {
+        let frame = CGRect(x: 1, y: 2, width: 3, height: 4)
+        let child = makeData(
+            kind: .primitive,
+            phase: .failed,
+            resetSeed: 3,
+            frame: frame
+        )
+        let root = makeData(
+            kind: .combiner,
+            children: GestureDebug.Data.Children(child),
+            phase: .possible(()),
+            resetSeed: 3,
+            frame: frame
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "+ EmptyGesture<Void> (possible(some)) reset:3 {(3.0, 4.0)} @(1.0, 2.0)",
+                "| + EmptyGesture<Void> (failed)",
+            ]
+        )
+    }
+
+    static var primitiveWithFrameDeltaChildren: PrintTreeCase {
+        let parentFrame = CGRect(x: 1, y: 2, width: 3, height: 4)
+        let sizeChangedChild = makeData(
+            kind: .primitive,
+            phase: .active(()),
+            frame: CGRect(x: 1, y: 2, width: 5, height: 6)
+        )
+        let originChangedChild = makeData(
+            kind: .modifier,
+            phase: .ended(()),
+            frame: CGRect(x: 7, y: 8, width: 3, height: 4)
+        )
+        let root = makeData(
+            kind: .primitive,
+            children: GestureDebug.Data.Children(sizeChangedChild, originChangedChild),
+            phase: .failed,
+            frame: parentFrame
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "EmptyGesture<Void> (failed) {(3.0, 4.0)} @(1.0, 2.0)",
+                "EmptyGesture<Void> (active) {(5.0, 6.0)}",
+                ".(EmptyGesture<Void>) (ended) @(7.0, 8.0)",
+            ]
+        )
+    }
+}
+
+private func makeData(
+    kind: GestureDebug.Kind = .primitive,
+    type: any Any.Type = EmptyGesture<Void>.self,
+    children: GestureDebug.Data.Children = GestureDebug.Data.Children(),
+    phase: GesturePhase<()> = .failed,
+    resetSeed: UInt32 = 0,
+    frame: CGRect = .zero,
+    properties: GestureDebug.Properties = GestureDebug.Properties()
+) -> GestureDebug.Data {
+    GestureDebug.Data(
+        kind: kind,
+        type: type,
+        children: children,
+        phase: phase,
+        attribute: nil,
+        resetSeed: resetSeed,
+        frame: frame,
+        properties: properties
+    )
+}
+
+@MainActor
+@Suite(.disabled(if: isX86_64, "OSLogStore does not reliably return current-process log entries on x86_64 simulator."))
+struct GestureDebugDualTests {
+    // NOTE: entry.date has some range diff. So we can't use $0.date > date. Use count instead.
+    @available(iOS 15, macOS 12, *)
+    private func getLogEntries(count: Int) throws -> [String] {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let entries = try store
+            .getEntries() // NOTE: options and position are not respected consistently.
+            .lazy
+            .compactMap {
+                $0 as? OSLogEntryLog
+            }
+            .filter {
+                $0.subsystem == "com.apple.diagnostics.events" && $0.category == "SwiftUI"
+            }
+            .reversed()
+            .prefix(count)
+            .reversed()
+        return Array(entries.map { $0.composedMessage })
+    }
+
+    @available(iOS 15, macOS 12, *)
+    @Test(arguments: printTreeCases)
+    func printTreeAcceptsOpenSwiftUIGestureDebugData(_ testCase: PrintTreeCase) throws {
+        testCase.root.swiftUI_printTree()
+        let logs = try getLogEntries(count: testCase.expected.count)
+        #expect(logs == testCase.expected)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Implement gesture view modifier responder wiring for masked view gestures, subview gesture propagation, and debug wrapping.
- Add simultaneous and high-priority gesture modifier/combiners, plus optional gesture support.
- Add public `View` gesture overloads for `GestureMask`, `isEnabled`, and named gestures with DocC.
- Add gesture debug tree formatting coverage and compatibility tests.
