### PR TITLE
Record OpenSwiftUI build metadata

### DIFF
--- a/Configurations/OpenSwiftUI-Info.plist
+++ b/Configurations/OpenSwiftUI-Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © OpenSwiftUIProject. All rights reserved.</string>
+	<key>OpenSwiftUIAGBackend</key>
+	<string>$(OPENSWIFTUI_BUILD_AG_BACKEND)</string>
+	<key>OpenSwiftUIRendererBackend</key>
+	<string>$(OPENSWIFTUI_BUILD_RENDERER_BACKEND)</string>
+	<key>OpenSwiftUILibraryType</key>
+	<string>$(OPENSWIFTUI_BUILD_LIBRARY_TYPE)</string>
+	<key>OpenSwiftUIUsesLocalDependencies</key>
+	<string>$(OPENSWIFTUI_BUILD_USES_LOCAL_DEPENDENCIES)</string>
+</dict>
+</plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d2bbf3a2d49238a686e9136cd94babcc57c7796f214611bf99db0ab16bf10db6",
+  "originHash" : "dbf61ba06c70969d5e404fc5b587cedcaa2261a1ae45df2605a24a6afcc52954",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -960,11 +960,13 @@ if let configuredAGBackend = envStringValue("AG_BACKEND_NAME") {
     openSwiftUIBuildAGBackend = "OpenAttributeGraph"
 }
 let openSwiftUIBuildRendererBackend = envStringValue("RENDERER_BACKEND_NAME") ?? (swiftUIRenderCondition ? "SwiftUI" : "OpenSwiftUI")
+let openSwiftUIBuildLibraryType = configuredLibraryType ?? "automatic"
 let openSwiftUITargetSettings: SettingsDictionary = [
-    "INFOPLIST_KEY_OpenSwiftUIAGBackend": .string(openSwiftUIBuildAGBackend),
-    "INFOPLIST_KEY_OpenSwiftUIRendererBackend": .string(openSwiftUIBuildRendererBackend),
-    "INFOPLIST_KEY_OpenSwiftUILibraryType": .string(configuredLibraryType ?? "automatic"),
-    "INFOPLIST_KEY_OpenSwiftUIUsesLocalDependencies": .string(useLocalDeps ? "YES" : "NO"),
+    "INFOPLIST_FILE": .string("Configurations/OpenSwiftUI-Info.plist"),
+    "OPENSWIFTUI_BUILD_AG_BACKEND": .string(openSwiftUIBuildAGBackend),
+    "OPENSWIFTUI_BUILD_RENDERER_BACKEND": .string(openSwiftUIBuildRendererBackend),
+    "OPENSWIFTUI_BUILD_LIBRARY_TYPE": .string(openSwiftUIBuildLibraryType),
+    "OPENSWIFTUI_BUILD_USES_LOCAL_DEPENDENCIES": .string(useLocalDeps ? "YES" : "NO"),
 ]
 
 let packageSettings = PackageSettings(


### PR DESCRIPTION
## Summary
- Add an explicit OpenSwiftUI Info.plist template with build configuration metadata keys.
- Wire Tuist build settings through OPENSWIFTUI_BUILD_* substitutions.
- Refresh Package.resolved after the manifest metadata change.

## Verification
- plutil -lint Configurations/OpenSwiftUI-Info.plist
- git diff --check
- swift package resolve with the Xcode default toolchain