### PR TITLE
Run Compute in the UI test workflow

### DIFF
--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Force updating reference images before running UI tests'
     required: false
     default: 'false'
+  compute:
+    description: 'Generate the Example project with the Compute backend'
+    required: false
+    default: 'false'
 
 outputs:
   test-result:
@@ -43,14 +47,6 @@ runs:
         install: false
         cache: false
 
-    - name: Install Tuist
-      run: |
-        cd Example
-        mise trust mise.toml
-        mise install
-        tuist version
-      shell: bash
-
     - name: Set up build environment
       run: Scripts/CI/darwin_setup_build.sh
       shell: bash
@@ -67,8 +63,11 @@ runs:
       shell: bash
       run: |
         cd Example
-        mise exec -- tuist install
-        mise exec -- tuist generate --no-open
+        if [[ "${{ inputs.compute }}" == "true" ]]; then
+          ./setup.sh --compute
+        else
+          ./setup.sh
+        fi
 
     - name: Resolve snapshot reference directory
       id: reference

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'Example/OpenSwiftUIUITests/**'
+      - 'Example/setup.sh'
+      - 'Example/mise*.toml'
       - '.github/workflows/uitests.yml'
       - '.github/actions/uitests/action.yml'
   workflow_dispatch:

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -23,6 +23,18 @@ on:
         required: false
         default: false
         type: boolean
+      configuration:
+        description: UI test configuration set
+        required: false
+        default: default
+        type: choice
+        options:
+          - default
+          - all
+          - swiftui-renderer-ag
+          - swiftui-renderer-iag
+          - openswiftui-renderer-ag
+          - openswiftui-renderer-iag
   issue_comment:
     types: [created]
 
@@ -33,16 +45,8 @@ permissions:
   statuses: write
 
 jobs:
-  prepare_issue_comment:
-    name: Prepare issue comment UI tests
-    if: >-
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-      (
-        github.event.comment.body == '/uitest' ||
-        startsWith(github.event.comment.body, '/uitest ')
-      )
+  prepare_uitests:
+    name: Prepare UI tests
     runs-on: ubuntu-latest
     outputs:
       repository: ${{ steps.prepare.outputs.repository }}
@@ -51,17 +55,58 @@ jobs:
       macos-requested: ${{ steps.prepare.outputs.macos-requested }}
       update-reference: ${{ steps.prepare.outputs.update-reference }}
       status-enabled: ${{ steps.prepare.outputs.status-enabled }}
+      configuration-matrix: ${{ steps.prepare.outputs.configuration-matrix }}
     steps:
-      - name: Prepare PR commit statuses
+      - name: Prepare requested UI tests
         id: prepare
         uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo;
-            const pull_number = context.payload.issue.number;
-            const comment = context.payload.comment;
-            const body = comment.body.trim();
             const allowedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const configurations = {
+              "swiftui-renderer-ag": {
+                id: "swiftui-renderer-ag",
+                swiftui_renderer: 1,
+                attributegraph: 1,
+                compute: 0,
+              },
+              "swiftui-renderer-iag": {
+                id: "swiftui-renderer-iag",
+                swiftui_renderer: 1,
+                attributegraph: 0,
+                compute: 1,
+              },
+              "openswiftui-renderer-ag": {
+                id: "openswiftui-renderer-ag",
+                swiftui_renderer: 0,
+                attributegraph: 1,
+                compute: 0,
+              },
+              "openswiftui-renderer-iag": {
+                id: "openswiftui-renderer-iag",
+                swiftui_renderer: 0,
+                attributegraph: 0,
+                compute: 1,
+              },
+            };
+            const configurationAliases = {
+              "all-configs": "all",
+              "sui-ag": "swiftui-renderer-ag",
+              "sui-iag": "swiftui-renderer-iag",
+              "osui-ag": "openswiftui-renderer-ag",
+              "osui-iag": "openswiftui-renderer-iag",
+            };
+            const defaultConfigurationIds = [
+              "swiftui-renderer-ag",
+              "openswiftui-renderer-iag",
+            ];
+            const allConfigurationIds = [
+              "swiftui-renderer-ag",
+              "swiftui-renderer-iag",
+              "openswiftui-renderer-ag",
+              "openswiftui-renderer-iag",
+            ];
             const outputs = {
               repository: "",
               ref: "",
@@ -69,42 +114,116 @@ jobs:
               "macos-requested": "false",
               "update-reference": "false",
               "status-enabled": "false",
+              "configuration-matrix": JSON.stringify(defaultConfigurationIds.map((id) => configurations[id])),
             };
             const setOutputs = () => {
               for (const [name, value] of Object.entries(outputs)) {
                 core.setOutput(name, value);
               }
             };
