### PR TITLE
Add underscored API documentation comments

### DIFF
--- a/Sources/OpenSwiftUI/App/Commands/Commands.swift
+++ b/Sources/OpenSwiftUI/App/Commands/Commands.swift
@@ -70,6 +70,7 @@ public protocol Commands {
         inputs: _CommandsInputs
     ) -> _CommandsOutputs
 
+    /// A function that applies `self`'s changes to the given menu.
     func _resolve(into resolved: inout _ResolvedCommands)
 }
 

--- a/Sources/OpenSwiftUI/Test/PerformanceTest.swift
+++ b/Sources/OpenSwiftUI/Test/PerformanceTest.swift
@@ -13,6 +13,7 @@ import OpenSwiftUI_SPI
 
 // MARK: - _PerformanceTest [6.4.41]
 
+/// A performance test that will be executed by PPT.
 @available(OpenSwiftUI_v1_0, *)
 public protocol _PerformanceTest: _Test {
     var name: String { get }
@@ -28,6 +29,9 @@ extension __App {
 
 @available(OpenSwiftUI_v1_0, *)
 extension _BenchmarkHost {
+    /// Notifies the `_BenchmarkHost` when you started a test
+    ///
+    /// - Parameter test: The test that was started
     public func _started(test: _PerformanceTest) {
         #if os(iOS) || os(visionOS)
         UIApplication.shared.startedTest(test.name)
@@ -37,6 +41,9 @@ extension _BenchmarkHost {
         #endif
     }
 
+    /// Notify the `_BenchmarkHost` when you finished a test
+    ///
+    /// - Parameter test: The test that was finished
     public func _finished(test: _PerformanceTest) {
         #if os(iOS) || os(visionOS)
         UIApplication.shared.finishedTest(test.name)
@@ -46,6 +53,9 @@ extension _BenchmarkHost {
         #endif
     }
 
+    /// Notify the `_BenchmarkHost` when you failed a test
+    ///
+    /// - Parameter test: The test that failed
     public func _failed(test: _PerformanceTest) {
         #if os(iOS) || os(visionOS)
         UIApplication.shared.failedTest(test.name, withFailure: nil)

--- a/Sources/OpenSwiftUICore/Animation/Animation/AnimationModifier.swift
+++ b/Sources/OpenSwiftUICore/Animation/Animation/AnimationModifier.swift
@@ -11,6 +11,7 @@ import OpenCoreGraphicsShims
 
 // MARK: - _AnimationModifier
 
+/// Concrete modifier type to apply an animation to the child view.
 @available(OpenSwiftUI_v1_0, *)
 @frozen
 public struct _AnimationModifier<Value>: ViewModifier, PrimitiveViewModifier where Value: Equatable {

--- a/Sources/OpenSwiftUICore/Animation/Transaction/Transaction.swift
+++ b/Sources/OpenSwiftUICore/Animation/Transaction/Transaction.swift
@@ -60,6 +60,7 @@ public protocol TransactionKey {
     /// The default value for the transaction key.
     static var defaultValue: Value { get }
 
+    /// Returns true if `lhs` and `rhs` are equal.
     static func _valuesEqual(_ lhs: Value, _ rhs: Value) -> Swift.Bool
 }
 

--- a/Sources/OpenSwiftUICore/Graphic/Color/ColorMatrix.swift
+++ b/Sources/OpenSwiftUICore/Graphic/Color/ColorMatrix.swift
@@ -36,6 +36,10 @@ public struct ColorMatrix: Equatable {
 
 // MARK: - _ColorMatrix
 
+/// A color matrix. The result of applying to a color is produced by
+/// multiplying the color by the square matrix formed by the first
+/// columns of the color matrix, then adding the last column to the
+/// result.
 @frozen
 public struct _ColorMatrix: Equatable, Codable {
     public var m11: Float = 1, m12: Float = 0, m13: Float = 0, m14: Float = 0, m15: Float = 0

--- a/Sources/OpenSwiftUICore/Layout/Layout.swift
+++ b/Sources/OpenSwiftUICore/Layout/Layout.swift
@@ -1527,6 +1527,7 @@ public struct LayoutSubview: Equatable {
 
     let containerLayoutDirection: LayoutDirection
 
+    /// Returns the trait value `K` associated with the subview.
     public func _trait<K>(key: K.Type) -> K.Value where K: _ViewTraitKey {
         proxy[key]
     }

--- a/Sources/OpenSwiftUICore/Layout/SafeAreaIgnoringLayout.swift
+++ b/Sources/OpenSwiftUICore/Layout/SafeAreaIgnoringLayout.swift
@@ -8,6 +8,8 @@
 import OpenAttributeGraphShims
 package import OpenCoreGraphicsShims
 
+/// A UnaryLayout which insets its child by the inverse of the safe area
+/// on the specified edges.
 @available(OpenSwiftUI_v1_0, *)
 @frozen
 public struct _SafeAreaIgnoringLayout: UnaryLayout {
@@ -49,6 +51,8 @@ public struct _SafeAreaIgnoringLayout: UnaryLayout {
 
 // MARK: - _SafeAreaRegionsIgnoringLayout
 
+/// A UnaryLayout which insets its child by the inverse of the safe area
+/// on the specified edges.
 @available(OpenSwiftUI_v2_0, *)
 @frozen
 public struct _SafeAreaRegionsIgnoringLayout: UnaryLayout {

--- a/Sources/OpenSwiftUICore/Modifier/ViewModifier/EnvironmentalModifier.swift
+++ b/Sources/OpenSwiftUICore/Modifier/ViewModifier/EnvironmentalModifier.swift
@@ -23,6 +23,11 @@ public protocol EnvironmentalModifier: ViewModifier where Body == Never {
     @available(OpenSwiftUI_v3_0, *)
     static var _requiresMainThread: Bool { get }
     
+    /// Flag to indicate whether this modifier tracks the values that are used
+    /// in the environment.
+    ///
+    /// The default is `true`. Override and return `false` for special cases
+    /// where this is undesirable.
     @available(OpenSwiftUI_v5_0, *)
     static var _tracksEnvironmentDependencies: Bool { get }
 }

--- a/Sources/OpenSwiftUICore/Render/RendererEffect/RendererEffect.swift
+++ b/Sources/OpenSwiftUICore/Render/RendererEffect/RendererEffect.swift
@@ -244,6 +244,9 @@ extension GraphicsBlendMode: RendererEffect {
 
 // MARK: - GeometryGroupEffect
 
+/// An effect that isolates the translational component of the frame
+/// rects of all content in the child view from changes in the parent
+/// view.
 @available(OpenSwiftUI_v5_0, *)
 @frozen
 public struct _GeometryGroupEffect: RendererEffect, Equatable {

--- a/Sources/OpenSwiftUICore/Shape/ShapeStyle/ShapeStyleShape.swift
+++ b/Sources/OpenSwiftUICore/Shape/ShapeStyle/ShapeStyleShape.swift
@@ -9,6 +9,7 @@ package import Foundation
 
 // MARK: - _ShapeStyle_Shape
 
+/// A shape that can have a ShapeStyle value applied to it.
 @available(OpenSwiftUI_v3_0, *)
 public struct _ShapeStyle_Shape {
     package enum Operation {

--- a/Sources/OpenSwiftUICore/Test/Benchmark.swift
+++ b/Sources/OpenSwiftUICore/Test/Benchmark.swift
@@ -21,6 +21,13 @@ public protocol _BenchmarkHost: AnyObject {
     @available(OpenSwiftUI_v3_0, *)
     func _renderAsyncForTest(interval: Double) -> Bool
 
+    /// Performs a scrolling test.
+    ///
+    /// - Parameter startOffset: the content offset to start the test from.
+    /// - Parameter iterations: the number of iterations to repeat the test.
+    /// - Parameter delta: the delta in points that the test should move each
+    /// tick of the display.
+    /// - Parameter length: the total length of each iteration in points.
     func _performScrollTest(startOffset: CGFloat, iterations: Int, delta: CGFloat, length: CGFloat, completion: (() -> Void)?)
 }
 

--- a/Sources/OpenSwiftUICore/View/Image/NamedImage.swift
+++ b/Sources/OpenSwiftUICore/View/Image/NamedImage.swift
@@ -609,6 +609,7 @@ package enum NamedImage {
 
 @available(OpenSwiftUI_v1_0, *)
 extension Image {
+    /// A way to specify where to load "main bundle" images from.
     public static var _mainNamedBundle: Bundle? { nil }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Font/ModifiedFont.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Font/ModifiedFont.swift
@@ -198,6 +198,7 @@ extension Font {
         _openSwiftUIUnimplementedFailure()
     }
 
+    /// Create a version of `self` that uses the specified stylistic set.
     public func _stylisticAlternative(_ alternative: Font._StylisticAlternative) -> Font {
         _openSwiftUIUnimplementedFailure()
     }
@@ -276,6 +277,9 @@ extension Font {
         }
     }
 
+    /// A stylistic alternative to apply to the font
+    /// The mapping of Style to a visual style is specific to the underlying
+    /// font
     public enum _StylisticAlternative: Int, Hashable {
         case one = 1
         case two = 2


### PR DESCRIPTION
## Agent Summary

Adds missing documentation comments for selected underscored public API surfaces.

The update places comments on the primary type or protocol declarations where appropriate, and avoids repeating identical comments on default implementations. It also keeps the wording aligned with OpenSwiftUI naming.

Validation:
- Ran `git diff --check`.
- Checked newly added comments for stale `SwiftUI` wording and `doc://` links.
- No build was run; this is a Swift documentation-comment-only change.