### PR TITLE
Add tap gesture APIs and examples

### DIFF
--- a/Example/Shared/Event/Gesture/SpatialTapGestureExample.swift
+++ b/Example/Shared/Event/Gesture/SpatialTapGestureExample.swift
@@ -1,0 +1,27 @@
+//
+//  SpatialTapGestureExample.swift
+//  Shared
+
+#if OPENSWIFTUI
+import OpenSwiftUI
+#else
+import SwiftUI
+#endif
+
+struct SpatialTapGestureExample: View {
+    @State private var location: CGPoint = .zero
+
+    var tap: some Gesture {
+        SpatialTapGesture()
+            .onEnded { event in
+                location = event.location
+            }
+    }
+
+    var body: some View {
+        Circle()
+            .fill(location.y > 50 ? Color.blue : Color.red)
+            .frame(width: 100, height: 100, alignment: .center)
+            .gesture(tap)
+    }
+}

--- a/Example/Shared/Event/Gesture/TapGestureExample.swift
+++ b/Example/Shared/Event/Gesture/TapGestureExample.swift
@@ -1,0 +1,25 @@
+//
+//  TapGestureExample.swift
+//  Shared
+
+#if OPENSWIFTUI
+import OpenSwiftUI
+#else
+import SwiftUI
+#endif
+
+struct TapGestureExample: View {
+    let colors: [Color] = [.gray, .red, .orange, .yellow,
+                           .green, .blue, .purple, .pink]
+    @State private var fgColor: Color = .gray
+
+    var body: some View {
+        Image(systemName: "heart.fill")
+            .resizable()
+            .frame(width: 200, height: 200)
+            .foregroundColor(fgColor)
+            .onTapGesture(count: 2) {
+                fgColor = colors.randomElement()!
+            }
+    }
+}