+            const requestPlatforms = (requested) => {
+              if (requested === "all") {
+                return ["ios", "macos"];
+              }
+              if (requested === "ios" || requested === "macos") {
+                return [requested];
+              }
+              return [];
+            };
+            const requestConfigurations = (requested) => {
+              const normalized = configurationAliases[requested] ?? requested;
+              if (normalized === "default") {
+                return defaultConfigurationIds.map((id) => configurations[id]);
+              }
+              if (normalized === "all") {
+                return allConfigurationIds.map((id) => configurations[id]);
+              }
+              if (configurations[normalized]) {
+                return [configurations[normalized]];
+              }
+              return [];
+            };
+            const applyRequest = (platforms, configurationMatrix, updateRequested) => {
+              outputs["ios-requested"] = String(platforms.includes("ios"));
+              outputs["macos-requested"] = String(platforms.includes("macos"));
+              outputs["update-reference"] = String(updateRequested);
+              outputs["configuration-matrix"] = JSON.stringify(configurationMatrix);
+            };
 
+            if (context.eventName === "push") {
+              applyRequest(requestPlatforms("all"), requestConfigurations("default"), false);
+              setOutputs();
+              return;
+            }
+
+            if (context.eventName === "workflow_dispatch") {
+              const inputs = context.payload.inputs ?? {};
+              const platforms = requestPlatforms(inputs.platform ?? "all");
+              const configurationMatrix = requestConfigurations(inputs.configuration ?? "default");
+              if (platforms.length === 0 || configurationMatrix.length === 0) {
+                setOutputs();
+                return;
+              }
+              applyRequest(platforms, configurationMatrix, inputs.update_reference === "true");
+              setOutputs();
+              return;
+            }
+
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            if (
+              context.eventName !== "issue_comment" ||
+              !issue?.pull_request ||
+              !comment ||
+              !allowedAssociations.has(comment.author_association)
+            ) {
+              setOutputs();
+              return;
+            }
+
+            const body = comment.body.trim();
             const args = body.split(/\s+/);
-            if (args[0] !== "/uitest" || !allowedAssociations.has(comment.author_association)) {
+            if (args[0] !== "/uitest") {
               setOutputs();
               return;
             }
 
-            const updateRequested = args.slice(1).includes("update");
-            const platformArgs = args.slice(1).filter((arg) => arg !== "update");
-            if (platformArgs.length > 1) {
+            let updateRequested = false;
+            let requestedPlatform = "all";
+            let requestedConfiguration = "default";
+            for (const rawArg of args.slice(1)) {
+              const arg = rawArg.toLowerCase();
+              if (arg === "update") {
+                updateRequested = true;
+              } else if (arg === "ios" || arg === "macos" || arg === "all") {
+                requestedPlatform = arg;
+              } else if (arg.startsWith("config=") || arg.startsWith("configuration=")) {
+                requestedConfiguration = arg.split("=", 2)[1] || "default";
+              } else if (
+                arg === "default" ||
+                arg === "all-configs" ||
+                configurations[arg] ||
+                configurationAliases[arg]
+              ) {
+                requestedConfiguration = arg;
+              } else {
+                core.warning(`Ignoring unsupported /uitest argument: ${rawArg}`);
+                setOutputs();
+                return;
+              }
+            }
+
+            const platforms = requestPlatforms(requestedPlatform);
+            const configurationMatrix = requestConfigurations(requestedConfiguration);
+            if (platforms.length === 0 || configurationMatrix.length === 0) {
               setOutputs();
               return;
             }
 
-            const requested = platformArgs[0] ?? "all";
-            const platforms =
-              requested === "all" ? ["ios", "macos"] :
-              requested === "ios" || requested === "macos" ? [requested] :
-              [];
-            if (platforms.length === 0) {
-              setOutputs();
-              return;
-            }
-
-            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number });
+            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: issue.number });
             outputs.repository = pull.head.repo.full_name;
             outputs.ref = pull.head.sha;
