### PR TITLE
Complete AccessibilityText implementation

### DIFF
--- a/Sources/OpenSwiftUICore/View/Text/Accessibility/Text+Accessibility.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Accessibility/Text+Accessibility.swift
@@ -3,7 +3,7 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: WIP
+//  Status: Complete
 //  ID: 96A6D9E0D6EA43C386EBC45EDA3A548B (SwiftUICore)
 
 package import Foundation
@@ -106,20 +106,15 @@ package struct AccessibilityText: Equatable {
     }
 
     package init(_ string: Any) {
-        #if canImport(Darwin)
-        let object = string as AnyObject
-        if object.isKind(of: NSAttributedString.self) {
-            self.storage = .attributed(object as! NSAttributedString)
+        if let attributedString = string as? NSAttributedString {
+            self.storage = .attributed(attributedString)
             self.optional = false
-        } else if let string = object as? String {
+        } else if let string = string as? String {
             self.storage = .plain(string)
             self.optional = false
         } else {
             preconditionFailure("not a string type")
         }
-        #else
-        _openSwiftUIPlatformUnimplementedFailure()
-        #endif
     }
 
     package var text: Text {
@@ -155,15 +150,36 @@ final package class AccessibilityTextStorage: AnyTextStorage, @unchecked Sendabl
     }
 }
 
