### PR TITLE
Update snapshot testing dependency to 1.19.3

### DIFF
--- a/Example/Example_Legacy.xcodeproj/project.pbxproj
+++ b/Example/Example_Legacy.xcodeproj/project.pbxproj
@@ -1378,7 +1378,7 @@
 			repositoryURL = "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git";
 			requirement = {
 				kind = exactVersion;
-				version = "1.19.2";
+				version = "1.19.3";
 			};
 		};
 		278EF52B2E2272F2009C32EB /* XCRemoteSwiftPackageReference "equatable" */ = {

--- a/Example/Example_Legacy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example_Legacy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e40b85245583a7bbe55d1e943345c3538a67605ef5d0beeb07825c0c5248f457",
+  "originHash" : "57d94e7c1e1ab561f6789ceb8f0f7c77a287462ba4a3d2f22ce9d741c4cae8dd",
   "pins" : [
     {
       "identity" : "equatable",
@@ -58,10 +58,10 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/OpenSwiftUIProject/swift-snapshot-testing",
+      "location" : "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "6456a4fd141fa6ae4aedfb433987038293220cfd",
-        "version" : "1.18.9-osui"
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {

--- a/Example/Example_Legacy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example_Legacy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
+        "revision" : "1bc16f430d8410e7f087d4c787767b26fd32fe30",
+        "version" : "1.19.3"
       }
     },
     {

--- a/Example/Tuist/Package.resolved
+++ b/Example/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "01744f7f8b6481b6a65f9cb93b209909899b7246fd0ba73c7508a8652608fc62",
+  "originHash" : "3b75843b30de7ae52117746121db03c09c1cef5f4217c839e9b86c5e31fc1265",
   "pins" : [
     {
       "identity" : "compute",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
-        "version" : "1.5.0"
+        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
+        "version" : "1.6.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
+        "revision" : "1bc16f430d8410e7f087d4c787767b26fd32fe30",
+        "version" : "1.19.3"
       }
     },
     {

--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -32,7 +32,7 @@ var dependencies: [PackageDescription.Package.Dependency] = [
     .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0"),
     .package(url: "https://github.com/OpenSwiftUIProject/equatable.git", branch: "main"),
     .package(url: "https://github.com/OpenSwiftUIProject/SymbolLocator.git", from: "0.2.0"),
-    .package(url: "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git", exact: "1.19.2"),
+    .package(url: "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git", exact: "1.19.3"),
 ]
 
 if enableLookInsideServer {


### PR DESCRIPTION
## Summary

- Update the Tuist and legacy Example projects to swift-snapshot-testing 1.19.3
- Refresh the checked-in package resolutions
- Align the legacy project's stale snapshot testing pin with its project requirement
- Update swift-custom-dump to the version required by SwiftPM trait resolution

## Validation

- Resolved the Tuist package graph with SwiftPM
- Resolved the legacy Xcode project using its checked-in package versions
- Validated the legacy project file and package resolution files