-            outputs["ios-requested"] = String(platforms.includes("ios"));
-            outputs["macos-requested"] = String(platforms.includes("macos"));
-            outputs["update-reference"] = String(updateRequested);
+            applyRequest(platforms, configurationMatrix, updateRequested);
 
             const sameRepository = pull.head.repo.full_name === `${owner}/${repo}`;
             if (!sameRepository) {
@@ -115,10 +234,9 @@ jobs:
 
             outputs["status-enabled"] = "true";
             const details_url = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const renderers = ["SwiftUI Renderer", "OpenSwiftUI Renderer"];
             for (const platform of platforms) {
               const label = platform === "ios" ? "iOS" : "macOS";
-              for (const renderer of renderers) {
+              for (const configuration of configurationMatrix) {
                 const description = `Queued by @${comment.user.login} with ${body}.`.slice(0, 140);
                 await github.rest.repos.createCommitStatus({
                   owner,
@@ -127,24 +245,17 @@ jobs:
                   state: "pending",
                   target_url: details_url,
                   description,
-                  context: `UI Tests / ${label} / ${renderer}`,
+                  context: `UI Tests / ${label} / ${configuration.id}`,
                 });
               }
             }
             setOutputs();
 
   ios_uitest:
-    name: Execute UI tests on iOS (${{ matrix.renderer.name }})
-    needs: prepare_issue_comment
+    name: Execute UI tests on iOS (${{ matrix.configuration.id }})
+    needs: prepare_uitests
     if: >-
-      always() && (
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_dispatch' && contains(fromJSON('["all", "ios"]'), inputs.platform)) ||
-        (
-          github.event_name == 'issue_comment' &&
-          needs.prepare_issue_comment.outputs.ios-requested == 'true'
-        )
-      )
+      needs.prepare_uitests.outputs.ios-requested == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -152,13 +263,7 @@ jobs:
         xcode-version: ["26.3"]
         release: [2024]
         ios-version: ["18.5"]
-        renderer:
-          - name: SwiftUI Renderer
-            swiftui_renderer: 1
-            artifact_suffix: swiftui-renderer
-          - name: OpenSwiftUI Renderer
-            swiftui_renderer: 0
-            artifact_suffix: openswiftui-renderer
+        configuration: ${{ fromJSON(needs.prepare_uitests.outputs.configuration-matrix) }}
         include:
           - ios-version: "18.5"
             ios-simulator-name: "iPhone 16 Pro"
@@ -167,19 +272,20 @@ jobs:
       - self-hosted
       - ${{ matrix.os }}
     env:
-      STATUS_CONTEXT: UI Tests / iOS / ${{ matrix.renderer.name }}
-      STATUS_ENABLED: ${{ needs.prepare_issue_comment.outputs.status-enabled }}
-      STATUS_SHA: ${{ needs.prepare_issue_comment.outputs.ref }}
-      RENDERER_NAME: ${{ matrix.renderer.name }}
+      STATUS_CONTEXT: UI Tests / iOS / ${{ matrix.configuration.id }}
+      STATUS_ENABLED: ${{ needs.prepare_uitests.outputs.status-enabled }}
+      STATUS_SHA: ${{ needs.prepare_uitests.outputs.ref }}
+      CONFIGURATION_NAME: ${{ matrix.configuration.id }}
       OPENSWIFTUI_WERROR: 0 # Disable it to avoid enable OAG's werror and hit conflicts
-      OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1
+      OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: ${{ matrix.configuration.attributegraph }}
+      OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE: ${{ matrix.configuration.compute }}
       OPENSWIFTUI_COMPATIBILITY_TEST: 0
       OPENSWIFTUI_SWIFT_LOG: 0
       OPENSWIFTUI_SWIFT_CRYPTO: 0
       OPENSWIFTUI_TARGET_RELEASE: ${{ matrix.release }}
       OPENSWIFTUI_USE_LOCAL_DEPS: 1
       OPENSWIFTUI_LINK_TESTING: 0
-      OPENSWIFTUI_SWIFTUI_RENDERER: ${{ matrix.renderer.swiftui_renderer }}
+      OPENSWIFTUI_SWIFTUI_RENDERER: ${{ matrix.configuration.swiftui_renderer }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Mark PR status running
@@ -194,13 +300,13 @@ jobs:
               sha: process.env.STATUS_SHA,
               state: "pending",
               target_url: `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`,
-              description: `iOS UI tests (${process.env.RENDERER_NAME}) are running.`,
+              description: `iOS UI tests (${process.env.CONFIGURATION_NAME}) are running.`,
               context: process.env.STATUS_CONTEXT,
             });
       - uses: actions/checkout@v4
         with:
-          repository: ${{ needs.prepare_issue_comment.outputs.repository || github.repository }}
-          ref: ${{ needs.prepare_issue_comment.outputs.ref || github.sha }}
+          repository: ${{ needs.prepare_uitests.outputs.repository || github.repository }}
+          ref: ${{ needs.prepare_uitests.outputs.ref || github.sha }}
       - name: Run UI Tests
         id: run-tests
         uses: ./.github/actions/uitests
@@ -208,8 +314,9 @@ jobs:
           xcode-version: ${{ matrix.xcode-version }}
           platform: ios
           destination: "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }}"
-          artifact-name: ios-uitest-snapshots-${{ matrix.ios-version }}-${{ matrix.renderer.artifact_suffix }}
-          update-reference: ${{ (github.event_name == 'workflow_dispatch' && inputs.update_reference) || needs.prepare_issue_comment.outputs.update-reference == 'true' }}
+          artifact-name: ios-uitest-snapshots-${{ matrix.ios-version }}-${{ matrix.configuration.id }}
+          update-reference: ${{ needs.prepare_uitests.outputs.update-reference == 'true' }}
+          compute: ${{ matrix.configuration.compute == 1 }}
       - name: Fail if tests failed
         if: steps.run-tests.outputs.test-result == 'failure'
         run: exit 1
@@ -226,7 +333,7 @@ jobs:
               "failure";
             const description = process.env.JOB_STATUS === "cancelled" ?
               "iOS UI tests were cancelled." :
-              `iOS UI tests (${process.env.RENDERER_NAME}) completed with ${state}.`;
+              `iOS UI tests (${process.env.CONFIGURATION_NAME}) completed with ${state}.`;
             await github.rest.repos.createCommitStatus({
               owner,
               repo,
@@ -238,47 +345,35 @@ jobs:
             });
 
   macos_uitest:
-    name: Execute UI tests on macOS (${{ matrix.renderer.name }})
-    needs: prepare_issue_comment
+    name: Execute UI tests on macOS (${{ matrix.configuration.id }})
+    needs: prepare_uitests
     if: >-
-      always() && (
-        github.event_name == 'push' ||
-        (github.event_name == 'workflow_dispatch' && contains(fromJSON('["all", "macos"]'), inputs.platform)) ||
-        (
-          github.event_name == 'issue_comment' &&
-          needs.prepare_issue_comment.outputs.macos-requested == 'true'
-        )
-      )
+      needs.prepare_uitests.outputs.macos-requested == 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15]
         xcode-version: ["26.3"]
         release: [2024]