-// MARK: - AccessibilityText + Protobuf [WIP]
+// MARK: - AccessibilityText + Protobuf
 
 extension AccessibilityText: ProtobufMessage {
     package func encode(to encoder: inout ProtobufEncoder) throws {
-        _openSwiftUIUnimplementedFailure()
+        switch storage {
+        case let .plain(string):
+            try encoder.stringField(1, string)
+        case let .attributed(attributedString):
+            try encoder.messageField(2, CodableAttributedString(attributedString))
+        }
+        encoder.boolField(3, optional)
     }
 
     package init(from decoder: inout ProtobufDecoder) throws {
-        _openSwiftUIUnimplementedFailure()
+        var storage: Storage = .plain("")
+        var optional = false
+        while let field = try decoder.nextField() {
+            switch field.tag {
+            case 1:
+                storage = .plain(try decoder.stringField(field))
+            case 2:
+                let attributedString: CodableAttributedString = try decoder.messageField(field)
+                storage = .attributed(attributedString.base)
+            case 3:
+                optional = try decoder.boolField(field)
+            default:
+                try decoder.skipField(field)
+            }
+        }
+        self.init(storage: storage, optional: optional)
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/Accessibility/Text+Accessibility.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Accessibility/Text+Accessibility.swift
@@ -3,7 +3,7 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: Blocked by Text.Style
+//  Status: WIP
 //  ID: 96A6D9E0D6EA43C386EBC45EDA3A548B (SwiftUICore)
 
 package import Foundation
@@ -206,7 +206,7 @@ package struct AccessibilityTextAttributes: Equatable {
     }
 }
 
-// MARK: - AccessibilityTextModifier [WIP]
+// MARK: - AccessibilityTextModifier
 
 final package class AccessibilityTextModifier: AnyTextModifier {
     package let value: AccessibilityTextAttributes
@@ -220,7 +220,11 @@ final package class AccessibilityTextModifier: AnyTextModifier {
     }
 
     override func modify(style: inout Text.Style, environment: EnvironmentValues) {
-        // TODO: Text.Style
+        if let accessibility = style.accessibility {
+            style.accessibility = value.combined(with: accessibility)
+        } else {
+            style.accessibility = value
+        }
     }
 
     override func isEqual(to other: AnyTextModifier) -> Bool {

--- a/Sources/OpenSwiftUISymbolDualTestsSupport/View/Text/Accessibility/AccessibilityTextTestsStub.c
+++ b/Sources/OpenSwiftUISymbolDualTestsSupport/View/Text/Accessibility/AccessibilityTextTestsStub.c
@@ -1,0 +1,14 @@
+//
+//  AccessibilityTextTestsStub.c
+//  OpenSwiftUISymbolDualTestsSupport
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+#import <SymbolLocator.h>
+
+// AccessibilityText
+DEFINE_SL_STUB_SLF(OpenSwiftUITestStub_AccessibilityTextEncode, SwiftUICore, $s7SwiftUI17AccessibilityTextV6encode2toyAA15ProtobufEncoderVz_tKF);
+DEFINE_SL_STUB_SLF(OpenSwiftUITestStub_AccessibilityTextDecode, SwiftUICore, $s7SwiftUI17AccessibilityTextV4fromAcA15ProtobufDecoderVz_tKcfC);
+
+#endif

--- a/Tests/OpenSwiftUISymbolDualTests/View/Text/Accessibility/AccessibilityTextDualTests.swift
+++ b/Tests/OpenSwiftUISymbolDualTests/View/Text/Accessibility/AccessibilityTextDualTests.swift
@@ -1,0 +1,71 @@
+//
+//  AccessibilityTextDualTests.swift
+//  OpenSwiftUISymbolDualTests
+
+#if canImport(SwiftUI, _underlyingVersion: 6.5.4)
+import Foundation
+@testable import OpenSwiftUICore
+import OpenSwiftUITestsSupport
+import Testing
+
+// MARK: - @_silgen_name declarations
+
+extension AccessibilityText {
+    @_silgen_name("OpenSwiftUITestStub_AccessibilityTextEncode")
+    func swiftUI_encode(to encoder: inout ProtobufEncoder) throws
+
+    @_silgen_name("OpenSwiftUITestStub_AccessibilityTextDecode")
+    init(swiftUI_from decoder: inout ProtobufDecoder) throws
+}
+
+// MARK: - AccessibilityText Dual Tests
+
+@Suite
+struct AccessibilityTextDualTests {
+    @Test(
+        arguments: [
+            // Both fields hold their default value, so nothing is emitted.
+            ("empty", AccessibilityText(storage: .plain(""), optional: false), "", nil),
+            // 0a = (1 << 3) | .lengthDelimited, 02 = length, 6869 = "hi"
+            ("plain", AccessibilityText(storage: .plain("hi"), optional: false), "0a026869", nil),
+            // 18 = (3 << 3) | .varint
+            ("optional", AccessibilityText(storage: .plain(""), optional: true), "1801", nil),
+            ("plainOptional", AccessibilityText(storage: .plain("hi"), optional: true), "0a0268691801", nil),
+            // 20 = (4 << 3) | .varint, an unknown field that must be skipped.
+            ("unknownField", AccessibilityText(storage: .plain("hi"), optional: false), "0a026869", "0a0268692001"),
+        ] as [(String, AccessibilityText, String, String?)]
+    )
+    func pbMessage(
+        label: String,
+        value: AccessibilityText,
+        hexString: String,
+        decodingHexString: String?
+    ) throws {
+        try value.testPBEncoding(hexString: hexString)
+        try value.testPBEncoding(swiftUI_hexString: hexString)
+        try value.testPBDecoding(hexString: decodingHexString ?? hexString)
+        try value.testPBDecoding(swiftUI_hexString: decodingHexString ?? hexString)
+    }
+}
+
+// MARK: - SwiftUI Dual Test Helpers
+
+extension AccessibilityText {
+    func testPBEncoding(swiftUI_hexString expectedHexString: String) throws {
+        let data = try ProtobufEncoder.encoding { encoder in
+            try swiftUI_encode(to: &encoder)
+        }
+        #expect(data.hexString == expectedHexString)
+    }
+
+    func testPBDecoding(swiftUI_hexString hexString: String) throws {
+        guard let data = Data(hexString: hexString) else {
+            throw ProtobufDecoder.DecodingError.failed
+        }
+        var decoder = ProtobufDecoder(data)
+        let decoded = try AccessibilityText(swiftUI_from: &decoder)
+        #expect(decoded == self)
+    }
+}
+
+#endif


### PR DESCRIPTION
Fills in the remaining unimplemented parts of `Text+Accessibility.swift`.

## Changes

- Implement `AccessibilityTextModifier.modify(style:environment:)`, merging the
  modifier's attributes into `Text.Style`. When `Text.Style` already carries
  accessibility attributes, they are combined per field, and the attributes
  already present take precedence over the modifier's own values.
- Implement `AccessibilityText: ProtobufMessage`. `.plain` encodes as field 1,
  `.attributed` as field 2 wrapped in `CodableAttributedString`, and `optional`
  as field 3. The decoder dispatches on tag and skips unknown fields.
- Make `AccessibilityText.init(_:)` cross-platform. The Objective-C
  `isKind(of:)` check is replaced with a conditional cast to
  `NSAttributedString`, removing the Darwin-only branch and the
  `_openSwiftUIPlatformUnimplementedFailure()` fallback. This also drops the
  `as AnyObject` bridge and a force cast; subclasses such as
  `NSMutableAttributedString` still match.

The file is promoted from `Status: WIP` to `Status: Complete`.

## Tests

Adds `AccessibilityTextDualTests`, covering the wire format against
`SwiftUICore` for plain/optional combinations, the default-value skips for the
empty string and `false`, and unknown field skipping.
