### PR TITLE
Enable Tuist Xcode caching and build insights in CI

### DIFF
--- a/.github/actions/build-xcframework/action.yml
+++ b/.github/actions/build-xcframework/action.yml
@@ -57,11 +57,11 @@ runs:
       with:
         install: false
         cache: false
-    - name: Install Tuist
+    - name: Set up Tuist
       run: |
-        mise trust mise.toml
-        mise install
-        tuist version
+        source Scripts/Tuist/common.sh
+        tuist_ci_setup
+        mise exec -- tuist version
       shell: bash
     - name: Set up build environment
       run: Scripts/CI/darwin_setup_build.sh

--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -59,6 +59,12 @@ runs:
           echo "OPENSWIFTUI_EXAMPLE_LOOKIN_SERVER=0"
         } >> "$GITHUB_ENV"
 
+    - name: Set up Tuist
+      shell: bash
+      run: |
+        source Scripts/Tuist/common.sh
+        tuist_ci_setup
+
     - name: Generate Example project
       shell: bash
       run: |
@@ -165,6 +171,7 @@ runs:
       continue-on-error: true
       shell: bash
       run: |
+        source Scripts/Tuist/common.sh
         cd Example
         snapshot_reference_platform_dir="${{ steps.reference.outputs.platform-directory }}"
         snapshot_reference_dir="${{ steps.reference.outputs.directory }}"
@@ -222,8 +229,9 @@ runs:
 
         set -o pipefail
         record_status=0
+        baseline_result_bundle="${RUNNER_TEMP:-/tmp}/swiftui-baseline-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ inputs.artifact-name }}.xcresult"
         # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
-        NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO test \
+        NSUnbufferedIO=YES tuist_xcodebuild "$baseline_result_bundle" test -IDEPackageEnablePrebuilts=NO \
           -workspace Example.xcworkspace \
           -scheme SUI_UITests \
           -destination "${{ inputs.destination }}" \
@@ -250,9 +258,11 @@ runs:
       run: |
         lockfile="${{ steps.record-baseline.outputs.lockfile }}"
         lock_owner="${{ steps.record-baseline.outputs.lock-owner }}"
+        baseline_result_bundle="${RUNNER_TEMP:-/tmp}/swiftui-baseline-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ inputs.artifact-name }}.xcresult"
         if [[ -n "$lockfile" ]] && [[ -f "$lockfile" ]] && [[ "$(cat "$lockfile" 2>/dev/null || true)" == "$lock_owner" ]]; then
           rm -f "$lockfile"
         fi
+        rm -rf "$baseline_result_bundle"
 
     - name: Fail if baseline recording failed
       if: steps.record-baseline.outcome == 'failure'
@@ -264,6 +274,7 @@ runs:
       continue-on-error: true
       shell: bash
       run: |
+        source Scripts/Tuist/common.sh
         cd Example
         uitest_tmp="${RUNNER_TEMP:-/tmp}/uitests-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ inputs.artifact-name }}"
         rm -rf "$uitest_tmp"
@@ -277,14 +288,13 @@ runs:
         echo "xcresult_archive=$uitest_tmp/${{ inputs.artifact-name }}.xcresult.zip" >> "$GITHUB_OUTPUT"
         set -o pipefail
         # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
-        NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO test \
+        NSUnbufferedIO=YES tuist_xcodebuild "$result_bundle" test -IDEPackageEnablePrebuilts=NO \
           -workspace Example.xcworkspace \
           -scheme OSUI_UITests \
           -destination "${{ inputs.destination }}" \
           -skipMacroValidation \
           -skipPackagePluginValidation \
           -derivedDataPath "${{ steps.build-directory.outputs.derived-data-path }}" \
-          -resultBundlePath "$result_bundle" \
           2>&1 | tee "$test_log"
 
     - name: Collect failed snapshots

--- a/.github/workflows/build_xcframework.yml
+++ b/.github/workflows/build_xcframework.yml
@@ -3,6 +3,10 @@ name: Build XCFramework
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_xcframework:
     name: Build XCFrameworks

