### PR TITLE
Fix UIKit trait collection change handling

### DIFF
--- a/Sources/OpenSwiftUI/Event/Event/UIKit/UIKitEventBindingBridge.swift
+++ b/Sources/OpenSwiftUI/Event/Event/UIKit/UIKitEventBindingBridge.swift
@@ -6,8 +6,15 @@
 //  Status: WIP
 
 #if os(iOS) || os(visionOS)
-// FIXME
-package class UIKitEventBindingBridge {
 
+@_spi(ForOpenSwiftUIOnly)
+import OpenSwiftUICore
+package import UIKit
+
+// FIXME
+package class UIKitEventBindingBridge: EventBindingBridge {
+    package var gestureRecognizer: UIGestureRecognizer?
+    // var hoverGestureRecognizer: UIKitHoverGestureRecognizer
+    // var keyPressResponder: UIKitKeyPressResponder?
 }
 #endif

--- a/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingView+Extension.swift
+++ b/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingView+Extension.swift
@@ -407,4 +407,14 @@ public func _makeUIHostingView<Content>(_ view: Content) -> NSObject where Conte
     _UIHostingView(rootView: view)
 }
 
+// MARK: - _UIHostingView + AnyUIHostingView
+
+extension _UIHostingView: AnyUIHostingView {
+    package var debugName: String? {
+        // TODO: UIHostingViewDebugOptions
+        _openSwiftUIUnimplementedWarning()
+        return nil
+    }
+}
+
 #endif

--- a/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingView.swift
+++ b/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingView.swift
@@ -49,8 +49,6 @@ open class _UIHostingView<Content>: UIView, XcodeViewDebugDataProvider where Con
 
     final package let renderer = DisplayList.ViewRenderer(platform: .init(definition: UIViewPlatformViewDefinition.self))
 
-    // final package let eventBindingManager: EventBindingManager
-
     var allowUIKitAnimations: Int32 = .zero
 
     var disabledBackgroundColor: Bool = false
@@ -115,7 +113,7 @@ open class _UIHostingView<Content>: UIView, XcodeViewDebugDataProvider where Con
     
     var currentEvent: UIEvent? = nil
     
-    // var eventBridge: UIKitEventBindingBridge
+    package var eventBridge: UIKitEventBindingBridge
 
     var colorScheme: ColorScheme? = nil {
         didSet {
@@ -177,6 +175,7 @@ open class _UIHostingView<Content>: UIView, XcodeViewDebugDataProvider where Con
             >.self,
             options: options
         )
+        eventBridge = UIKitEventBindingBridge(eventBindingManager: _base.eventBindingManager)
         // TODO
         if _UIUpdateAdaptiveRateNeeded() {
             _base.viewGraph.append(feature: EnableVFDFeature())
@@ -300,6 +299,10 @@ open class _UIHostingView<Content>: UIView, XcodeViewDebugDataProvider where Con
             #endif
             viewGraph.emptyTransaction(transaction)
         }
+        if traitCollection.userInterfaceIdiom != previousTraitCollection?.userInterfaceIdiom {
+            updateEventBridge()
+        }
+        invalidateProperties(.environment)
     }
 
     open override func safeAreaInsetsDidChange() {
@@ -344,7 +347,17 @@ open class _UIHostingView<Content>: UIView, XcodeViewDebugDataProvider where Con
     }
 
     // TODO
-    
+
+    func updateEventBridge() {
+        let bridge = eventBridge
+        guard traitCollection.userInterfaceIdiom == .carPlay,
+              let gestureRecognizer = bridge.gestureRecognizer
+        else {
+            return
+        }
+        gestureRecognizer.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.direct.rawValue)]
+    }
+
     func setRootView(_ view: Content, transaction: Transaction) {
         _rootView = view
         viewGraph.asyncTransaction(transaction) { [weak self] in


### PR DESCRIPTION
## Summary

- Refresh the UIKit event bridge when the hosting view's user interface idiom changes.
- Invalidate the hosting environment after trait collection changes.
- Wire `UIKitEventBindingBridge` through `AnyUIHostingView`/`EventBindingBridge` so the bridge can update CarPlay touch handling.
