### PR TITLE
Disable SwiftSyntax prebuilts for UI tests

### DIFF
--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -222,7 +222,8 @@ runs:
 
         set -o pipefail
         record_status=0
-        NSUnbufferedIO=YES xcodebuild test \
+        # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
+        NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO test \
           -workspace Example.xcworkspace \
           -scheme SUI_UITests \
           -destination "${{ inputs.destination }}" \
@@ -275,7 +276,8 @@ runs:
         echo "artifact_dir=$uitest_tmp/artifacts" >> "$GITHUB_OUTPUT"
         echo "xcresult_archive=$uitest_tmp/${{ inputs.artifact-name }}.xcresult.zip" >> "$GITHUB_OUTPUT"
         set -o pipefail
-        NSUnbufferedIO=YES xcodebuild test \
+        # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
+        NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO test \
           -workspace Example.xcworkspace \
           -scheme OSUI_UITests \
           -destination "${{ inputs.destination }}" \


### PR DESCRIPTION
## Summary

- disable SwiftSyntax package prebuilts for both UI test `xcodebuild` invocations
- apply the workaround consistently across iOS and macOS UI test jobs
- document that Swift 6.3 fixes the issue so the workaround can be removed after the Xcode 26.6 upgrade

## Context

Swift 6.2 can select SwiftSyntax macro prebuilts that cause architecture or duplicate-link failures in UI test builds. Passing `-IDEPackageEnablePrebuilts=NO` keeps both baseline recording and OpenSwiftUI UI tests on the same temporary workaround.

## Validation

- parsed `.github/actions/uitests/action.yml` as YAML
- ran `git diff --check`