-        renderer:
-          - name: SwiftUI Renderer
-            swiftui_renderer: 1
-            artifact_suffix: swiftui-renderer
-          - name: OpenSwiftUI Renderer
-            swiftui_renderer: 0
-            artifact_suffix: openswiftui-renderer
+        configuration: ${{ fromJSON(needs.prepare_uitests.outputs.configuration-matrix) }}
     # Limit to self-hosted to reduce action cost
     runs-on:
       - self-hosted
       - ${{ matrix.os }}
     env:
-      STATUS_CONTEXT: UI Tests / macOS / ${{ matrix.renderer.name }}
-      STATUS_ENABLED: ${{ needs.prepare_issue_comment.outputs.status-enabled }}
-      STATUS_SHA: ${{ needs.prepare_issue_comment.outputs.ref }}
-      RENDERER_NAME: ${{ matrix.renderer.name }}
+      STATUS_CONTEXT: UI Tests / macOS / ${{ matrix.configuration.id }}
+      STATUS_ENABLED: ${{ needs.prepare_uitests.outputs.status-enabled }}
+      STATUS_SHA: ${{ needs.prepare_uitests.outputs.ref }}
+      CONFIGURATION_NAME: ${{ matrix.configuration.id }}
       OPENSWIFTUI_WERROR: 0
