### PR TITLE
Fix Example setup on macOS system Bash

### DIFF
--- a/Example/setup.sh
+++ b/Example/setup.sh
@@ -13,6 +13,14 @@ usage() {
     "  --compute  Use mise.compute.toml while installing tools and generating the project."
 }
 
+run_mise() {
+  if [[ ${#MISE_ARGS[@]} -gt 0 ]]; then
+    mise "${MISE_ARGS[@]}" "$@"
+  else
+    mise "$@"
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --compute)
@@ -35,6 +43,6 @@ mise trust "$SCRIPT_DIR/mise.toml"
 if [[ ${#MISE_ARGS[@]} -gt 0 ]]; then
   mise trust "$SCRIPT_DIR/mise.compute.toml"
 fi
-mise "${MISE_ARGS[@]}" install
-mise "${MISE_ARGS[@]}" exec -- tuist install
-mise "${MISE_ARGS[@]}" exec -- tuist generate --no-open
+run_mise install
+run_mise exec -- tuist install
+run_mise exec -- tuist generate --no-open


### PR DESCRIPTION
Close #927

## Summary

- Add a small `run_mise` helper for `Example/setup.sh`.
- Avoid expanding an empty `MISE_ARGS` array under `set -u`, which fails on macOS system Bash 3.2.
- Preserve the existing `--compute` behavior by passing `--env compute` to the `mise` commands only when requested.

## Validation

- `/bin/bash -n Example/setup.sh`
- `bash -n Example/setup.sh`
- `shellcheck Example/setup.sh`
- Verified `/bin/bash ./setup.sh` and `/bin/bash ./setup.sh --compute` with a stubbed `mise`.