### PR TITLE
Fix mismatched optional/static view aliases

### DIFF
--- a/Example/Modules/Platform/cocoa/SwiftUI_SPI.swiftinterface
+++ b/Example/Modules/Platform/cocoa/SwiftUI_SPI.swiftinterface
@@ -15,6 +15,28 @@ public class CAHostingLayer<Content> : QuartzCore.CALayer where Content : SwiftU
   }
 }
 
+public struct DisplayList : Swift.CustomStringConvertible {
+  public struct Version {}
+  public var description: Swift.String {
+    get
+  }
+}
+
+public final class ViewGraph {
+  public struct Outputs : Swift.OptionSet {
+    public let rawValue: Swift.UInt8
+    public init(rawValue: Swift.UInt8)
+    public static var displayList: ViewGraph.Outputs {
+      get
+    }
+  }
+  public init<Root>(rootViewType: Root.Type, requestedOutputs: ViewGraph.Outputs) where Root : SwiftUI.View
+  public func instantiateOutputs()
+  public func setRootView<Root>(_ view: Root) where Root : SwiftUI.View
+  public func setProposedSize(_ size: CoreGraphics.CGSize)
+  public func displayList() -> (DisplayList, DisplayList.Version)
+}
+
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *)
 extension SwiftUI.View {
   public func variableBlur(maxRadius: CoreGraphics.CGFloat, mask: SwiftUI.Image, opaque: Swift.Bool = false) -> some SwiftUI.View

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbf61ba06c70969d5e404fc5b587cedcaa2261a1ae45df2605a24a6afcc52954",
+  "originHash" : "13632f122dbb85cdf5116b25776b9d61aa9318fd2f2f321e8a38c4b885ec58c4",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "3052c4709ceb8678d107677d6b5c5d4404fcd380"
+        "revision" : "d93839821ebebdab22081fbc0f3d0b8cb0e30b2f"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -654,7 +654,9 @@ let openSwiftUITestsSupportTarget = Target.target(
     dependencies: (compatibilityTestCondition ? [] : ["OpenSwiftUI"]),
     cSettings: sharedCSettings,
     cxxSettings: sharedCxxSettings,
-    swiftSettings: sharedSwiftSettings
+    swiftSettings: sharedSwiftSettings + (compatibilityTestCondition ? [
+        .unsafeFlags(["-I", "\(Context.packageDirectory)/Example/Modules/Platform/cocoa"]),
+    ] : [])
 )
 
 let openSwiftUIExtensionTarget = Target.target(
@@ -688,7 +690,9 @@ let openSwiftUICompatibilityTestTarget = Target.testTarget(
     exclude: ["README.md"],
     cSettings: sharedCSettings,
     cxxSettings: sharedCxxSettings,
-    swiftSettings: sharedSwiftSettings
+    swiftSettings: sharedSwiftSettings + (compatibilityTestCondition ? [
+        .unsafeFlags(["-I", "\(Context.packageDirectory)/Example/Modules/Platform/cocoa"]),
+    ] : [])
 )
 
 // MARK: - OpenSwiftUIBridge Target

--- a/Sources/OpenSwiftUI/View/Configuration/ViewAlias.swift
+++ b/Sources/OpenSwiftUI/View/Configuration/ViewAlias.swift
@@ -2,7 +2,7 @@
 //  ViewAlias.swift
 //  OpenSwiftUI
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 //  ID: D9F7AF928092578A4B8FA861B49E2161 (SwiftUI)
 
@@ -24,8 +24,6 @@ import OpenAttributeGraphShims
 protocol ViewAlias: PrimitiveView {
     init()
 }
-
-// Audited for 6.5.4
 
 extension ViewAlias {
     nonisolated public static func _makeView(view: _GraphValue<Self>, inputs: _ViewInputs) -> _ViewOutputs {

--- a/Sources/OpenSwiftUI/View/Configuration/ViewAlias.swift
+++ b/Sources/OpenSwiftUI/View/Configuration/ViewAlias.swift
@@ -225,12 +225,12 @@ private struct SourceFormula<Source>: AnySourceFormula where Source: View {
             return .init()
         }
         return if source.valueIsNil == nil {
-            Optional<Source>.makeDebuggableView(
+            Source.makeDebuggableView(
                 view: _GraphValue(Attribute(identifier: attribute)),
                 inputs: inputs
             )
         } else {
-            Source.makeDebuggableView(
+            Optional<Source>.makeDebuggableView(
                 view: _GraphValue(Attribute(identifier: attribute)),
                 inputs: inputs
             )
@@ -246,12 +246,12 @@ private struct SourceFormula<Source>: AnySourceFormula where Source: View {
             return .emptyViewList(inputs: inputs)
         }
         return if source.valueIsNil == nil {
-            Optional<Source>.makeDebuggableViewList(
+            Source.makeDebuggableViewList(
                 view: _GraphValue(Attribute(identifier: attribute)),
                 inputs: inputs
             )
         } else {
-            Source.makeDebuggableViewList(
+            Optional<Source>.makeDebuggableViewList(
                 view: _GraphValue(Attribute(identifier: attribute)),
                 inputs: inputs
             )
@@ -263,9 +263,9 @@ private struct SourceFormula<Source>: AnySourceFormula where Source: View {
         inputs: _ViewListCountInputs
     ) -> Int? {
         if source.valueIsNil == nil {
-            Optional<Source>._viewListCount(inputs: inputs)
-        } else {
             Source._viewListCount(inputs: inputs)
+        } else {
+            Optional<Source>._viewListCount(inputs: inputs)
         }
     }
 }

--- a/Sources/OpenSwiftUITestsSupport/Render/DisplayListUtil.swift
+++ b/Sources/OpenSwiftUITestsSupport/Render/DisplayListUtil.swift
@@ -1,0 +1,28 @@
+//
+//  DisplayListUtil.swift
+//  OpenSwiftUITestsSupport
+
+import Foundation
+package import OpenSwiftUICore
+
+package enum DisplayListUtil {
+    package static func renderDisplayList<Content: View>(_ content: Content) -> String {
+        let graph = ViewGraph(
+            rootViewType: Content.self,
+            requestedOutputs: [.displayList]
+        )
+        graph.instantiateOutputs()
+        graph.setRootView(content)
+        graph.setProposedSize(CGSize(width: 100, height: 100))
+        let (displayList, _) = graph.displayList()
+        return displayList.description
+    }
+
+    package static func containsAnyColor(_ displayList: String) -> Bool {
+        displayList.contains("(color #")
+    }
+
+    package static func containsColor(_ color: String, in displayList: String) -> Bool {
+        displayList.contains("(color \(color))")
+    }
+}

--- a/Sources/OpenSwiftUITestsSupport/Render/DisplayListUtil.swift
+++ b/Sources/OpenSwiftUITestsSupport/Render/DisplayListUtil.swift
@@ -3,7 +3,11 @@
 //  OpenSwiftUITestsSupport
 
 import Foundation
+#if OPENSWIFTUI
 package import OpenSwiftUICore
+#else
+package import SwiftUI_SPI
+#endif
 
 package enum DisplayListUtil {
     package static func renderDisplayList<Content: View>(_ content: Content) -> String {

--- a/Tests/OpenSwiftUICompatibilityTests/Render/DisplayListUtilCompatibilityTests.swift
+++ b/Tests/OpenSwiftUICompatibilityTests/Render/DisplayListUtilCompatibilityTests.swift
@@ -1,0 +1,15 @@
+//
+//  DisplayListUtilCompatibilityTests.swift
+//  OpenSwiftUICompatibilityTests
+
+import OpenSwiftUITestsSupport
+import Testing
+
+@MainActor
+struct DisplayListUtilCompatibilityTests {
+    @Test
+    func rendersColor() {
+        let displayList = DisplayListUtil.renderDisplayList(Color.red)
+        #expect(DisplayListUtil.containsAnyColor(displayList))
+    }
+}

--- a/Tests/OpenSwiftUITests/View/Configuration/ViewAliasTests.swift
+++ b/Tests/OpenSwiftUITests/View/Configuration/ViewAliasTests.swift
@@ -14,58 +14,186 @@ import OpenSwiftUITestsSupport
 @Suite(.disabled(if: attributeGraphVendor == .oag))
 struct ViewAliasTests {
     @Test
-    func optionalViewAliasDynamicProperty() async throws {
+    func staticViewAliasUsageRendersSource() {
+        struct Alias: ViewAlias {}
+
         struct ContentView: View {
-            var confirmation: Confirmation?
-
-            @OptionalViewAlias
-            private var alias: ChildView.Alias?
-
             var body: some View {
-                ChildView(confirmation: confirmation)
-                    .viewAlias(ChildView.Alias.self) { Color.red }
-                    .onAppear {
-                        #expect(alias == nil)
-                        confirmation?()
+                Alias()
+                    .viewAlias(Alias.self) {
+                        Color.black
                     }
             }
         }
 
-        struct ChildView: View {
-            var confirmation: Confirmation?
+        let displayList = DisplayListUtil.renderDisplayList(ContentView())
+        #expect(displayList.contains(singleColorDisplayListRegex("#000000FF")))
+        #expect(DisplayListUtil.containsColor("#000000FF", in: displayList))
+    }
 
+    @Test(arguments: [true, false])
+    func optionalViewAliasUsage(sourceIsPresent: Bool) {
+        struct Alias: ViewAlias {}
+
+        struct ContentView: View {
+            var source: Color?
+
+            var body: some View {
+                Alias()
+                    .optionalViewAlias(Alias.self) {
+                        source
+                    }
+            }
+        }
+
+        let source: Color? = sourceIsPresent ? .black : nil
+        let displayList = DisplayListUtil.renderDisplayList(ContentView(source: source))
+        if sourceIsPresent {
+            #expect(displayList.contains(effectColorDisplayListRegex("#000000FF")))
+            #expect(DisplayListUtil.containsColor("#000000FF", in: displayList))
+        } else {
+            #expect(displayList.wholeMatch(of: emptyDisplayListRegex) != nil)
+            #expect(!DisplayListUtil.containsAnyColor(displayList))
+        }
+    }
+
+    @Test
+    func viewListUsageRendersStaticAndOptionalAliasSources() {
+        struct StaticAlias: ViewAlias {}
+        struct OptionalAlias: ViewAlias {}
+
+        struct StaticContentView: View {
+            var body: some View {
+                VStack {
+                    StaticAlias()
+                }
+                .viewAlias(StaticAlias.self) {
+                    Color.black
+                }
+            }
+        }
+
+        struct OptionalContentView: View {
+            var source: Color?
+
+            var body: some View {
+                VStack {
+                    OptionalAlias()
+                }
+                .optionalViewAlias(OptionalAlias.self) {
+                    source
+                }
+            }
+        }
+
+        let staticDisplayList = DisplayListUtil.renderDisplayList(StaticContentView())
+        #expect(staticDisplayList.contains(singleColorDisplayListRegex("#000000FF")))
+        #expect(DisplayListUtil.containsColor("#000000FF", in: staticDisplayList))
+
+        let optionalPresentDisplayList = DisplayListUtil.renderDisplayList(OptionalContentView(source: .black))
+        #expect(optionalPresentDisplayList.contains(effectColorDisplayListRegex("#000000FF")))
+        #expect(DisplayListUtil.containsColor("#000000FF", in: optionalPresentDisplayList))
+
+        let optionalNilDisplayList = DisplayListUtil.renderDisplayList(OptionalContentView(source: nil))
+        #expect(optionalNilDisplayList.wholeMatch(of: emptyDisplayListRegex) != nil)
+        #expect(!DisplayListUtil.containsAnyColor(optionalNilDisplayList))
+    }
+
+    @Test
+    func optionalViewAliasConsumerTracksPresentAndNilSource() {
+        struct Alias: ViewAlias {}
+
+        struct AliasReader: View {
+            @OptionalViewAlias
+            private var alias: Alias?
+
+            var body: some View {
+                if let alias {
+                    alias
+                } else {
+                    Color.white
+                }
+            }
+        }
+
+        struct ContentView: View {
+            var source: Color?
+
+            var body: some View {
+                AliasReader()
+                    .optionalViewAlias(Alias.self) {
+                        source
+                    }
+            }
+        }
+
+        let presentDisplayList = DisplayListUtil.renderDisplayList(ContentView(source: .black))
+        #expect(presentDisplayList.contains(effectColorDisplayListRegex("#000000FF")))
+        #expect(DisplayListUtil.containsColor("#000000FF", in: presentDisplayList))
+        #expect(!presentDisplayList.contains(effectColorDisplayListRegex("#FFFFFFFF")))
+        #expect(!DisplayListUtil.containsColor("#FFFFFFFF", in: presentDisplayList))
+
+        let nilDisplayList = DisplayListUtil.renderDisplayList(ContentView(source: nil))
+        #expect(nilDisplayList.contains(effectColorDisplayListRegex("#FFFFFFFF")))
+        #expect(DisplayListUtil.containsColor("#FFFFFFFF", in: nilDisplayList))
+        #expect(!nilDisplayList.contains(effectColorDisplayListRegex("#000000FF")))
+        #expect(!DisplayListUtil.containsColor("#000000FF", in: nilDisplayList))
+    }
+
+    @Test
+    func optionalViewAliasDynamicProperty() {
+        struct ContentView: View {
+            @OptionalViewAlias
+            private var alias: ChildView.Alias?
+
+            var body: some View {
+                if alias == nil {
+                    ChildView()
+                        .viewAlias(ChildView.Alias.self) { Color.black }
+                } else {
+                    Color.red
+                }
+            }
+        }
+
+        struct ChildView: View {
             struct Alias: ViewAlias {}
 
             @OptionalViewAlias
             private var alias: Alias?
 
             var body: some View {
-                Alias()
-                    .onAppear {
-                        #expect(alias != nil)
-                        confirmation?()
-                    }
+                if let alias {
+                    alias
+                } else {
+                    Color.white
+                }
             }
         }
-        #if canImport(Darwin)
-        try await triggerLayoutWithWindow(expectedCount: 2) { confirmation in
-            PlatformHostingController(
-                rootView: ContentView(
-                    confirmation: confirmation
-                )
-            )
-        }
-        #endif
-        let graph = ViewGraph(
-            rootViewType: ContentView.self,
-            requestedOutputs: [.displayList]
-        )
-        graph.instantiateOutputs()
-        graph.setRootView(ContentView())
-        graph.setProposedSize(CGSize(width: 100, height: 100))
-        let (displayList, _) = graph.displayList()
-        print(displayList.description)
-        let expectRegex = try! Regex(#"""
+
+        let displayList = DisplayListUtil.renderDisplayList(ContentView())
+        #expect(displayList.contains(effectColorDisplayListRegex("#000000FF")))
+        #expect(DisplayListUtil.containsColor("#000000FF", in: displayList))
+        #expect(!DisplayListUtil.containsColor("#FF3B30FF", in: displayList))
+        #expect(!DisplayListUtil.containsColor("#FFFFFFFF", in: displayList))
+    }
+
+    private var emptyDisplayListRegex: Regex<AnyRegexOutput> {
+        try! Regex(#"\(display-list\)"#)
+    }
+
+    private func singleColorDisplayListRegex(_ color: String) -> Regex<AnyRegexOutput> {
+        try! Regex(#"""
+        \(display-list
+          \(item #:identity \d+ #:version \d+
+            \(frame \([^)]+\)\)
+            \(content-seed \d+\)
+            \(color \#(color)\)\)\)
+        """#)
+    }
+
+    private func effectColorDisplayListRegex(_ color: String) -> Regex<AnyRegexOutput> {
+        try! Regex(#"""
         \(display-list
           \(item #:identity \d+ #:version \d+
             \(frame \([^)]+\)\)
@@ -73,8 +201,7 @@ struct ViewAliasTests {
               \(item #:identity \d+ #:version \d+
                 \(frame \([^)]+\)\)
                 \(content-seed \d+\)
-                \(color #[0-9A-F]{8}\)\)\)\)\)
+                \(color \#(color)\)\)\)\)\)
         """#)
-        #expect(displayList.description.contains(expectRegex))
     }
 }


### PR DESCRIPTION
For static view aliases, i.e. where `AnySource.valueIsNil` is itself nil (i.e. not nillable), the view type is just `Source`.
For optional view aliases, i.e. where `AnySource.valueIsNil` can be evaluated, the view type is `Optional<Source>`.