### PR TITLE
Update SwiftSyntax to 603.0.2

### DIFF
--- a/Example/Tuist/Package.resolved
+++ b/Example/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b75843b30de7ae52117746121db03c09c1cef5f4217c839e9b86c5e31fc1265",
+  "originHash" : "ee286270d6801deb55932ce0284217d2bb8c6af5df688799e2ec977426804b04",
   "pins" : [
     {
       "identity" : "compute",
@@ -16,7 +16,7 @@
       "location" : "https://github.com/openswiftuiproject/equatable",
       "state" : {
         "branch" : "main",
-        "revision" : "8f1dccead65d97173ed695c6c1ba9d0570d35619"
+        "revision" : "c50e4f72fdd163a43738dfd4d92bf62c2531f367"
       }
     },
     {
@@ -34,7 +34,7 @@
       "location" : "https://github.com/openswiftuiproject/openobservation",
       "state" : {
         "branch" : "main",
-        "revision" : "05e0581e76b7153338836469320a4789fd0257e2"
+        "revision" : "51c52f318eb3278b1eaa8b724f50d1af9f9f8bae"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -29,7 +29,7 @@ var dependencies: [PackageDescription.Package.Dependency] = [
     .package(path: "../../../DarwinPrivateFrameworks"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     .package(url: "https://github.com/apple/swift-numerics", from: "1.0.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
     .package(url: "https://github.com/OpenSwiftUIProject/equatable.git", branch: "main"),
     .package(url: "https://github.com/OpenSwiftUIProject/SymbolLocator.git", from: "0.2.0"),
     .package(url: "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git", exact: "1.19.3"),

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9ee38d6f53b74893089a214e320ca61727938f544556a98e447376e3d3f9f15e",
+  "originHash" : "3e4458027d5c69453bb80f8dc4daa2b61492d2a6ab8cd796cdeaeaf0fcf7423b",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",
@@ -34,7 +34,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/OpenObservation",
       "state" : {
         "branch" : "main",
-        "revision" : "05e0581e76b7153338836469320a4789fd0257e2"
+        "revision" : "51c52f318eb3278b1eaa8b724f50d1af9f9f8bae"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -778,7 +778,7 @@ let package = Package(
     products: products,
     dependencies: [
         .package(url: "https://github.com/apple/swift-numerics", from: "1.0.3"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
     ],
     targets: [
         openSwiftUISPITarget,

--- a/Renderer/Stdout/Tuist/Package.swift
+++ b/Renderer/Stdout/Tuist/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .package(url: "https://github.com/OpenSwiftUIProject/SymbolLocator.git", from: "0.2.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-numerics", from: "1.0.3"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
     ]
 )
 


### PR DESCRIPTION
## Summary

- update the SwiftSyntax dependency requirement to the 603 release series
- resolve SwiftSyntax at 603.0.2
- refresh the OpenObservation and Equatable revisions to versions compatible with SwiftSyntax 603
- update the root, example, and renderer package configurations consistently

## Motivation

SwiftSyntax 603 includes updated macro plugin termination handling that prevents repeated corrupted JSON diagnostics during builds with newer Swift toolchains.

The OpenObservation and Equatable revisions are updated together so the complete dependency graph can resolve SwiftSyntax 603 without conflicting version requirements.

## Validation

- validated the root, example, and renderer package manifests
- completed a Linux build with Swift 6.2.4 and SwiftSyntax 603
- confirmed the complete build log contained no `Internal Error`, `Corrupted JSON`, or `unexpected end of file` diagnostics