-      OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: 1
+      OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: ${{ matrix.configuration.attributegraph }}
+      OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE: ${{ matrix.configuration.compute }}
       OPENSWIFTUI_COMPATIBILITY_TEST: 0
       OPENSWIFTUI_SWIFT_LOG: 0
       OPENSWIFTUI_SWIFT_CRYPTO: 0
       OPENSWIFTUI_TARGET_RELEASE: ${{ matrix.release }}
       OPENSWIFTUI_USE_LOCAL_DEPS: 1
-      OPENSWIFTUI_SWIFTUI_RENDERER: ${{ matrix.renderer.swiftui_renderer }}
+      OPENSWIFTUI_SWIFTUI_RENDERER: ${{ matrix.configuration.swiftui_renderer }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Mark PR status running
@@ -293,13 +388,13 @@ jobs:
               sha: process.env.STATUS_SHA,
               state: "pending",
               target_url: `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${context.runId}`,
-              description: `macOS UI tests (${process.env.RENDERER_NAME}) are running.`,
+              description: `macOS UI tests (${process.env.CONFIGURATION_NAME}) are running.`,
               context: process.env.STATUS_CONTEXT,
             });
       - uses: actions/checkout@v4
         with:
-          repository: ${{ needs.prepare_issue_comment.outputs.repository || github.repository }}
-          ref: ${{ needs.prepare_issue_comment.outputs.ref || github.sha }}
+          repository: ${{ needs.prepare_uitests.outputs.repository || github.repository }}
+          ref: ${{ needs.prepare_uitests.outputs.ref || github.sha }}
       - name: Run UI Tests
         id: run-tests
         uses: ./.github/actions/uitests
@@ -307,8 +402,9 @@ jobs:
           xcode-version: ${{ matrix.xcode-version }}
           platform: macos
           destination: "platform=macOS"
-          artifact-name: macos-uitest-snapshots-${{ matrix.renderer.artifact_suffix }}
-          update-reference: ${{ (github.event_name == 'workflow_dispatch' && inputs.update_reference) || needs.prepare_issue_comment.outputs.update-reference == 'true' }}
+          artifact-name: macos-uitest-snapshots-${{ matrix.configuration.id }}
+          update-reference: ${{ needs.prepare_uitests.outputs.update-reference == 'true' }}
+          compute: ${{ matrix.configuration.compute == 1 }}
       - name: Fail if tests failed
         if: steps.run-tests.outputs.test-result == 'failure'
         run: exit 1
@@ -325,7 +421,7 @@ jobs:
               "failure";
             const description = process.env.JOB_STATUS === "cancelled" ?
               "macOS UI tests were cancelled." :