--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -63,6 +63,9 @@ jobs:
           OPENSWIFTUI_COMPATIBILITY_TEST: 1
   compatibility_tests_ios:
     name: Execute compatibility tests for iOS
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -93,6 +96,16 @@ jobs:
         uses: OpenSwiftUIProject/setup-xcode@v2
         with:
           xcode-version: ${{ matrix.xcode-version }}
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+          cache: false
+      - name: Set up Tuist
+        run: |
+          source Scripts/Tuist/common.sh
+          tuist_ci_setup
+        shell: bash
       - name: Set up build environment
         run: Scripts/CI/darwin_setup_build.sh
         shell: bash
@@ -103,18 +116,25 @@ jobs:
         run: |
           openswiftui_derived_data_path="${RUNNER_TEMP:-/tmp}/compatibility-ios-derived-data-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ matrix.ios-version }}-${{ matrix.release }}-openswiftui"
           swiftui_derived_data_path="${RUNNER_TEMP:-/tmp}/compatibility-ios-derived-data-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ matrix.ios-version }}-${{ matrix.release }}-swiftui"
+          openswiftui_result_bundle_path="${RUNNER_TEMP:-/tmp}/compatibility-ios-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ matrix.ios-version }}-${{ matrix.release }}-openswiftui.xcresult"
+          swiftui_result_bundle_path="${RUNNER_TEMP:-/tmp}/compatibility-ios-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ matrix.ios-version }}-${{ matrix.release }}-swiftui.xcresult"
           rm -rf "$openswiftui_derived_data_path" "$swiftui_derived_data_path"
           mkdir -p "$openswiftui_derived_data_path" "$swiftui_derived_data_path"
-          echo "OPENSWIFTUI_DERIVED_DATA_PATH=$openswiftui_derived_data_path" >> "$GITHUB_ENV"
-          echo "SWIFTUI_DERIVED_DATA_PATH=$swiftui_derived_data_path" >> "$GITHUB_ENV"
+          {
+            echo "OPENSWIFTUI_DERIVED_DATA_PATH=$openswiftui_derived_data_path"
+            echo "SWIFTUI_DERIVED_DATA_PATH=$swiftui_derived_data_path"
+            echo "OPENSWIFTUI_RESULT_BUNDLE_PATH=$openswiftui_result_bundle_path"
+            echo "SWIFTUI_RESULT_BUNDLE_PATH=$swiftui_result_bundle_path"
+          } >> "$GITHUB_ENV"
       - name: Run compatibility tests on OpenSwiftUI + iOS
         run: |
           set -o pipefail
+          source Scripts/Tuist/common.sh
           # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
           # Xcode 26.3 + iOS 18.5 fails to launch arm64 SwiftPM package test
           # runners with CoreSimulator codesigning errors; force the x86_64
           # simulator slice until that launch path is fixed.
-          NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO test \
+          NSUnbufferedIO=YES tuist_xcodebuild "$OPENSWIFTUI_RESULT_BUNDLE_PATH" test -IDEPackageEnablePrebuilts=NO \
             -scheme OpenSwiftUI \
             -configuration Debug \
             -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }},arch=x86_64" \
@@ -129,10 +149,11 @@ jobs:
       - name: Run compatibility tests on SwiftUI + iOS
         run: |
           set -o pipefail
+          source Scripts/Tuist/common.sh
           # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
           # See the OpenSwiftUI iOS compatibility step above: force x86_64 to
           # avoid the arm64 package test runner launch/codesigning failure.
-          NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO test \
+          NSUnbufferedIO=YES tuist_xcodebuild "$SWIFTUI_RESULT_BUNDLE_PATH" test -IDEPackageEnablePrebuilts=NO \
             -scheme OpenSwiftUI \
             -configuration Debug \
             -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }},arch=x86_64" \
@@ -153,4 +174,10 @@ jobs:
           fi
           if [[ -n "${SWIFTUI_DERIVED_DATA_PATH:-}" ]]; then
             rm -rf "$SWIFTUI_DERIVED_DATA_PATH"
