### PR TITLE
Fix 0.19.0 iOS binary package usage

### DIFF
--- a/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingView.swift
+++ b/Sources/OpenSwiftUI/Integration/Hosting/UIKit/View/UIHostingView.swift
@@ -242,6 +242,7 @@ open class _UIHostingView<Content>: UIView, XcodeViewDebugDataProvider where Con
         base.layoutSubviews()
     }
 
+    @_spi(_)
     override dynamic open func _geometryChanged(
         _ geometry: UnsafeRawPointer,
         forAncestor ancestor: UIView?


### PR DESCRIPTION
## Summary

Fixes a 0.19.0 iOS binary package usage issue where downstream apps could fail to import OpenSwiftUI from the prebuilt XCFramework.

The UIKit geometry hook remains implemented, but is now hidden from the public Swift interface with SPI.

## Root Cause

The iOS simulator XCFramework public `.swiftinterface` exposed `_UIHostingView._geometryChanged(_:forAncestor:)` as an open UIKit override. Downstream consumers validated that declaration against UIKit's public module interface, where this selector is not declared, so importing OpenSwiftUI could fail before the app target built.

Keeping the override `open` is still required for the implementation to compile, so this change marks it as SPI instead of lowering the access level.