--- a/Sources/OpenSwiftUI/Event/Gesture/SpatialTapGesture.swift
+++ b/Sources/OpenSwiftUI/Event/Gesture/SpatialTapGesture.swift
@@ -1,0 +1,125 @@
+//
+//  SpatialTapGesture.swift
+//  OpenSwiftUI
+//
+//  Audited for 6.5.4
+//  Status: Complete
+//  ID: 4CBCFA1A8492A311E8B21AE224C33BFC (SwiftUI)
+
+@_spi(ForOpenSwiftUIOnly) public import OpenSwiftUICore
+import OpenAttributeGraphShims
+
+// MARK: - SpatialTapGesture
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
+@_spi_available(tvOS, introduced: 17.0)
+public struct SpatialTapGesture: PrimitiveGesture, Gesture {
+    private struct Phase: Rule {
+        @Attribute var phase: GesturePhase<TappableSpatialEvent>
+
+        typealias Value = GesturePhase<SpatialTapGesture.Value>
+
+        var value: GesturePhase<SpatialTapGesture.Value> {
+            phase.map { event in
+                SpatialTapGesture.Value(location: event.location)
+            }
+        }
+    }
+
+    private struct Child: Rule {
+        @Attribute var gesture: SpatialTapGesture
+
+        var value: some Gesture<TappableSpatialEvent> {
+            SingleTapGesture<TappableSpatialEvent>()
+                .repeatCount(gesture.count)
+                .coordinateSpace(gesture.coordinateSpace)
+                .requiredTapCount(gesture.count)
+        }
+    }
+
+    public struct Value: Equatable, @unchecked Sendable {
+        public var location: CGPoint
+    }
+
+    public var count: Int
+
+    public var coordinateSpace: CoordinateSpace
+
+    @available(iOS, introduced: 16.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @available(macOS, introduced: 13.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @available(watchOS, introduced: 9.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @available(tvOS, unavailable)
+    @available(visionOS, introduced: 1.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @_disfavoredOverload
+    public init(count: Int = 1, coordinateSpace: CoordinateSpace = .local) {
+        self.count = count
+        self.coordinateSpace = coordinateSpace
+    }
+
+    @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+    @_spi_available(tvOS, introduced: 17.0)
+    public init(count: Int = 1, coordinateSpace: some CoordinateSpaceProtocol = .local) {
+        self.count = count
+        self.coordinateSpace = coordinateSpace.coordinateSpace
+    }
+
+    nonisolated public static func _makeGesture(
+        gesture: _GraphValue<SpatialTapGesture>,
+        inputs: _GestureInputs
+    ) -> _GestureOutputs<SpatialTapGesture.Value> {
+        let child = Attribute(Child(gesture: gesture.value))
+        let outputs = Child.Value.makeDebuggableGesture(
+            gesture: _GraphValue(child),
+            inputs: inputs
+        )
+        let phase = Attribute(Phase(phase: outputs.phase))
+        return outputs.withPhase(phase)
+    }
+
+    public typealias Body = Never
+}
+
+@available(*, unavailable)
+extension SpatialTapGesture: Sendable {}
+
+// MARK: - View + SpatialTapGesture
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
+@available(tvOS, unavailable)
+extension View {
+    @available(iOS, introduced: 16.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @available(macOS, introduced: 13.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @available(watchOS, introduced: 9.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @available(tvOS, unavailable)
+    @available(visionOS, introduced: 1.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    @_disfavoredOverload
+    nonisolated public func onTapGesture(
+        count: Int = 1,
+        coordinateSpace: CoordinateSpace = .local,
+        perform action: @escaping (CGPoint) -> Void
+    ) -> some View {
+        gesture(
+            SpatialTapGesture(count: count, coordinateSpace: coordinateSpace).onEnded { value in
+                action(value.location)
+            },
+            including: .all
+        )
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+@_spi_available(tvOS, introduced: 17.0)
+extension View {
+    nonisolated public func onTapGesture(
+        count: Int = 1,
+        coordinateSpace: some CoordinateSpaceProtocol = .local,
+        perform action: @escaping (CGPoint) -> Void
+    ) -> some View {
+        gesture(
+            SpatialTapGesture(count: count, coordinateSpace: coordinateSpace).onEnded { value in
+                action(value.location)
+            },
+            including: .all
+        )
+    }
+}

--- a/Sources/OpenSwiftUI/Event/Gesture/SpatialTapGesture.swift
+++ b/Sources/OpenSwiftUI/Event/Gesture/SpatialTapGesture.swift
@@ -11,7 +11,31 @@ import OpenAttributeGraphShims
 
 // MARK: - SpatialTapGesture
 
-@available(iOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
+/// A gesture that recognizes one or more taps and reports their location.
+///
+/// To recognize a tap gesture on a view, create and configure the gesture, and
+/// then add it to the view using the ``View/gesture(_:including:)`` modifier.
+/// The following code adds a tap gesture to a ``Circle`` that toggles the color
+/// of the circle based on the tap location:
+///
+///     struct TapGestureView: View {
+///         @State private var location: CGPoint = .zero
+///
+///         var tap: some Gesture {
+///             SpatialTapGesture()
+///                 .onEnded { event in
+///                     self.location = event.location
+///                  }
+///         }
+///
+///         var body: some View {
+///             Circle()
+///                 .fill(self.location.y > 50 ? Color.blue : Color.red)
+///                 .frame(width: 100, height: 100, alignment: .center)
+///                 .gesture(tap)
+///         }
+///     }
+@available(OpenSwiftUI_v4_0, *)
 @_spi_available(tvOS, introduced: 17.0)
 public struct SpatialTapGesture: PrimitiveGesture, Gesture {
     private struct Phase: Rule {
@@ -37,26 +61,41 @@ public struct SpatialTapGesture: PrimitiveGesture, Gesture {
         }
     }
 
+    /// The attributes of a tap gesture.
     public struct Value: Equatable, @unchecked Sendable {
+        /// The location of the tap gesture's current event.
         public var location: CGPoint
     }
 
+    /// The required number of tap events.
     public var count: Int
 
+    /// The coordinate space in which to receive location values.
     public var coordinateSpace: CoordinateSpace
 
-    @available(iOS, introduced: 16.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
-    @available(macOS, introduced: 13.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
-    @available(watchOS, introduced: 9.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    /// Creates a tap gesture with the number of required taps and the
+    /// coordinate space of the gesture's location.
+    ///
+    /// - Parameters:
+    ///   - count: The required number of taps to complete the tap
+    ///     gesture.
+    ///   - coordinateSpace: The coordinate space of the tap gesture's location.
+    @available(*, deprecated, message: "use overload that accepts a CoordinateSpaceProtocol instead")
     @available(tvOS, unavailable)
-    @available(visionOS, introduced: 1.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
     @_disfavoredOverload
     public init(count: Int = 1, coordinateSpace: CoordinateSpace = .local) {
         self.count = count
         self.coordinateSpace = coordinateSpace
     }
 
-    @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+    /// Creates a tap gesture with the number of required taps and the
+    /// coordinate space of the gesture's location.
+    ///
+    /// - Parameters:
+    ///   - count: The required number of taps to complete the tap
+    ///     gesture.
+    ///   - coordinateSpace: The coordinate space of the tap gesture's location.
+    @available(OpenSwiftUI_v5_0, *)
     @_spi_available(tvOS, introduced: 17.0)
     public init(count: Int = 1, coordinateSpace: some CoordinateSpaceProtocol = .local) {
         self.count = count
@@ -68,7 +107,7 @@ public struct SpatialTapGesture: PrimitiveGesture, Gesture {
         inputs: _GestureInputs
     ) -> _GestureOutputs<SpatialTapGesture.Value> {
         let child = Attribute(Child(gesture: gesture.value))
-        let outputs = Child.Value.makeDebuggableGesture(
+        let outputs = Child.Value._makeGesture(
             gesture: _GraphValue(child),
             inputs: inputs
         )
@@ -84,14 +123,44 @@ extension SpatialTapGesture: Sendable {}
 
 // MARK: - View + SpatialTapGesture
 
-@available(iOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
+@available(OpenSwiftUI_v4_0, *)
 @available(tvOS, unavailable)
 extension View {
-    @available(iOS, introduced: 16.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
-    @available(macOS, introduced: 13.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
-    @available(watchOS, introduced: 9.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
-    @available(tvOS, unavailable)
-    @available(visionOS, introduced: 1.0, deprecated: 100000.0, message: "use overload that accepts a CoordinateSpaceProtocol instead")
+    /// Adds an action to perform when this view recognizes a tap gesture,
+    /// and provides the action with the location of the interaction.
+    ///
+    /// Use this method to perform the specified `action` when the user clicks
+    /// or taps on the modified view `count` times. The action closure receives
+    /// the location of the interaction.
+    ///
+    /// > Note: If you create a control that's functionally equivalent
+    /// to a ``Button``, use ``ButtonStyle`` to create a customized button
+    /// instead.
+    ///
+    /// The following code adds a tap gesture to a ``Circle`` that toggles the color
+    /// of the circle based on the tap location.
+    ///
+    ///     struct TapGestureExample: View {
+    ///         @State private var location: CGPoint = .zero
+    ///
+    ///         var body: some View {
+    ///             Circle()
+    ///                 .fill(self.location.y > 50 ? Color.blue : Color.red)
+    ///                 .frame(width: 100, height: 100, alignment: .center)
+    ///                 .onTapGesture { location in
+    ///                     self.location = location
+    ///                 }
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - count: The number of taps or clicks required to trigger the action
+    ///      closure provided in `action`. Defaults to `1`.
+    ///    - coordinateSpace: The coordinate space in which to receive
+    ///      location values. Defaults to ``CoordinateSpace/local``.
+    ///    - action: The action to perform. This closure receives an input
+    ///      that indicates where the interaction occurred.
+    @available(*, deprecated, message: "use overload that accepts a CoordinateSpaceProtocol instead")
     @_disfavoredOverload
     nonisolated public func onTapGesture(
         count: Int = 1,
@@ -107,9 +176,43 @@ extension View {
     }
 }
 
-@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+@available(OpenSwiftUI_v5_0, *)
 @_spi_available(tvOS, introduced: 17.0)
 extension View {
+    /// Adds an action to perform when this view recognizes a tap gesture,
+    /// and provides the action with the location of the interaction.
+    ///
+    /// Use this method to perform the specified `action` when the user clicks
+    /// or taps on the modified view `count` times. The action closure receives
+    /// the location of the interaction.
+    ///
+    /// > Note: If you create a control that's functionally equivalent
+    /// to a ``Button``, use ``ButtonStyle`` to create a customized button
+    /// instead.
+    ///
+    /// The following code adds a tap gesture to a ``Circle`` that toggles the color
+    /// of the circle based on the tap location.
+    ///
+    ///     struct TapGestureExample: View {
+    ///         @State private var location: CGPoint = .zero
+    ///
+    ///         var body: some View {
+    ///             Circle()
+    ///                 .fill(self.location.y > 50 ? Color.blue : Color.red)
+    ///                 .frame(width: 100, height: 100, alignment: .center)
+    ///                 .onTapGesture { location in
+    ///                     self.location = location
+    ///                 }
+    ///         }
+    ///     }
+    ///
+    /// - Parameters:
+    ///    - count: The number of taps or clicks required to trigger the action
+    ///      closure provided in `action`. Defaults to `1`.
+    ///    - coordinateSpace: The coordinate space in which to receive
+    ///      location values. Defaults to ``CoordinateSpace/local``.
+    ///    - action: The action to perform. This closure receives an input
+    ///      that indicates where the interaction occurred.
     nonisolated public func onTapGesture(
         count: Int = 1,
         coordinateSpace: some CoordinateSpaceProtocol = .local,

--- a/Sources/OpenSwiftUICore/Event/Gesture/RepeatGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/RepeatGesture.swift
@@ -24,6 +24,7 @@ package struct RepeatGesture<Value>: GestureModifier {
     package var maximumDelay: Double
 
     package init(count: Int, maximumDelay: Double = 0.35) {
+        precondition(count > 0, "count must be positive")
         self.count = count
         self.maximumDelay = maximumDelay
     }

--- a/Sources/OpenSwiftUICore/Event/Gesture/TapGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/TapGesture.swift
@@ -1,0 +1,167 @@
+//
+//  TapGesture.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+//  ID: 067A6A2846A89ACCD702678B6B8D0D6F (SwiftUICore)
+
+package import Foundation
+import OpenAttributeGraphShims
+
+// MARK: - TapGesture
+
+/// A gesture that recognizes one or more taps.
+///
+/// To recognize a tap gesture on a view, create and configure the gesture, and
+/// then add it to the view using the ``View/gesture(_:including:)`` modifier.
+/// The following code adds a tap gesture to a ``Circle`` that toggles the color
+/// of the circle:
+///
+///     struct TapGestureView: View {
+///         @State private var tapped = false
+///
+///         var tap: some Gesture {
+///             TapGesture(count: 1)
+///                 .onEnded { _ in self.tapped = !self.tapped }
+///         }
+///
+///         var body: some View {
+///             Circle()
+///                 .fill(self.tapped ? Color.blue : Color.red)
+///                 .frame(width: 100, height: 100, alignment: .center)
+///                 .gesture(tap)
+///         }
+///     }
+@available(OpenSwiftUI_v1_0, *)
+public struct TapGesture: PrimitiveGesture, Gesture {
+    private struct Phase: Rule {
+        @Attribute var phase: GesturePhase<TappableEvent>
+
+        typealias Value = GesturePhase<Void>
+
+        var value: GesturePhase<Void> {
+            phase.withValue(())
+        }
+    }
+
+    private struct Child: Rule {
+        @Attribute var gesture: TapGesture
+
+        var value: some Gesture<TappableEvent> {
+            SingleTapGesture<TappableEvent>()
+                .repeatCount(gesture.count)
+                .category(gesture.count == 1 ? .select : [])
+                .requiredTapCount(gesture.count)
+        }
+    }
+
+    /// The required number of tap events.
+    public var count: Int
+
+    /// Creates a tap gesture with the number of required taps.
+    ///
+    /// - Parameter count: The required number of taps to complete the tap
+    ///   gesture.
+    public init(count: Int = 1) {
+        self.count = count
+    }
+
+    nonisolated public static func _makeGesture(
+        gesture: _GraphValue<TapGesture>,
+        inputs: _GestureInputs
+    ) -> _GestureOutputs<Void> {
+        let child = Attribute(Child(gesture: gesture.value))
+        let outputs = Child.Value.makeDebuggableGesture(
+            gesture: _GraphValue(child),
+            inputs: inputs
+        )
+        let phase = Attribute(Phase(phase: outputs.phase))
+        return outputs.withPhase(phase)
+    }
+
+    public typealias Value = Void
+}
+
+@available(*, unavailable)
+extension TapGesture: Sendable {}
+
+// MARK: - View + TapGesture
+
+@available(OpenSwiftUI_v1_0, *)
+extension View {
+    /// Adds an action to perform when this view recognizes a tap gesture.
+    ///
+    /// Use this method to perform the specified `action` when the user clicks
+    /// or taps on the view or container `count` times.
+    ///
+    /// > Note: If you create a control that's functionally equivalent
+    /// to a ``Button``, use ``ButtonStyle`` to create a customized button
+    /// instead.
+    ///
+    /// In the example below, the color of the heart images changes to a random
+    /// color from the `colors` array whenever the user clicks or taps on the
+    /// view twice:
+    ///
+    ///     struct TapGestureExample: View {
+    ///         let colors: [Color] = [.gray, .red, .orange, .yellow,
+    ///                                .green, .blue, .purple, .pink]
+    ///         @State private var fgColor: Color = .gray
+    ///
+    ///         var body: some View {
+    ///             Image(systemName: "heart.fill")
+    ///                 .resizable()
+    ///                 .frame(width: 200, height: 200)
+    ///                 .foregroundColor(fgColor)
+    ///                 .onTapGesture(count: 2) {
+    ///                     fgColor = colors.randomElement()!
+    ///                 }
+    ///         }
+    ///     }
+    ///
+    /// ![A screenshot of a view of a heart.](OpenSwiftUI-View-TapGesture.png)
+    ///
+    /// - Parameters:
+    ///    - count: The number of taps or clicks required to trigger the action
+    ///      closure provided in `action`. Defaults to `1`.
+    ///    - action: The action to perform.
+    nonisolated public func onTapGesture(
+        count: Int = 1,
+        perform action: @escaping () -> Void
+    ) -> some View {
+        gesture(
+            TapGesture(count: count).onEnded { _ in
+                action()
+            },
+            including: .all
+        )
+    }
+}
+
+// MARK: - Tap Threshold Constant
+
+package let tapMovementThreshold: CGFloat = 45
+
+package let tapDurationThreshold: CGFloat = 0.75
+
+// MARK: - SingleTapGesture
+
+package struct SingleTapGesture<BaseEvent>: Gesture where BaseEvent: TappableEventType {
+    package init() {}
+
+//    typealias Body = ModifierGesture<EventFilter<A>, ModifierGesture<Map2Gesture<A, ModifierGesture<CoordinateSpaceGesture<CGFloat>, DistanceGesture>, A>, ModifierGesture<Map2Gesture<A, ModifierGesture<DurationGesture<TappableEvent>, EventListener<TappableEvent>>, A>, ModifierGesture<(DependentGesture in _8687835E41FEE17B108D67665C1D2D0B)<A>, ModifierGesture<MapGesture<A, A>, EventListener<A>>>>>>
+
+
+    package var body: some Gesture<BaseEvent> {
+        EventListener<BaseEvent>()
+            .discrete()
+            .dependency(.failIfActive)
+            .gated(by: EventListener<TappableEvent>().duration(maximum: tapDurationThreshold))
+            .gated(by: DistanceGesture(maximumDistance: tapMovementThreshold).coordinateSpace(.global))
+            .eventFilter(forType: MouseEvent.self) { event in
+                event.button == .primary
+            }
+    }
+
+    package typealias Value = BaseEvent
+}

--- a/Sources/OpenSwiftUICore/View/Image/ImageDynamicRange.swift
+++ b/Sources/OpenSwiftUICore/View/Image/ImageDynamicRange.swift
@@ -11,7 +11,7 @@ package import Foundation
 // MARK: - Image.DynamicRange
 
 @available(OpenSwiftUI_v5_0, *)
-// @_spi_available(watchOS, introduced: 10.0)
+@_spi_available(watchOS, introduced: 10.0)
 extension Image {
     public struct DynamicRange: Hashable, Sendable {
         package enum Storage: UInt8, Hashable, Comparable {
@@ -123,7 +123,7 @@ private struct AllowedDynamicRangeKey : EnvironmentKey {
 }
 
 @available(OpenSwiftUI_v5_0, *)
-// @_spi_available(watchOS, introduced: 10.0)
+@_spi_available(watchOS, introduced: 10.0)
 extension EnvironmentValues {
     /// The allowed dynamic range for the view, or nil.
     public var allowedDynamicRange: Image.DynamicRange? {
@@ -145,7 +145,7 @@ extension EnvironmentValues {
     }
 }
 
-@available(iOS 17.0, macOS 14.0, tvOS 17.0, *)
+@available(OpenSwiftUI_v5_0, *)
 @_spi_available(watchOS, introduced: 10.0)
 extension View {
 


### PR DESCRIPTION
## Summary

- Add `TapGesture` support, including the public gesture API, tap-count handling, gesture phase mapping, and `View.onTapGesture(count:perform:)`.
- Add `SpatialTapGesture` support with coordinate-space location reporting and matching `View.onTapGesture(count:coordinateSpace:perform:)` overloads.
- Add shared examples for `TapGesture` and `SpatialTapGesture`.
- Add DocC documentation for the new gesture APIs and align availability annotations with OpenSwiftUI availability macros.

## Related

- Related to #772.
- Builds on #905.