+          fi
+          if [[ -n "${OPENSWIFTUI_RESULT_BUNDLE_PATH:-}" ]]; then
+            rm -rf "$OPENSWIFTUI_RESULT_BUNDLE_PATH"
+          fi
+          if [[ -n "${SWIFTUI_RESULT_BUNDLE_PATH:-}" ]]; then
+            rm -rf "$SWIFTUI_RESULT_BUNDLE_PATH"
           fi

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   ios_test:
     name: Execute tests on iOS
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -42,6 +45,16 @@ jobs:
         uses: OpenSwiftUIProject/setup-xcode@v2
         with:
           xcode-version: ${{ matrix.xcode-version }}
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+          cache: false
+      - name: Set up Tuist
+        run: |
+          source Scripts/Tuist/common.sh
+          tuist_ci_setup
+        shell: bash
       - name: Set up build environment
         run: Scripts/CI/darwin_setup_build.sh
         shell: bash
@@ -51,18 +64,25 @@ jobs:
         shell: bash
         run: |
           derived_data_path="${RUNNER_TEMP:-/tmp}/ios-derived-data-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ matrix.ios-version }}-${{ matrix.release }}"
+          build_result_bundle_path="${RUNNER_TEMP:-/tmp}/ios-build-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ matrix.ios-version }}-${{ matrix.release }}.xcresult"
+          test_result_bundle_path="${RUNNER_TEMP:-/tmp}/ios-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-0}-${{ matrix.ios-version }}-${{ matrix.release }}.xcresult"
           rm -rf "$derived_data_path"
           mkdir -p "$derived_data_path"
-          echo "DERIVED_DATA_PATH=$derived_data_path" >> "$GITHUB_ENV"
+          {
+            echo "DERIVED_DATA_PATH=$derived_data_path"
+            echo "BUILD_RESULT_BUNDLE_PATH=$build_result_bundle_path"
+            echo "TEST_RESULT_BUNDLE_PATH=$test_result_bundle_path"
+          } >> "$GITHUB_ENV"
       - name: Build test target in debug mode
         run: |
           set -o pipefail
+          source Scripts/Tuist/common.sh
           # Xcode 26.3 + iOS 18.5 fails to launch arm64 SwiftPM package test
           # runners with CoreSimulator codesigning errors. Build the x86_64
           # simulator slice to match the test command below until that is fixed.
           # Swift 6.2 macro prebuilts do not support the x86_64 simulator
           # testable macro target, so build SwiftSyntax from source instead.
-          NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO build \
+          NSUnbufferedIO=YES tuist_xcodebuild "$BUILD_RESULT_BUNDLE_PATH" build -IDEPackageEnablePrebuilts=NO \
             -scheme OpenSwiftUI \
             -configuration Debug \
             -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }},arch=x86_64" \
@@ -74,9 +94,10 @@ jobs:
       - name: Run test target in debug mode
         run: |
           set -o pipefail
+          source Scripts/Tuist/common.sh
           # See the build step above: force x86_64 to avoid the arm64 package
           # test runner launch/codesigning failure on this Xcode/iOS pair.
-          NSUnbufferedIO=YES xcodebuild -IDEPackageEnablePrebuilts=NO test \
+          NSUnbufferedIO=YES tuist_xcodebuild "$TEST_RESULT_BUNDLE_PATH" test -IDEPackageEnablePrebuilts=NO \
             -scheme OpenSwiftUI \
             -configuration Debug \
             -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=${{ matrix.ios-simulator-name }},arch=x86_64" \
@@ -91,4 +112,10 @@ jobs:
         run: |
           if [[ -n "${DERIVED_DATA_PATH:-}" ]]; then
             rm -rf "$DERIVED_DATA_PATH"