-              `macOS UI tests (${process.env.RENDERER_NAME}) completed with ${state}.`;
+              `macOS UI tests (${process.env.CONFIGURATION_NAME}) completed with ${state}.`;
             await github.rest.repos.createCommitStatus({
               owner,
               repo,

--- a/Docs/CI/UITest.md
+++ b/Docs/CI/UITest.md
@@ -1,0 +1,71 @@
+# UI Test CI
+
+The UI test workflow is defined in `.github/workflows/uitests.yml` and uses the shared action in `.github/actions/uitests/action.yml`.
+
+The workflow uses the same Example setup entry point as local development. Non-Compute configurations run `Example/setup.sh`, and Compute configurations run `Example/setup.sh --compute`.
+
+## Default Matrix
+
+Pushes to `main` run the default matrix on both iOS Simulator and macOS:
+
+| Configuration | Renderer | Attribute graph backend |
+| --- | --- | --- |
+| `swiftui-renderer-ag` | SwiftUI | AttributeGraph |
+| `openswiftui-renderer-iag` | OpenSwiftUI | Compute |
+
+## Manual Dispatch
+
+Manual workflow dispatch supports these inputs:
+
+- `platform`: `all`, `ios`, or `macos`.
+- `configuration`: `default`, `all`, `swiftui-renderer-ag`, `swiftui-renderer-iag`, `openswiftui-renderer-ag`, or `openswiftui-renderer-iag`.
+- `update_reference`: update CI reference images before running tests.
+
+From the GitHub CLI:
+
+```shell
+gh workflow run uitests.yml \
+  --ref main \
+  -f platform=all \
+  -f configuration=default \
+  -f update_reference=false
+```
+
+Examples:
+
+```shell
+gh workflow run uitests.yml --ref main -f platform=ios -f configuration=openswiftui-renderer-iag -f update_reference=false
+gh workflow run uitests.yml --ref main -f platform=macos -f configuration=all -f update_reference=false
+gh workflow run uitests.yml --ref main -f platform=all -f configuration=default -f update_reference=true
+```
+
+## Pull Request Comments
+
+Trusted PR commenters can request UI tests with:
+
+```text
+/uitest [platform] [configuration] [update]
+```
+
+Examples:
+
+```text
+/uitest
+/uitest ios
+/uitest macos osui-iag
+/uitest all all-configs
+/uitest ios config=openswiftui-renderer-iag
+/uitest macos update osui-ag
+```
+
+The comment command accepts `all`, `ios`, or `macos` as the platform. For configurations, it accepts the workflow configuration names above plus these aliases:
+
+| Alias | Configuration |
+| --- | --- |
+| `all-configs` | `all` |
+| `sui-ag` | `swiftui-renderer-ag` |
+| `sui-iag` | `swiftui-renderer-iag` |
+| `osui-ag` | `openswiftui-renderer-ag` |
+| `osui-iag` | `openswiftui-renderer-iag` |
+
+When the command is accepted on a same-repository PR, the workflow creates commit statuses named `UI Tests / iOS / <configuration>` and `UI Tests / macOS / <configuration>` for the requested matrix.

--- a/Example/OpenSwiftUIUITests/Animation/Animation/AnimationCompletionUITests.swift
+++ b/Example/OpenSwiftUIUITests/Animation/Animation/AnimationCompletionUITests.swift
@@ -8,6 +8,9 @@ import SnapshotTesting
 @MainActor
 @Suite(.snapshots(record: .never, diffTool: diffTool))
 struct AnimationCompletionUITests {
+    @Test(
+        .disabled(if: attributeGraphVendor == .compute, "Temporarily disabled for Compute snapshot crash. It works fine when this single test case. But it will crash when running the whole test plan"),
+    )
     func logicalAndRemovedComplete() {
         struct ContentView: AnimationTestView {
             nonisolated static var model: AnimationTestModel {

--- a/Example/OpenSwiftUIUITests/Animation/Animation/AnimationCompletionUITests.swift
+++ b/Example/OpenSwiftUIUITests/Animation/Animation/AnimationCompletionUITests.swift
@@ -8,7 +8,6 @@ import SnapshotTesting
 @MainActor
 @Suite(.snapshots(record: .never, diffTool: diffTool))
 struct AnimationCompletionUITests {
-    @Test
     func logicalAndRemovedComplete() {
         struct ContentView: AnimationTestView {
             nonisolated static var model: AnimationTestModel {

--- a/Example/OpenSwiftUIUITests/Export.swift
+++ b/Example/OpenSwiftUIUITests/Export.swift
@@ -7,6 +7,7 @@ import SnapshotTesting
 
 #if OPENSWIFTUI
 @_exported import OpenSwiftUI
+@_exported import OpenAttributeGraphShims
 let shouldRecord: SnapshotTestingConfiguration.Record? = nil
 #else
 @_exported import SwiftUI
@@ -28,6 +29,23 @@ public struct ViewRendererVendor: RawRepresentable, Hashable, CaseIterable {
     public static var allCases: [ViewRendererVendor] { [.osui, .sui] }
 }
 public let viewRendererVendor = ViewRendererVendor.sui
+
+public struct AttributeGraphVendor: RawRepresentable, Hashable, CaseIterable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    /// Apple's private AttributeGraph framework.
+    public static let ag = AttributeGraphVendor(rawValue: "com.apple.AttributeGraph")
+
+    /// An incremental computation library for Swift by @jcmosc.
+    public static let compute = AttributeGraphVendor(rawValue: "dev.incrematic.compute")
+
+    public static var allCases: [AttributeGraphVendor] { [.ag, .compute] }
+}
+public let attributeGraphVendor = AttributeGraphVendor.ag
 #endif
 let diffTool: SnapshotTestingConfiguration.DiffTool = .odiff
 

--- a/Example/OpenSwiftUIUITests/View/DynamicViewContent/ForEachUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/DynamicViewContent/ForEachUITests.swift
@@ -120,6 +120,13 @@ struct ForEachUITests {
     }
 
     @Test(
+        .disabled("Temporarily disabled for Compute snapshot crash. It works fine when this single test case. But it will crash when running the whole ForEachUITests suite for Compute on macOS") {
+            #if os(macOS)
+            attributeGraphVendor == .compute
+            #else
+            false
+            #endif
+        },
         .bug(
             "https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/655",
             id: 655

--- a/Example/OpenSwiftUIUITests/View/DynamicViewContent/ForEachUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/DynamicViewContent/ForEachUITests.swift
@@ -7,7 +7,10 @@ import SnapshotTesting
 @testable import TestingHost
 
 @MainActor
-@Suite(.snapshots(record: .never, diffTool: diffTool))
+@Suite(
+    .disabled(if: attributeGraphVendor == .compute, "Temporarily disabled for Compute snapshot crash. It will crash when running the whole test plan"),
+    .snapshots(record: .never, diffTool: diffTool),
+)
 struct ForEachUITests {
     @Test
     func offset() {
@@ -119,19 +122,7 @@ struct ForEachUITests {
         openSwiftUIAssertSnapshot(of: ContentView())
     }
 
-    @Test(
-        .disabled("Temporarily disabled for Compute snapshot crash. It works fine when this single test case. But it will crash when running the whole ForEachUITests suite for Compute on macOS") {
-            #if os(macOS)
-            attributeGraphVendor == .compute
-            #else
-            false
-            #endif
-        },
-        .bug(
-            "https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/655",
-            id: 655
-        )
-    )
+    @Test(.bug("https://github.com/OpenSwiftUIProject/OpenSwiftUI/issues/655", id: 655))
     func transitionAnimation() {
         struct ContentView: AnimationTestView {
             nonisolated static var model: AnimationTestModel {

--- a/Example/OpenSwiftUIUITests/View/LabeledContent/LabeledContentUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/LabeledContent/LabeledContentUITests.swift
@@ -6,7 +6,10 @@ import Testing
 import SnapshotTesting
 
 @MainActor
-@Suite(.snapshots(record: .never, diffTool: diffTool))
+@Suite(
+    .disabled(if: attributeGraphVendor == .compute, "Temporarily disabled for Compute snapshot stack overflow. See https://github.com/jcmosc/Compute/issues/47"),
+    .snapshots(record: .never, diffTool: diffTool)
+)
 struct LabeledContentUITests {
     @Test
     func defaultStyle() {

--- a/Example/Tuist/Package.resolved
+++ b/Example/Tuist/Package.resolved
@@ -2,6 +2,15 @@
   "originHash" : "01744f7f8b6481b6a65f9cb93b209909899b7246fd0ba73c7508a8652608fc62",
   "pins" : [
     {
+      "identity" : "compute",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenSwiftUIProject/Compute",
+      "state" : {
+        "revision" : "bf9cfe57ba8b3dc7307a95fb10a6133e70db3089",
+        "version" : "0.3.0-bugfix.1"
+      }
+    },
+    {
       "identity" : "equatable",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OpenSwiftUIProject/equatable.git",


### PR DESCRIPTION
## Summary

- Route the shared UI test action through `Example/setup.sh` so CI uses the same setup path as local runs.
- Add a Compute option for UI tests and include the OpenSwiftUI renderer + Compute configuration in the default UI test matrix.
- Keep workflow dispatch and `/uitest` flexible enough to request individual or all renderer/backend configurations.
- Add UI test access to the active attribute graph vendor and temporarily exclude known Compute-specific unstable snapshot cases.

## Why

This lets CI exercise the Compute setup path directly, so setup regressions like #927 are covered by UI tests instead of only being found locally.

## Validation

- macOS `OSUI_UITests` + Compute: passed
  - 136 total, 106 passed, 22 skipped, 8 expected failures, 0 failed
- iOS Simulator 18.5 `OSUI_UITests` + Compute: passed
  - 136 total, 112 passed, 20 skipped, 4 expected failures, 0 failed