### PR TITLE
Fix compatibility test import flag parsing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "536952dcd1e42c1f24dcd5e8e77be318da6236302a603374019cc568ef4d3c57",
+  "originHash" : "13c69621d8a7bc34851161e1b06d0ef0e1304c504885cc1f439a9d38564c5f97",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -471,6 +471,12 @@ extension [Platform] {
 }
 
 extension [SwiftSetting] {
+    fileprivate func compatibilityTestSettings() -> Self {
+        self + (compatibilityTestCondition ? [
+            .unsafeFlags(["-I\(Context.packageDirectory)/Example/Modules/Platform/cocoa"]),
+        ] : [])
+    }
+
     /// Settings which define commonly-used OS availability macros.
     ///
     /// These leverage a pseudo-experimental feature in the Swift compiler for
@@ -655,9 +661,7 @@ let openSwiftUITestsSupportTarget = Target.target(
     dependencies: (compatibilityTestCondition ? [] : ["OpenSwiftUI"]),
     cSettings: sharedCSettings,
     cxxSettings: sharedCxxSettings,
-    swiftSettings: sharedSwiftSettings + (compatibilityTestCondition ? [
-        .unsafeFlags(["-I", "\(Context.packageDirectory)/Example/Modules/Platform/cocoa"]),
-    ] : [])
+    swiftSettings: sharedSwiftSettings.compatibilityTestSettings()
 )
 
 let openSwiftUIExtensionTarget = Target.target(
@@ -691,9 +695,7 @@ let openSwiftUICompatibilityTestTarget = Target.testTarget(
     exclude: ["README.md"],
     cSettings: sharedCSettings,
     cxxSettings: sharedCxxSettings,
-    swiftSettings: sharedSwiftSettings + (compatibilityTestCondition ? [
-        .unsafeFlags(["-I", "\(Context.packageDirectory)/Example/Modules/Platform/cocoa"]),
-    ] : [])
+    swiftSettings: sharedSwiftSettings.compatibilityTestSettings()
 )
 
 // MARK: - OpenSwiftUIBridge Target


### PR DESCRIPTION
## Summary

- Centralize SwiftUI compatibility test settings in a shared `[SwiftSetting]` helper.
- Pass the `SwiftUI_SPI` module search path as a single `-I<path>` compiler argument.
- Regenerate `Package.resolved` for the updated manifest.

## Motivation

The macOS compatibility workflow fails under Xcode 26.3 while compiling `OpenSwiftUICompatibilityTests`:

```text
error: unexpected input file: .../usr/lib/swift/host/plugins/testing
```

SwiftPM previously emitted the custom module search option as separate `-I` and path arguments. With the testing plugin options added by this toolchain, the plugin directory could be misclassified as an input file.

Passing the module search path as one argument preserves the same search behavior while avoiding the argument parsing failure. The shared helper also keeps both compatibility test targets configured consistently.