+          fi
+          if [[ -n "${BUILD_RESULT_BUNDLE_PATH:-}" ]]; then
+            rm -rf "$BUILD_RESULT_BUNDLE_PATH"
+          fi
+          if [[ -n "${TEST_RESULT_BUNDLE_PATH:-}" ]]; then
+            rm -rf "$TEST_RESULT_BUNDLE_PATH"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build-xcframeworks:

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -256,6 +256,12 @@ jobs:
   ios_uitest:
     name: Execute UI tests on iOS (${{ matrix.configuration.id }})
     needs: prepare_uitests
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      statuses: write
+      id-token: write
     if: >-
       needs.prepare_uitests.outputs.ios-requested == 'true'
     strategy:
@@ -349,6 +355,12 @@ jobs:
   macos_uitest:
     name: Execute UI tests on macOS (${{ matrix.configuration.id }})
     needs: prepare_uitests
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      statuses: write
+      id-token: write
     if: >-
       needs.prepare_uitests.outputs.macos-requested == 'true'
     strategy:

--- a/Example/Tuist.swift
+++ b/Example/Tuist.swift
@@ -1,8 +1,13 @@
 import ProjectDescription
 
 let tuist = Tuist(
+    fullHandle: "OpenSwiftUIProject/openswiftui",
+    xcodeCache: .xcodeCache(
+        upload: Environment.isCI
+    ),
     project: .tuist(
         generationOptions: .options(
+            enableCaching: Environment.isCI,
             manifestEnvironment: [
                 "DARWINPRIVATEFRAMEWORKS_*",
                 "OPENATTRIBUTEGRAPH_*",

--- a/Scripts/Tuist/common.sh
+++ b/Scripts/Tuist/common.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+TUIST_REPOSITORY_ROOT="$(
+    cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1
+    pwd -P
+)"
+TUIST_CACHE_SOCKET_PATH="${TUIST_CACHE_SOCKET_PATH:-${XDG_STATE_HOME:-$HOME/.local/state}/tuist/OpenSwiftUIProject_openswiftui.sock}"
+
+tuist_cache_service_is_ready() {
+    [[ -S "$TUIST_CACHE_SOCKET_PATH" ]] || return 1
+
+    if command -v lsof >/dev/null 2>&1; then
+        lsof "$TUIST_CACHE_SOCKET_PATH" >/dev/null 2>&1
+    fi
+}
+
+tuist_wait_for_cache_service() {
+    local attempt
+    for ((attempt = 0; attempt < 40; attempt++)); do
+        if tuist_cache_service_is_ready; then
+            return 0
+        fi
+        sleep 0.25
+    done
+
+    echo "Tuist cache service is not listening at $TUIST_CACHE_SOCKET_PATH." >&2
+    echo "If Tuist reported a different socket, set TUIST_CACHE_SOCKET_PATH to that path." >&2
+    return 69
+}
+
+tuist_ci_setup() (
+    set -e
+
+    cd "$TUIST_REPOSITORY_ROOT"
+    mise trust mise.toml
+    mise install
+    mise exec -- tuist auth login
+    mise exec -- tuist setup cache --path "$TUIST_REPOSITORY_ROOT"
+    tuist_wait_for_cache_service
+)
+
+tuist_xcodebuild() (
+    set -e
+
+    if [[ $# -lt 2 ]]; then
+        echo "Usage: tuist_xcodebuild <result-bundle.xcresult> <action> [arguments ...]" >&2
+        return 64
+    fi
+
+    local result_bundle_path="$1"
+    local action="$2"
+    shift 2
+
+    if [[ -z "$result_bundle_path" || "$result_bundle_path" != *.xcresult ]]; then
+        echo "Tuist result bundle path must end in .xcresult: $result_bundle_path" >&2
+        return 64
+    fi
+
+    if [[ "$result_bundle_path" != /* ]]; then
+        result_bundle_path="$PWD/$result_bundle_path"
+    fi
+
+    local cache_settings=()
+    if tuist_cache_service_is_ready; then
+        cache_settings=(
+            COMPILATION_CACHE_ENABLE_CACHING=YES
+            "COMPILATION_CACHE_REMOTE_SERVICE_PATH=$TUIST_CACHE_SOCKET_PATH"
+            COMPILATION_CACHE_ENABLE_PLUGIN=YES
+            COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES
+        )
+    elif [[ -n "${CI:-}" ]]; then
+        echo "Tuist cache service is unavailable at $TUIST_CACHE_SOCKET_PATH." >&2
+        return 69
+    else
+        echo "Tuist cache service is unavailable; building without compilation caching." >&2
+        echo "Run 'mise exec -- tuist setup cache' to enable it locally." >&2
+        cache_settings=(
+            COMPILATION_CACHE_ENABLE_CACHING=NO
+            COMPILATION_CACHE_ENABLE_PLUGIN=NO
+        )
+    fi
+
+    rm -rf "$result_bundle_path"
+    mise exec -- tuist xcodebuild "$action" \
+        -resultBundlePath "$result_bundle_path" \
+        "$@" \
+        "${cache_settings[@]}"
+)

--- a/Scripts/build_xcframework.sh
+++ b/Scripts/build_xcframework.sh
@@ -12,6 +12,8 @@ export OPENSWIFTUI_SWIFTUI_RENDERER
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+source "$SCRIPT_DIR/Tuist/common.sh"
+
 cd "$PROJECT_ROOT"
 
 PROJECT_BUILD_DIR="${PROJECT_BUILD_DIR:-"${PROJECT_ROOT}/build"}"
@@ -394,6 +396,7 @@ prebuild_compute_framework() {
 
     local archive_path
     archive_path="$(compute_archive_path "$sdk")"
+    local result_bundle_path="$archive_path.xcresult"
 
     local project_path
     project_path="$(compute_project_path)"
@@ -426,7 +429,7 @@ prebuild_compute_framework() {
         xcodebuild_args+=("ARCHS=${archs//,/ }")
     fi
 
-    xcodebuild "${xcodebuild_args[@]}"
+    tuist_xcodebuild "$result_bundle_path" "${xcodebuild_args[@]}"
 
     local framework
     framework="$(framework_path "$archive_path" "Compute")"
@@ -443,6 +446,7 @@ build_framework() {
     local archs="$4"
 
     local archive_path="$PROJECT_BUILD_DIR/$scheme-$sdk.xcarchive"
+    local result_bundle_path="$archive_path.xcresult"
     local project_args
     read -r -a project_args <<<"$(project_args_for_scheme "$scheme")"
 
@@ -481,7 +485,7 @@ build_framework() {
         xcodebuild_args+=("FRAMEWORK_SEARCH_PATHS=${framework_search_paths[*]} \$(inherited)")
     fi
 
-    xcodebuild "${xcodebuild_args[@]}"
+    tuist_xcodebuild "$result_bundle_path" "${xcodebuild_args[@]}"
 
     local framework
     framework="$(framework_path "$archive_path" "$scheme")"

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -1,8 +1,13 @@
 import ProjectDescription
 
 let tuist = Tuist(
+    fullHandle: "OpenSwiftUIProject/openswiftui",
+    xcodeCache: .xcodeCache(
+        upload: Environment.isCI
+    ),
     project: .tuist(
         generationOptions: .options(
+            enableCaching: Environment.isCI,
             manifestEnvironment: [
                 "OPENSWIFTUI_*",
             ]

--- a/mise.compute.toml
+++ b/mise.compute.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.203.0"
+tuist = "4.203.1"
 
 [env]
 TUIST_USE_SWIFTERPM=1

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.203.0"
+tuist = "4.203.1"
 
 [env]
 TUIST_USE_SWIFTERPM=1


### PR DESCRIPTION
## Summary

- update the Tuist toolchain to 4.203.1
- configure the root and Example projects for Xcode compilation caching with uploads limited to CI
- authenticate Xcode-driven CI jobs through GitHub OIDC and initialize the Tuist cache service
- report XCFramework archives, iOS builds, compatibility tests, and UI tests through `tuist xcodebuild` result bundles
- centralize Tuist setup, cache health checks, and local fallback behavior in a shared script

## Motivation

Reuse compilation outputs across CI runs and publish build timing and cache-effectiveness data to Tuist without making local builds depend on an available cache daemon.