### PR TITLE
Implement Text.Style.nsAttributes attribute resolution

### DIFF
--- a/Sources/OpenSwiftUICore/Accessibility/AccessibilityAnnouncementPriority.swift
+++ b/Sources/OpenSwiftUICore/Accessibility/AccessibilityAnnouncementPriority.swift
@@ -65,6 +65,15 @@ package struct AccessibilitySpeechAttributes: Equatable {
         self.phoneticRepresentation = phoneticRepresentation
     }
 
+    package init(in environment: EnvironmentValues) {
+        self.init(
+            alwaysIncludesPunctuation: environment.speechAlwaysIncludesPunctuation,
+            spellsOutCharacters: environment.speechSpellsOutCharacters,
+            adjustedPitch: environment.speechAdjustedPitch,
+            announcementsPriority: environment.speechAnnouncementsPriority
+        )
+    }
+
     package func applyTo(environment: inout EnvironmentValues) {
         environment.speechAlwaysIncludesPunctuation = alwaysIncludesPunctuation
         environment.speechSpellsOutCharacters = spellsOutCharacters
@@ -91,6 +100,17 @@ extension Text.Style {
         environment: EnvironmentValues,
         includeDefaultAttributes: Bool = true
     ) {
-        _openSwiftUIUnimplementedFailure()
+        let speechAttributes = AccessibilitySpeechAttributes(
+            alwaysIncludesPunctuation: speech?.alwaysIncludesPunctuation ?? environment.speechAlwaysIncludesPunctuation,
+            spellsOutCharacters: speech?.spellsOutCharacters ?? environment.speechSpellsOutCharacters,
+            adjustedPitch: speech?.adjustedPitch ?? environment.speechAdjustedPitch,
+            announcementsPriority: speech?.announcementsPriority ?? environment.speechAnnouncementsPriority
+        )
+        AccessibilityCore.resolveAccessibilitySpeechAttributes(
+            into: &attributes,
+            speechAttr: speechAttributes,
+            environment: environment,
+            includeDefaultAttributes: includeDefaultAttributes
+        )
     }
 }

--- a/Sources/OpenSwiftUICore/Shim/ColorNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/ColorNonDarwinShims.swift
@@ -6,7 +6,7 @@
 package import Foundation
 
 /// A CGColor replacement in non-Darwin platform.
-final package class NDColor: NSObject {
+final package class NDColor: CFCompatObject {
     package let red: CGFloat
 
     package let green: CGFloat
@@ -20,6 +20,24 @@ final package class NDColor: NSObject {
         self.green = green
         self.blue = blue
         self.alpha = alpha
+        super.init()
+    }
+
+    package override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? NDColor else { return false }
+        return other.red == red
+            && other.green == green
+            && other.blue == blue
+            && other.alpha == alpha
+    }
+
+    package override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(red)
+        hasher.combine(green)
+        hasher.combine(blue)
+        hasher.combine(alpha)
+        return hasher.finalize()
     }
 }
 

--- a/Sources/OpenSwiftUICore/Shim/ColorNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/ColorNonDarwinShims.swift
@@ -1,0 +1,41 @@
+//
+//  ColorNonDarwinShims.swift
+//  OpenSwiftUICore
+
+#if !canImport(CoreGraphics)
+package import Foundation
+
+/// A CGColor replacement in non-Darwin platform.
+final package class NDColor: NSObject {
+    package let red: CGFloat
+
+    package let green: CGFloat
+
+    package let blue: CGFloat
+
+    package let alpha: CGFloat
+
+    package init(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.alpha = alpha
+    }
+}
+
+extension Color.Resolved {
+    private static let cache: ObjectCache<Color.Resolved, NSObject> = ObjectCache { resolved in
+        NDColor(
+            red: CGFloat(resolved.red),
+            green: CGFloat(resolved.green),
+            blue: CGFloat(resolved.blue),
+            alpha: CGFloat(resolved.opacity)
+        )
+    }
+
+    package var kitColor: NSObject {
+        Self.cache[self]
+    }
+}
+
+#endif

--- a/Sources/OpenSwiftUICore/Shim/CoreFoundationNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/CoreFoundationNonDarwinShims.swift
@@ -4,6 +4,7 @@
 
 #if canImport(CoreFoundation) && !canImport(ObjectiveC)
 public import CoreFoundation
+public import Foundation
 
 extension CFDictionary: @retroactive Swift.Hashable {
     public static func == (lhs: CFDictionary, rhs: CFDictionary) -> Bool {
@@ -12,6 +13,50 @@ extension CFDictionary: @retroactive Swift.Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(CFHash(self))
+    }
+}
+
+private let cfCompatObjectClassName = strdup("OpenSwiftUICFCompatObject")!
+
+private nonisolated(unsafe) var cfCompatObjectClass = CFRuntimeClass(
+    version: 0,
+    className: UnsafePointer(cfCompatObjectClassName),
+    init: nil,
+    copy: nil,
+    finalize: nil,
+    equal: { lhs, rhs in (lhs as? NSObject)?.isEqual(rhs) ?? false },
+    hash: { value in CFHashCode(bitPattern: (value as? NSObject)?.hash ?? 0) },
+    copyFormattingDesc: nil,
+    copyDebugDesc: nil,
+    reclaim: nil,
+    refcount: nil,
+    requiredAlignment: 0
+)
+
+private let cfCompatObjectTypeID: CFTypeID = withUnsafePointer(to: &cfCompatObjectClass) {
+    _CFRuntimeRegisterClass($0)
+}
+
+/// A base class for shim types that are stored as CoreFoundation values, such as
+/// `NSAttributedString` attribute values.
+///
+/// Without an ObjC runtime, CoreFoundation identifies an object by reading the
+/// `_cfinfoa` field of `CFRuntimeBase`, which in the Swift layout sits directly after
+/// the isa and the refcount — the same offset as the first stored property of a Swift
+/// `NSObject` subclass. Reading an unrelated property as `_cfinfoa` usually yields the
+/// type ID `_kCFRuntimeIDNotAType`, whose `equal` callback is `HALT`.
+///
+/// Declaring the `_cfinfoa` storage first and stamping it with a registered type ID makes
+/// the object a valid CoreFoundation instance, so `CFEqual` and `CFHash` route back to
+/// `isEqual(_:)` and `hash`.
+open class CFCompatObject: NSObject {
+    /// Overlays `CFRuntimeBase._cfinfoa` and must stay the first stored property of the
+    /// class hierarchy.
+    private var _cfinfoa: UInt64 = 0
+
+    public override init() {
+        super.init()
+        _cfinfoa = UInt64(cfCompatObjectTypeID) << 8
     }
 }
 #endif

--- a/Sources/OpenSwiftUICore/Shim/FontNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/FontNonDarwinShims.swift
@@ -6,8 +6,8 @@
 public import Foundation
 
 // Placeholder for CoreText when not available.
-public class CTFontDescriptor: NSObject {}
+public class CTFontDescriptor: CFCompatObject {}
 
-public class CTFont: NSObject {}
+public class CTFont: CFCompatObject {}
 
 #endif

--- a/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
@@ -197,6 +197,22 @@ extension NSMutableAttributedString {
     }
 }
 
+let NSTextEncapsulationAttributeName: NSAttributedString.Key = .init("NSTextEncapsulation")
+
+package class NSTextEncapsulation: NSObject {
+    package var scale: NSTextEncapsulationScale = .medium
+    package var shape: NSTextEncapsulationShape = .roundedRectangle
+    package var style: NSTextEncapsulationStyle = .outline
+    package var platterSize: NSTextEncapsulationPlatterSize = .regular
+    package var lineWeight: CGFloat = .zero
+    package var color: NSObject?
+    package var minimumWidth: CGFloat = .zero
+
+    package func setPlatformColor(_ platformColor: NSObject?) {
+        color = platformColor
+    }
+}
+
 package class NSTextLineFragment: NSObject {
     package init(attributedString: NSAttributedString, range: NSRange) {
         self.attributedString = attributedString

--- a/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
@@ -31,6 +31,13 @@ package enum NSLineBreakMode: Int {
     case byTruncatingMiddle
 }
 
+package enum NSTextHorizontalAlignment: Int {
+    case natural = 0
+    case left = 2
+    case right = 3
+    case center = 4
+}
+
 package class NSParagraphStyle: NSObject {
     fileprivate var _compositionLanguage: NSCompositionLanguage = .unset
     fileprivate var _fullyJustified = false

--- a/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
@@ -38,11 +38,36 @@ package enum NSTextHorizontalAlignment: Int {
     case center = 4
 }
 
+package struct NSLineBreakStrategy: OptionSet {
+    package let rawValue: UInt
+
+    package init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+
+    package static let pushOut = NSLineBreakStrategy(rawValue: 1 << 0)
+
+    package static let hangulWordPriority = NSLineBreakStrategy(rawValue: 1 << 1)
+
+    package static let standard = NSLineBreakStrategy(rawValue: 0xFFFF)
+}
+
 package class NSParagraphStyle: NSObject {
     fileprivate var _compositionLanguage: NSCompositionLanguage = .unset
     fileprivate var _fullyJustified = false
+    fileprivate var _spansAllLines = false
     fileprivate var _baseWritingDirection: NSWritingDirection = .natural
+    fileprivate var _horizontalAlignment: NSTextHorizontalAlignment = .natural
     fileprivate var _lineBreakMode: NSLineBreakMode = .byWordWrapping
+    fileprivate var _secondaryLineBreakMode: NSLineBreakMode = .byWordWrapping
+    fileprivate var _lineBreakStrategy: NSLineBreakStrategy = []
+    fileprivate var _lineSpacing: CGFloat = .zero
+    fileprivate var _lineHeightMultiple: CGFloat = .zero
+    fileprivate var _maximumLineHeight: CGFloat = .zero
+    fileprivate var _minimumLineHeight: CGFloat = .zero
+    fileprivate var _firstLineHeadIndent: CGFloat = .zero
+    fileprivate var _hyphenationFactor: Float = .zero
+    fileprivate var _allowsDefaultTighteningForTruncation = false
 }
 
 extension NSParagraphStyle {
@@ -56,14 +81,69 @@ extension NSParagraphStyle {
         set { _fullyJustified = newValue }
     }
 
+    package var spansAllLines: Bool {
+        get { _spansAllLines }
+        set { _spansAllLines = newValue }
+    }
+
     package var baseWritingDirection: NSWritingDirection {
         get { _baseWritingDirection }
         set { _baseWritingDirection = newValue }
     }
 
+    package var horizontalAlignment: NSTextHorizontalAlignment {
+        get { _horizontalAlignment }
+        set { _horizontalAlignment = newValue }
+    }
+
     package var lineBreakMode: NSLineBreakMode {
         get { _lineBreakMode }
         set { _lineBreakMode = newValue }
+    }
+
+    package var secondaryLineBreakMode: NSLineBreakMode {
+        get { _secondaryLineBreakMode }
+        set { _secondaryLineBreakMode = newValue }
+    }
+
+    package var lineBreakStrategy: NSLineBreakStrategy {
+        get { _lineBreakStrategy }
+        set { _lineBreakStrategy = newValue }
+    }
+
+    package var lineSpacing: CGFloat {
+        get { _lineSpacing }
+        set { _lineSpacing = newValue }
+    }
+
+    package var lineHeightMultiple: CGFloat {
+        get { _lineHeightMultiple }
+        set { _lineHeightMultiple = newValue }
+    }
+
+    package var maximumLineHeight: CGFloat {
+        get { _maximumLineHeight }
+        set { _maximumLineHeight = newValue }
+    }
+
+    package var minimumLineHeight: CGFloat {
+        get { _minimumLineHeight }
+        set { _minimumLineHeight = newValue }
+    }
+
+    package var firstLineHeadIndent: CGFloat {
+        get { _firstLineHeadIndent }
+        set { _firstLineHeadIndent = newValue }
+    }
+
+    package var hyphenationFactor: Float {
+        get { _hyphenationFactor }
+        set { _hyphenationFactor = newValue }
+    }
+
+    package var allowsDefaultTighteningForTruncation: Bool {
+        get { _allowsDefaultTighteningForTruncation }
+        set { _allowsDefaultTighteningForTruncation = newValue }
     }
 }
 

--- a/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
@@ -52,7 +52,7 @@ package struct NSLineBreakStrategy: OptionSet {
     package static let standard = NSLineBreakStrategy(rawValue: 0xFFFF)
 }
 
-package class NSParagraphStyle: NSObject {
+package class NSParagraphStyle: NSObject, NSCopying, NSMutableCopying {
     fileprivate var _compositionLanguage: NSCompositionLanguage = .unset
     fileprivate var _fullyJustified = false
     fileprivate var _spansAllLines = false
@@ -68,6 +68,36 @@ package class NSParagraphStyle: NSObject {
     fileprivate var _firstLineHeadIndent: CGFloat = .zero
     fileprivate var _hyphenationFactor: Float = .zero
     fileprivate var _allowsDefaultTighteningForTruncation = false
+
+    fileprivate func copyProperties(from other: NSParagraphStyle) {
+        _compositionLanguage = other._compositionLanguage
+        _fullyJustified = other._fullyJustified
+        _spansAllLines = other._spansAllLines
+        _baseWritingDirection = other._baseWritingDirection
+        _horizontalAlignment = other._horizontalAlignment
+        _lineBreakMode = other._lineBreakMode
+        _secondaryLineBreakMode = other._secondaryLineBreakMode
+        _lineBreakStrategy = other._lineBreakStrategy
+        _lineSpacing = other._lineSpacing
+        _lineHeightMultiple = other._lineHeightMultiple
+        _maximumLineHeight = other._maximumLineHeight
+        _minimumLineHeight = other._minimumLineHeight
+        _firstLineHeadIndent = other._firstLineHeadIndent
+        _hyphenationFactor = other._hyphenationFactor
+        _allowsDefaultTighteningForTruncation = other._allowsDefaultTighteningForTruncation
+    }
+
+    package func copy(with zone: NSZone? = nil) -> Any {
+        let style = NSParagraphStyle()
+        style.copyProperties(from: self)
+        return style
+    }
+
+    package func mutableCopy(with zone: NSZone? = nil) -> Any {
+        let style = NSMutableParagraphStyle()
+        style.copyProperties(from: self)
+        return style
+    }
 }
 
 extension NSParagraphStyle {

--- a/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
+++ b/Sources/OpenSwiftUICore/Shim/TextNonDarwinShims.swift
@@ -52,7 +52,7 @@ package struct NSLineBreakStrategy: OptionSet {
     package static let standard = NSLineBreakStrategy(rawValue: 0xFFFF)
 }
 
-package class NSParagraphStyle: NSObject, NSCopying, NSMutableCopying {
+package class NSParagraphStyle: CFCompatObject, NSCopying, NSMutableCopying {
     fileprivate var _compositionLanguage: NSCompositionLanguage = .unset
     fileprivate var _fullyJustified = false
     fileprivate var _spansAllLines = false
@@ -97,6 +97,45 @@ package class NSParagraphStyle: NSObject, NSCopying, NSMutableCopying {
         let style = NSMutableParagraphStyle()
         style.copyProperties(from: self)
         return style
+    }
+
+    package override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? NSParagraphStyle else { return false }
+        return _compositionLanguage == other._compositionLanguage
+            && _fullyJustified == other._fullyJustified
+            && _spansAllLines == other._spansAllLines
+            && _baseWritingDirection == other._baseWritingDirection
+            && _horizontalAlignment == other._horizontalAlignment
+            && _lineBreakMode == other._lineBreakMode
+            && _secondaryLineBreakMode == other._secondaryLineBreakMode
+            && _lineBreakStrategy == other._lineBreakStrategy
+            && _lineSpacing == other._lineSpacing
+            && _lineHeightMultiple == other._lineHeightMultiple
+            && _maximumLineHeight == other._maximumLineHeight
+            && _minimumLineHeight == other._minimumLineHeight
+            && _firstLineHeadIndent == other._firstLineHeadIndent
+            && _hyphenationFactor == other._hyphenationFactor
+            && _allowsDefaultTighteningForTruncation == other._allowsDefaultTighteningForTruncation
+    }
+
+    package override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(_compositionLanguage)
+        hasher.combine(_fullyJustified)
+        hasher.combine(_spansAllLines)
+        hasher.combine(_baseWritingDirection)
+        hasher.combine(_horizontalAlignment)
+        hasher.combine(_lineBreakMode)
+        hasher.combine(_secondaryLineBreakMode)
+        hasher.combine(_lineBreakStrategy.rawValue)
+        hasher.combine(_lineSpacing)
+        hasher.combine(_lineHeightMultiple)
+        hasher.combine(_maximumLineHeight)
+        hasher.combine(_minimumLineHeight)
+        hasher.combine(_firstLineHeadIndent)
+        hasher.combine(_hyphenationFactor)
+        hasher.combine(_allowsDefaultTighteningForTruncation)
+        return hasher.finalize()
     }
 }
 
@@ -179,8 +218,8 @@ extension NSParagraphStyle {
 
 package class NSMutableParagraphStyle: NSParagraphStyle {}
 
-package class NSTextAttachment: NSObject {
-    override init() {
+package class NSTextAttachment: CFCompatObject {
+    package override init() {
         super.init()
     }
 
@@ -199,7 +238,7 @@ extension NSMutableAttributedString {
 
 let NSTextEncapsulationAttributeName: NSAttributedString.Key = .init("NSTextEncapsulation")
 
-package class NSTextEncapsulation: NSObject {
+package class NSTextEncapsulation: CFCompatObject {
     package var scale: NSTextEncapsulationScale = .medium
     package var shape: NSTextEncapsulationShape = .roundedRectangle
     package var style: NSTextEncapsulationStyle = .outline
@@ -213,10 +252,11 @@ package class NSTextEncapsulation: NSObject {
     }
 }
 
-package class NSTextLineFragment: NSObject {
+package class NSTextLineFragment: CFCompatObject {
     package init(attributedString: NSAttributedString, range: NSRange) {
         self.attributedString = attributedString
         self.range = range
+        super.init()
     }
 
     private(set) package var attributedString: NSAttributedString

--- a/Sources/OpenSwiftUICore/Util/Extension/NSAttributedString+Extension.swift
+++ b/Sources/OpenSwiftUICore/Util/Extension/NSAttributedString+Extension.swift
@@ -1,0 +1,97 @@
+//
+//  NSAttributedString+Extension.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+package import Foundation
+package import UIFoundation_Private
+
+// MARK: - NSAttributedString + Extension
+
+extension NSAttributedString {
+    package var range: NSRange {
+        NSRange(location: 0, length: length)
+    }
+
+    package func firstAttribute<T>(_ type: T.Type, name: NSAttributedString.Key) -> T? {
+        var result: T?
+        enumerateAttribute(name, in: range) { value, _, stop in
+            guard let value = value as? T else {
+                return
+            }
+            result = value
+            stop.pointee = true
+        }
+        return result
+    }
+}
+
+extension NSAttributedString {
+    package func replacingLineBreakModes(_ newMode: NSLineBreakMode) -> NSAttributedString {
+        var result: NSMutableAttributedString?
+        enumerateAttribute(.kitParagraphStyle, in: range) { value, range, _ in
+            guard let style = value as? NSParagraphStyle,
+                  style.lineBreakMode != newMode
+            else {
+                return
+            }
+            let newStyle = style.mutableCopy() as! NSMutableParagraphStyle
+            newStyle.lineBreakMode = newMode
+            if result == nil {
+                result = mutableCopy() as? NSMutableAttributedString
+            }
+            guard let result else {
+                return
+            }
+            result.addAttribute(.kitParagraphStyle, value: newStyle, range: range)
+        }
+        return result ?? self
+    }
+}
+
+// MARK: - NSMutableAttributedString + Extension
+
+extension NSMutableAttributedString {
+    package func addUniformAttribute(_ name: NSAttributedString.Key, value: Any) {
+        addAttribute(name, value: value, range: range)
+    }
+
+    package func addUniformAttributes(_ attributes: NSAttributedStringAttributes) {
+        addAttributes(attributes, range: range)
+    }
+}
+
+extension NSMutableAttributedString {
+    /// Replaces the attributes of `range` with `attrs`, preserving the
+    /// attributes that were already present.
+    package func mergeAttributes(_ attrs: NSAttributedStringAttributes, in range: NSRange? = nil) {
+        let range = range ?? self.range
+        guard range.length != 0 else {
+            return
+        }
+        var existing: [NSRange: NSAttributedStringAttributes] = [:]
+        enumerateAttributes(in: range) { attributes, range, _ in
+            existing[range] = attributes
+        }
+        setAttributes(attrs, range: range)
+        for (range, attributes) in existing {
+            addAttributes(attributes, range: range)
+        }
+    }
+}
+
+// MARK: - NSAttributedString.Runs
+
+extension NSAttributedString {
+    package typealias Runs = [(range: NSRange, attributes: NSAttributedStringAttributes)]
+
+    package func runs(in range: NSRange? = nil) -> Runs {
+        var runs: Runs = []
+        enumerateAttributes(in: range ?? self.range) { attributes, range, _ in
+            runs.append((range: range, attributes: attributes))
+        }
+        return runs
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Archive/ArchivedViewCore.swift
+++ b/Sources/OpenSwiftUICore/View/Archive/ArchivedViewCore.swift
@@ -27,7 +27,7 @@ package struct ArchivedViewCore {
 
         package var preferredBundleLanguage: String? = Bundle.main.preferredLocalizations.first
         @CodableRawRepresentable
-        package var preferredCompositionLanguage: CTCompositionLanguage = OpenSwiftUI_CTParagraphStyleGetCompositionLanguageForLanguage(nil)
+        package var preferredCompositionLanguage: CTCompositionLanguage = CTParagraphStyleGetCompositionLanguageForLanguage(nil)
 
         package init(
             majorVersion: Int = ArchivedViewCore.majorVersion,

--- a/Sources/OpenSwiftUICore/View/Text/Accessibility/NSAttributedString+Accessibility.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Accessibility/NSAttributedString+Accessibility.swift
@@ -79,7 +79,8 @@ extension AccessibilityCore {
         _ attributes: inout [NSAttributedString.Key: Any],
         environment: EnvironmentValues
     ) {
-        _openSwiftUIUnimplementedFailure()
+        environment.accessibilityTextAttributeResolver?
+            .resolveDefaultAttributes(&attributes)
     }
 
     package static func resolveAccessibilitySpeechAttributes(
@@ -88,7 +89,13 @@ extension AccessibilityCore {
         environment: EnvironmentValues,
         includeDefaultAttributes: Bool = true
     ) {
-        _openSwiftUIUnimplementedFailure()
+        environment.accessibilityTextAttributeResolver?
+            .resolveAccessibilitySpeechAttributes(
+                into: &attributes,
+                speechAttr: speechAttr,
+                environment: environment,
+                includeDefaultAttributes: includeDefaultAttributes
+            )
     }
 
     package static func textsResolvedToAttributedText(
@@ -110,7 +117,27 @@ extension Text {
         in environment: EnvironmentValues,
         idiom: AnyInterfaceIdiom? = nil
     ) -> AccessibilityText? {
-        _openSwiftUIUnimplementedFailure()
+        AccessibilityText(self, environment: environment, idiom: idiom)
+    }
+}
+
+// MARK: - Text.Style + AccessibilityTextAttributes
+
+extension Text.Style {
+    package func resolveAccessibilityTextAttributes(
+        into attributes: inout [NSAttributedString.Key: Any],
+        environment: EnvironmentValues
+    ) {
+        environment.accessibilityTextAttributeResolver?
+            .resolveTextStyleAttributes(
+                &attributes,
+                textStyle: self,
+                environment: environment
+            )
+        AccessibilityCore.resolveAttributedTextAttributes(
+            &attributes,
+            environment: environment
+        )
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -344,6 +344,15 @@ extension Text.Style {
         if !environment.shouldRedactContent, (scale ?? environment.textScale) == .secondary {
             attributes[._textScale] = _kCTTextScaleSecondary
         }
+        #if canImport(Darwin)
+        if let adaptiveImageGlyph {
+            attributes[.adaptiveImageGlyph] = NSAdaptiveImageGlyph(
+                ctAdaptiveImageGlyph: CTAdaptiveImageGlyph._adaptiveImageGlyph(
+                    convertingFrom: adaptiveImageGlyph
+                )
+            )
+        }
+        #endif
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -392,6 +392,9 @@ extension Text.Style {
                 environment: environment
             )
         }
+        if !customAttributes.isEmpty {
+            attributes[.customAttributes] = Text.CustomAttributes(attributes: customAttributes)
+        }
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -54,21 +54,16 @@ package func makeParagraphStyle(environment: EnvironmentValues) -> NSMutablePara
     return paragraphStyle
 }
 
-#if canImport(CoreText)
-@_silgen_name("kCTUIFontTextStyleTitle0")
-let kCTTextScaleRatioAttributeName: CFString
-#endif
-
 extension NSAttributedString.Key {
-    static let resolvableAttributeConfiguration: NSAttributedString.Key = .init("OpenSwiftUI.resolvableAttributeConfiguration")
+    package static let resolvableAttributeConfiguration: NSAttributedString.Key = .init("OpenSwiftUI.resolvableAttributeConfiguration")
 
-    static let _textScale: NSAttributedString.Key = .init("NSTextScale")
+    package static let _textScale: NSAttributedString.Key = .init("NSTextScale")
 
     #if canImport(CoreText)
-    static let _textScaleRatio: NSAttributedString.Key = .init(kCTTextScaleRatioAttributeName as String)
+    package static let _textScaleRatio: NSAttributedString.Key = .init(kCTTextScaleRatioAttributeName as String)
     #endif
 
-    static let _textScaleStaticWeightMatching: NSAttributedString.Key = .init("NSTextScaleStaticWeightMatching")
+    package static let _textScaleStaticWeightMatching: NSAttributedString.Key = .init("NSTextScaleStaticWeightMatching")
 }
 
 extension NSAttributedString {

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -273,7 +273,14 @@ extension Text.Style {
         with options: Text.ResolveOptions,
         properties: inout Text.ResolvedProperties
     ) -> [NSAttributedString.Key: Any] {
-        _openSwiftUIUnimplementedWarning()
-        return [:]
+        var attributes: [NSAttributedString.Key: Any] = [:]
+        let isRedacted = environment.shouldRedactContent
+        var modifiers = environment.fontModifiers
+        if !clearedFontModifiers.isEmpty {
+            modifiers = modifiers.filter { !clearedFontModifiers.contains($0.typeID) }
+        }
+        modifiers.append(contentsOf: fontModifiers)
+        properties.paragraph.compositionLanguage = .unset
+        return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -353,6 +353,31 @@ extension Text.Style {
             )
         }
         #endif
+        if let shadow {
+            let resolved = shadow.shadow.resolve(in: environment).style
+            properties.insets.formPointwiseMin(resolved.insets)
+            #if canImport(Darwin)
+            if let platformColor = CoreColor.platformColor(resolvedColor: resolved.color),
+               let kitShadow = CoreMakeNSShadow(
+                   color: platformColor,
+                   offsetX: resolved.offset.width,
+                   offsetY: resolved.offset.height,
+                   blurRadius: resolved.radius * 2
+               ) {
+                attributes[.kitShadow] = kitShadow
+            }
+            #endif
+        } else if options.contains(.includeTransitions), let transition {
+            #if canImport(Darwin)
+            if let kitShadow = CoreMakeNSShadowWithCustomStyleIndex(
+                system: .default,
+                index: CGFloat(properties.transitions.count)
+            ) {
+                attributes[.kitShadow] = kitShadow
+            }
+            #endif
+            properties.transitions.append(transition.resolved)
+        }
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -8,7 +8,11 @@
 package import Foundation
 package import UIFoundation_Private
 #if canImport(CoreText)
-import CoreText
+package import CoreText
+package import CoreText_Private
+#endif
+#if canImport(Darwin)
+package import OpenSwiftUI_SPI
 #endif
 
 package func makeParagraphStyle(environment: EnvironmentValues) -> NSMutableParagraphStyle {
@@ -333,6 +337,9 @@ extension Text.Style {
                 attributes[.kitUnderlineColor] = color.kitColor
                 properties.addColor(color)
             }
+        }
+        if let encapsulation {
+            attributes[NSTextEncapsulationAttributeName] = encapsulation.resolve(in: environment)
         }
         return attributes
     }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -117,7 +117,15 @@ extension EnvironmentValues {
         includeDefaultAttributes: Bool = true,
         options: Text.ResolveOptions = []
     ) -> [NSAttributedString.Key: Any] {
-        _openSwiftUIUnimplementedFailure()
+        var properties = Text.ResolvedProperties()
+        let style = Text.Style()
+        return style.nsAttributes(
+            content: nil,
+            environment: self,
+            includeDefaultAttributes: includeDefaultAttributes,
+            with: options,
+            properties: &properties
+        )
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -8,14 +8,49 @@
 package import Foundation
 package import UIFoundation_Private
 #if canImport(CoreText)
-package import CoreText
+import CoreText
 #endif
 
 package func makeParagraphStyle(environment: EnvironmentValues) -> NSMutableParagraphStyle {
+    let layoutProperties = TextLayoutProperties(environment)
     let paragraphStyle = NSMutableParagraphStyle()
-    #if canImport(Darwin)
-    // TODO
-    #endif
+    paragraphStyle.horizontalAlignment = NSTextHorizontalAlignment(
+        layoutProperties.multilineTextAlignment,
+        layoutDirection: layoutProperties.layoutDirection,
+        writingMode: layoutProperties.writingMode
+    )
+    let isBalanced = environment.paragraphTypesetting.storage == .balanced
+    switch environment.textJustification.storage {
+    case let .full(full):
+        paragraphStyle.fullyJustified = true
+        paragraphStyle.spansAllLines = full.allLines || isBalanced
+    case .none:
+        paragraphStyle.fullyJustified = false
+        paragraphStyle.spansAllLines = isBalanced
+    }
+    paragraphStyle.lineBreakMode = switch layoutProperties.truncationMode {
+    case .head: .byTruncatingHead
+    case .tail: .byTruncatingTail
+    case .middle: .byTruncatingMiddle
+    }
+    paragraphStyle.lineSpacing = layoutProperties.lineSpacing
+    paragraphStyle.lineBreakStrategy = .standard
+    if !environment.avoidsOrphans {
+        paragraphStyle.lineBreakStrategy = paragraphStyle.lineBreakStrategy.subtracting(.pushOut)
+    }
+    paragraphStyle.lineHeightMultiple = layoutProperties.lineHeightMultiple
+    paragraphStyle.maximumLineHeight = layoutProperties.maximumLineHeight
+    paragraphStyle.minimumLineHeight = layoutProperties.minimumLineHeight
+    let hyphenationDisabled = layoutProperties.hyphenationDisabled
+    paragraphStyle.hyphenationFactor = hyphenationDisabled ? 0 : Float(layoutProperties.hyphenationFactor)
+    paragraphStyle.secondaryLineBreakMode = hyphenationDisabled ? .byClipping : .byWordWrapping
+    paragraphStyle.firstLineHeadIndent = layoutProperties.bodyHeadOutdent
+    if environment.bodyHeadOutdent > 0 {
+        paragraphStyle.baseWritingDirection = environment.writingMode == .verticalRightToLeft
+            ? .leftToRight
+            : NSWritingDirection(layoutProperties.layoutDirection)
+    }
+    paragraphStyle.allowsDefaultTighteningForTruncation = environment.allowsTightening
     return paragraphStyle
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -395,6 +395,15 @@ extension Text.Style {
         if !customAttributes.isEmpty {
             attributes[.customAttributes] = Text.CustomAttributes(attributes: customAttributes)
         }
+        #if canImport(CoreText)
+        if superscript != nil, let font = attributes[.kitFont] as! CTFont? {
+            let baselineOffset = attributes[.kitBaselineOffset] as? CGFloat ?? .zero
+            let newFont = font.scaled(by: 0.65, toMultipleOf: 0.25, maintainVisualWeight: true)
+            let newBaselineOffset = baselineOffset + (font.capHeight - newFont.capHeight)
+            attributes[.kitFont] = newFont
+            attributes[.kitBaselineOffset] = newBaselineOffset
+        }
+        #endif
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -281,6 +281,13 @@ extension Text.Style {
         }
         modifiers.append(contentsOf: fontModifiers)
         properties.paragraph.compositionLanguage = .unset
+        typesettingConfiguration.language.apply(
+            content: content,
+            locale: environment.locale,
+            to: &attributes,
+            modifiers: &modifiers,
+            properties: &properties
+        )
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -89,17 +89,20 @@ extension Text {
         options: Text.ResolveOptions = [.includeSupportForRepeatedResolution],
         idiom: AnyInterfaceIdiom? = nil
     ) -> NSAttributedString? {
-        // FIXME
-        _openSwiftUIUnimplementedWarning()
         var container = Text.Resolved()
         container.includeDefaultAttributes = includeDefaultAttributes
         container.idiom = idiom
-        // container.properties = options
-        resolve(into: &container, in: environment, with: options)
-        if let attributedString = container.attributedString {
-            // attributedString.resolveUpdateSchedule(recalculate: true )
+        var configuration = environment.typesettingConfiguration
+        if !storage.allowsTypesettingLanguage() {
+            configuration.language = .automatic
         }
-        return container.attributedString
+        container.style.typesettingConfiguration = configuration
+        resolve(into: &container, in: environment, with: options)
+        let attributedString = container.attributedString
+        if let attributedString {
+            _ = attributedString.resolveUpdateSchedule(recalculate: true)
+        }
+        return attributedString
     }
 
     package func resolveAttributedStringAndProperties(
@@ -108,7 +111,43 @@ extension Text {
         options: Text.ResolveOptions = [.includeSupportForRepeatedResolution],
         idiom: AnyInterfaceIdiom? = nil
     ) -> (NSAttributedString?, Text.ResolvedProperties) {
-        _openSwiftUIUnimplementedFailure()
+        var container = Text.Resolved()
+        container.includeDefaultAttributes = includeDefaultAttributes
+        container.idiom = idiom
+        var configuration = environment.typesettingConfiguration
+        if !storage.allowsTypesettingLanguage() {
+            configuration.language = .automatic
+        }
+        container.style.typesettingConfiguration = configuration
+        if options.contains([.allowsKeyColors, .allowsTextSuffix]) {
+            let styles = environment.textSuffix.styles
+            if !styles.isEmpty {
+                container.properties.styles = styles
+                container.properties.features = .keyColor
+            }
+        }
+        resolve(into: &container, in: environment, with: options)
+        let attributedString = container.attributedString
+        container.properties.suffix = .none
+        if options.contains(.allowsTextSuffix) {
+            let suffix = environment.textSuffix
+            switch suffix {
+            case .none:
+                break
+            case .truncated:
+                container.properties.suffix = suffix
+            case let .alwaysVisible(line, _):
+                let offset = attributedString?.length ?? 0
+                // TODO: append ConcreteCustomTextAttachment(LineAttachment(line:bounds:))
+                _openSwiftUIUnimplementedWarning()
+                container.properties.registerCustomAttachment(at: offset)
+                container.properties.suffix = suffix
+            }
+        }
+        if let attributedString {
+            _ = attributedString.resolveUpdateSchedule(recalculate: true)
+        }
+        return (attributedString, container.properties)
     }
 }
 

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -308,6 +308,18 @@ extension Text.Style {
             attributes[.kitBackgroundColor] = resolved.kitColor
             properties.addColor(resolved)
         }
+        let baselineOffsetValue = baselineOffset ?? environment.defaultBaselineOffset
+        if baselineOffsetValue != 0 {
+            attributes[.kitBaselineOffset] = baselineOffsetValue
+        }
+        let kerningValue = kerning ?? environment.defaultKerning
+        if kerningValue != 0 {
+            attributes[.kitKern] = kerningValue
+        }
+        let trackingValue = tracking ?? environment.defaultTracking
+        if trackingValue != 0 {
+            attributes[.kitTracking] = trackingValue
+        }
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -61,7 +61,7 @@ package func makeParagraphStyle(environment: EnvironmentValues) -> NSMutablePara
 extension NSAttributedString.Key {
     package static let resolvableAttributeConfiguration: NSAttributedString.Key = .init("OpenSwiftUI.resolvableAttributeConfiguration")
 
-    package static let _textScale: NSAttributedString.Key = .init("NSTextScale")
+    package static let _textScale: NSAttributedString.Key = .init(_kCTTextScaleAttributeName)
 
     #if canImport(CoreText)
     package static let _textScaleRatio: NSAttributedString.Key = .init(kCTTextScaleRatioAttributeName as String)
@@ -278,7 +278,7 @@ extension Text.Style {
         properties: inout Text.ResolvedProperties
     ) -> [NSAttributedString.Key: Any] {
         var attributes: [NSAttributedString.Key: Any] = [:]
-        let isRedacted = environment.shouldRedactContent
+        let shouldRedactContent = environment.shouldRedactContent
         var modifiers = environment.fontModifiers
         if !clearedFontModifiers.isEmpty {
             modifiers = modifiers.filter { !clearedFontModifiers.contains($0.typeID) }
@@ -340,6 +340,9 @@ extension Text.Style {
         }
         if let encapsulation {
             attributes[NSTextEncapsulationAttributeName] = encapsulation.resolve(in: environment)
+        }
+        if !environment.shouldRedactContent, (scale ?? environment.textScale) == .secondary {
+            attributes[._textScale] = _kCTTextScaleSecondary
         }
         return attributes
     }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -289,6 +289,25 @@ extension Text.Style {
             properties: &properties
         )
         typesettingConfiguration.languageAwareLineHeightRatio.apply(to: &modifiers)
+        if let font = baseFont.resolve(in: environment, includeDefaultAttributes: includeDefaultAttributes) {
+            attributes[.kitFont] = font.platformFont(in: environment, modifiers: modifiers)
+        } else {
+            attributes[.kitFont] = nil
+        }
+        if let color = color.resolve(
+            in: environment,
+            with: options,
+            properties: &properties,
+            includeDefaultAttributes: includeDefaultAttributes && !options.contains(.writeAuxiliaryMetadata)
+        ) {
+            attributes[.kitForegroundColor] = color.kitColor
+            properties.addColor(color)
+        }
+        if let backgroundColor {
+            let resolved = backgroundColor.resolve(in: environment)
+            attributes[.kitBackgroundColor] = resolved.kitColor
+            properties.addColor(resolved)
+        }
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -288,6 +288,7 @@ extension Text.Style {
             modifiers: &modifiers,
             properties: &properties
         )
+        typesettingConfiguration.languageAwareLineHeightRatio.apply(to: &modifiers)
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -320,6 +320,20 @@ extension Text.Style {
         if trackingValue != 0 {
             attributes[.kitTracking] = trackingValue
         }
+        if let resolved = strikethrough.resolve(in: environment, fallbackStyle: environment.strikethroughStyle) {
+            attributes[.kitStrikethroughStyle] = NSNumber(value: resolved.nsUnderlineStyle.rawValue)
+            if let color = resolved.color {
+                attributes[.kitStrikethroughColor] = color.kitColor
+                properties.addColor(color)
+            }
+        }
+        if let resolved = underline.resolve(in: environment, fallbackStyle: environment.underlineStyle) {
+            attributes[.kitUnderlineStyle] = NSNumber(value: resolved.nsUnderlineStyle.rawValue)
+            if let color = resolved.color {
+                attributes[.kitUnderlineColor] = color.kitColor
+                properties.addColor(color)
+            }
+        }
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -378,6 +378,9 @@ extension Text.Style {
             #endif
             properties.transitions.append(transition.resolved)
         }
+        if includeDefaultAttributes || shouldRedactContent {
+            attributes[.kitParagraphStyle] = properties.paragraph.style(environment: environment)
+        }
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -381,6 +381,17 @@ extension Text.Style {
         if includeDefaultAttributes || shouldRedactContent {
             attributes[.kitParagraphStyle] = properties.paragraph.style(environment: environment)
         }
+        if options.contains(.includeAccessibility), !shouldRedactContent {
+            resolveAccessibilitySpeechAttributes(
+                into: &attributes,
+                environment: environment,
+                includeDefaultAttributes: includeDefaultAttributes
+            )
+            resolveAccessibilityTextAttributes(
+                into: &attributes,
+                environment: environment
+            )
+        }
         return attributes
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
@@ -60,6 +60,11 @@ package func CTFontDescriptorCreateForUIType(
 @_silgen_name("CTFontCopySystemUIFontExcessiveLineHeightCharacterSet")
 package func CTFontCopySystemUIFontExcessiveLineHeightCharacterSet() -> CFCharacterSet?
 
+@_silgen_name("CTFontCopyTallestTextStyleLanguageForString")
+package func CTFontCopyTallestTextStyleLanguageForString(
+    _ string: CFString
+) -> CFString?
+
 @_silgen_name("CTFontGetLanguageAwareOutsets")
 package func CTFontGetLanguageAwareOutsets(
     _ font: CTFont,
@@ -95,6 +100,12 @@ let kCTFontGradeTrait: CFString?
 
 @_silgen_name("kCTFontLegibilityWeightAttribute")
 let kCTFontLegibilityWeightAttribute: CFString
+
+@_silgen_name("kCTFontDescriptorLanguageAttribute")
+let kCTFontDescriptorLanguageAttribute: CFString
+
+@_silgen_name("kCTFontLanguageAwareLineHeightRatioAttribute")
+let kCTFontLanguageAwareLineHeightRatioAttribute: CFString
 
 // MARK: - CTFontTextStyle
 

--- a/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
@@ -5,6 +5,7 @@
 #if canImport(CoreText)
 package import CoreText
 import CoreFoundation
+package import Foundation
 
 // MARK: - Private CoreText APIs
 
@@ -251,5 +252,8 @@ let kCTFontWidthTrait: CFString
 
 @_silgen_name("kCTTextScaleRatioAttributeName")
 let kCTTextScaleRatioAttributeName: CFString
+
+@_silgen_name("NSTextEncapsulationAttributeName")
+let NSTextEncapsulationAttributeName: NSAttributedString.Key
 
 #endif

--- a/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
@@ -4,6 +4,7 @@
 
 #if canImport(CoreText)
 package import CoreText
+package import CoreText_Private
 import CoreFoundation
 package import Foundation
 
@@ -247,6 +248,16 @@ let kCTFontWidthStandard: CGFloat
 
 @_silgen_name("kCTFontWidthTrait")
 let kCTFontWidthTrait: CFString
+
+// MARK: - CTAdaptiveImageGlyph
+
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension CTAdaptiveImageGlyph {
+    @_silgen_name("$sSo20CTAdaptiveImageGlyphC8CoreTextE09_adaptivebC014convertingFromAB10Foundation16AttributedStringVACE08AdaptivebC0V_tFZ")
+    package static func _adaptiveImageGlyph(
+        convertingFrom adaptiveImageGlyph: AttributedString.AdaptiveImageGlyph
+    ) -> CTAdaptiveImageGlyph
+}
 
 // MARK: - Attribute Name
 

--- a/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Font/CoreText+Private.swift
@@ -235,4 +235,10 @@ let kCTFontWidthStandard: CGFloat
 
 @_silgen_name("kCTFontWidthTrait")
 let kCTFontWidthTrait: CFString
+
+// MARK: - Attribute Name
+
+@_silgen_name("kCTTextScaleRatioAttributeName")
+let kCTTextScaleRatioAttributeName: CFString
+
 #endif

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Encapsulation.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Encapsulation.swift
@@ -92,5 +92,31 @@ extension Text {
 
             public static let large: Text.Encapsulation.PlatterSize = .init(nsPlatterSize: .large)
         }
+
+        func resolve(in environment: EnvironmentValues) -> NSTextEncapsulation {
+            let resolved = NSTextEncapsulation()
+            if let scale {
+                resolved.scale = scale.nsScale
+            }
+            if let shape {
+                resolved.shape = shape.nsShape
+            }
+            if let style {
+                resolved.style = style.nsStyle
+            }
+            if let platterSize {
+                resolved.platterSize = platterSize.nsPlatterSize
+            }
+            if let lineWeight {
+                resolved.lineWeight = lineWeight
+            }
+            if let color {
+                resolved.setPlatformColor(color.resolve(in: environment).kitColor)
+            }
+            if let minimumWidth {
+                resolved.minimumWidth = minimumWidth
+            }
+            return resolved
+        }
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Renderer.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Renderer.swift
@@ -101,6 +101,12 @@ extension Text.Modifier {
     }
 }
 
+extension NSAttributedString.Key {
+    static let customAttributes: NSAttributedString.Key = .init(
+        AttributeScopes.OpenSwiftUIAttributes.CustomContainerAttribute.name
+    )
+}
+
 // MARK: Text + CustomAttributes
 
 @_spi(Private)
@@ -111,6 +117,10 @@ extension Text {
 
         public init() {
             _openSwiftUIEmptyStub()
+        }
+
+        package init(attributes: [TextAttributeModifierBase]) {
+            self.attributes = attributes
         }
 
         public mutating func add<T>(_ value: T) where T: TextAttribute {

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Scale.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Scale.swift
@@ -5,6 +5,9 @@
 //  Audited for 6.5.4
 //  Status: Complete
 
+let _kCTTextScaleAttributeName = "NSTextScale"
+let _kCTTextScaleSecondary = "NSTextScaleSecondary"
+
 @available(OpenSwiftUI_v1_0, *)
 extension Text {
 
@@ -39,7 +42,7 @@ extension Text {
 
 extension Text.Scale {
     package init?(_ string: String) {
-        guard string == "NSTextScaleSecondary" else {
+        guard string == _kCTTextScaleSecondary else {
             return nil
         }
         self = .secondary

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+Suffix.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+Suffix.swift
@@ -145,3 +145,10 @@ private struct TextSuffixModifier: PrimitiveViewModifier, _GraphInputsModifier {
 private struct TextSuffixKey: EnvironmentKey {
     static let defaultValue: ResolvedTextSuffix = .none
 }
+
+extension EnvironmentValues {
+    package var textSuffix: ResolvedTextSuffix {
+        get { self[TextSuffixKey.self] }
+        set { self[TextSuffixKey.self] = newValue }
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguage.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguage.swift
@@ -7,6 +7,7 @@
 //  ID: E539E054FF6DF2E95534C4C9F8C35428 (SwiftUICore)
 
 public import Foundation
+import UIFoundation_Private
 #if canImport(CoreText)
 import CoreText_Private
 #endif
@@ -251,6 +252,31 @@ extension TypesettingLanguage {
                 identifier: language.maximalIdentifier,
                 modifyFont: flags.contains(.modifyFont)
             )
+        }
+    }
+
+    func apply(
+        content: (() -> String)?,
+        locale: Locale,
+        to attributes: inout [NSAttributedString.Key: Any],
+        modifiers: inout [AnyFontModifier],
+        properties: inout Text.ResolvedProperties
+    ) {
+        guard self != .automatic else {
+            return
+        }
+        switch resolve(with: content, locale: locale) {
+        case let .language(identifier, modifyFont):
+            attributes[.languageIdentifier] = identifier
+            let compositionLanguage = CTParagraphStyleGetCompositionLanguageForLanguage(identifier as CFString)
+            properties.paragraph.compositionLanguage = NSCompositionLanguage(rawValue: compositionLanguage.rawValue)!
+            if modifyFont {
+                modifiers.append(.languageModifier(identifier))
+            }
+        case let .font(identifier):
+            modifiers.append(.languageModifier(identifier))
+        case .none:
+            break
         }
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguage.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguage.swift
@@ -4,8 +4,12 @@
 //
 //  Audited for 6.5.4
 //  Status: Complete
+//  ID: E539E054FF6DF2E95534C4C9F8C35428 (SwiftUICore)
 
 public import Foundation
+#if canImport(CoreText)
+import CoreText_Private
+#endif
 
 // MARK: - TypesettingLanguage
 
@@ -207,5 +211,89 @@ extension Text {
         }
         let modifier: Text.Modifier = .anyTextModifier(LanguageTextModifier(language: language))
         return modified(with: modifier)
+    }
+}
+
+// MARK: - TypesettingLanguage + Resolution
+
+extension TypesettingLanguage {
+    enum Resolved {
+        case language(identifier: String, modifyFont: Bool)
+        case font(identifier: String)
+        case none
+    }
+
+    func resolve(
+        with content: (() -> String)?,
+        locale: Locale
+    ) -> Resolved {
+        switch storage {
+        case .automatic:
+            return .none
+        case .contentAware:
+            #if canImport(CoreText)
+            if let content,
+               let identifier = CTFontCopyTallestTextStyleLanguageForString(
+                   content() as CFString
+               ) as String? {
+                return .font(identifier: identifier)
+            }
+            #endif
+            guard let languageCode = locale.language.languageCode else {
+                return .none
+            }
+            return .language(
+                identifier: languageCode.identifier,
+                modifyFont: true
+            )
+        case let .explicit(language, flags):
+            return .language(
+                identifier: language.maximalIdentifier,
+                modifyFont: flags.contains(.modifyFont)
+            )
+        }
+    }
+}
+
+// MARK: - LanguageFontModifier
+
+extension AnyFontModifier {
+    private static var languageModifiers: [String: AnyFontModifier] = [:]
+
+    fileprivate static func languageModifier(_ identifier: String) -> AnyFontModifier {
+        if let modifier = languageModifiers[identifier] {
+            return modifier
+        }
+        let modifier = AnyFontModifier.dynamic(
+            LanguageFontModifier(identifier: identifier)
+        )
+        languageModifiers[identifier] = modifier
+        return modifier
+    }
+}
+
+struct LanguageFontModifier: FontModifier {
+    var identifier: String
+
+    func modify(
+        descriptor: inout CTFontDescriptor,
+        in context: Font.Context
+    ) {
+        #if canImport(CoreText)
+        guard CTFontDescriptorCopyAttribute(
+            descriptor,
+            kCTFontDescriptorLanguageAttribute
+        ) == nil else {
+            return
+        }
+        descriptor = CTFontDescriptorCreateCopyWithAttributes(
+            descriptor,
+            [
+                kCTFontDescriptorLanguageAttribute: identifier,
+            ] as CFDictionary
+        )
+        #else
+        _openSwiftUIPlatformUnimplementedWarning()
+        #endif
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguage.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguage.swift
@@ -8,9 +8,7 @@
 
 public import Foundation
 import UIFoundation_Private
-#if canImport(CoreText)
 import CoreText_Private
-#endif
 
 // MARK: - TypesettingLanguage
 
@@ -268,8 +266,10 @@ extension TypesettingLanguage {
         switch resolve(with: content, locale: locale) {
         case let .language(identifier, modifyFont):
             attributes[.languageIdentifier] = identifier
+            #if canImport(Darwin)
             let compositionLanguage = CTParagraphStyleGetCompositionLanguageForLanguage(identifier as CFString)
             properties.paragraph.compositionLanguage = NSCompositionLanguage(rawValue: compositionLanguage.rawValue)!
+            #endif
             if modifyFont {
                 modifiers.append(.languageModifier(identifier))
             }

--- a/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguageAwareLineHeightRatio.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Typesetting/TypesettingLanguageAwareLineHeightRatio.swift
@@ -5,6 +5,10 @@
 //  Audited for 6.5.4
 //  Status: Complete
 
+#if canImport(CoreText)
+import CoreText_Private
+#endif
+
 // MARK: - TypesettingLanguageAwareLineHeightRatio
 
 @_spi(Private)
@@ -83,5 +87,44 @@ extension Text {
             return self
         }
         return modified(with: .anyTextModifier(LanguageAwareLineHeightRatioTextModifier(ratio: ratio)))
+    }
+}
+
+// MARK: - LanguageAwareLineHeightRatioFontModifier
+
+extension TypesettingLanguageAwareLineHeightRatio {
+    func apply(to modifiers: inout [AnyFontModifier]) {
+        let modifier: LanguageAwareLineHeightRatioFontModifier
+        switch storage {
+        case .automatic:
+            return
+        case let .custom(ratio):
+            modifier = .init(ratio: ratio)
+        case .disable:
+            modifier = .init(ratio: 0)
+        case .legacy:
+            modifier = .init(ratio: 0.33)
+        }
+        modifiers.append(.dynamic(modifier))
+    }
+}
+
+struct LanguageAwareLineHeightRatioFontModifier: FontModifier {
+    let ratio: Double
+
+    func modify(
+        descriptor: inout CTFontDescriptor,
+        in context: Font.Context
+    ) {
+        #if canImport(CoreText)
+        descriptor = CTFontDescriptorCreateCopyWithAttributes(
+            descriptor,
+            [
+                kCTFontLanguageAwareLineHeightRatioAttribute: ratio,
+            ] as CFDictionary
+        )
+        #else
+        _openSwiftUIPlatformUnimplementedWarning()
+        #endif
     }
 }

--- a/Sources/OpenSwiftUICore/View/Text/Util/ParagraphTypesetting.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/ParagraphTypesetting.swift
@@ -1,0 +1,50 @@
+//
+//  ParagraphTypesetting.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+//  ID: D39DBD719189F2769C15C168465CE407 (SwiftUICore)
+
+@_spi(Private)
+@available(OpenSwiftUI_v5_0, *)
+public struct ParagraphTypesetting: Equatable {
+    package enum Storage: Hashable {
+        case automatic
+
+        case balanced
+    }
+
+    package var storage: ParagraphTypesetting.Storage
+
+    public static let automatic: ParagraphTypesetting = .init(storage: .automatic)
+
+    public static let balanced: ParagraphTypesetting = .init(storage: .balanced)
+}
+
+private struct ParagraphTypesettingKey: EnvironmentKey {
+    static let defaultValue: ParagraphTypesetting = .automatic
+}
+
+extension EnvironmentValues {
+    package var paragraphTypesetting: ParagraphTypesetting {
+        get { self[ParagraphTypesettingKey.self] }
+        set { self[ParagraphTypesettingKey.self] = newValue }
+    }
+}
+
+@available(OpenSwiftUI_v1_0, *)
+extension View {
+    @_spi(Private)
+    @available(OpenSwiftUI_v5_0, *)
+    nonisolated public func paragraphTypesetting(
+        _ typesetting: ParagraphTypesetting,
+        isEnabled: Bool = true
+    ) -> some View {
+        transformEnvironment(\.paragraphTypesetting) {
+            if isEnabled {
+                $0 = typesetting
+            }
+        }
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Text/Util/ReducedTimelineSchedule.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/ReducedTimelineSchedule.swift
@@ -35,3 +35,35 @@ extension NSAttributedString {
         return schedule
     }
 }
+
+extension NSMutableAttributedString {
+
+    /// Returns the schedule on which the receiver needs to be resolved again.
+    ///
+    /// When `recalculate` is false the cached ``NSAttributedString/Key/updateSchedule``
+    /// attribute is read back; otherwise the schedule is recomputed from the
+    /// resolvable text segments and the cached attribute is refreshed.
+    package func resolveUpdateSchedule(recalculate: Bool) -> (any TimelineSchedule)? {
+        guard length >= 1 else {
+            return nil
+        }
+        guard recalculate else {
+            return attribute(.updateSchedule, at: 0, effectiveRange: nil) as? any TimelineSchedule
+        }
+        var schedule: (any TimelineSchedule)?
+        enumerateAttribute(.resolvableTextSegment, in: range) { value, _, _ in
+            guard value != nil else {
+                return
+            }
+            // TODO: ResolvableTextSegmentAttribute
+            _openSwiftUIUnimplementedWarning()
+            schedule = nil
+        }
+        if let schedule {
+            addAttribute(.updateSchedule, value: schedule, range: range)
+        } else {
+            removeAttribute(.updateSchedule, range: range)
+        }
+        return schedule
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Text/Util/WritingMode.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Util/WritingMode.swift
@@ -6,12 +6,13 @@
 //  Status: Complete
 //  ID: 82074A2E22E8635055FCB3A2D5E40280 (SwiftUICore)
 
+package import UIFoundation_Private
+
 @available(OpenSwiftUI_v1_0, *)
 extension Text {
     @_spi(Private)
     @available(OpenSwiftUI_v5_0, *)
     public struct WritingMode: Sendable, Hashable {
-        @_spi(Private)
         package enum Storage {
             case horizontalTopToBottom
             case verticalRightToLeft
@@ -63,27 +64,50 @@ extension Text.WritingMode: ProtobufEnum {
     }
 }
 
-//#if canImport(UIFoundation_Private)
-//import UIFoundation_Private
-//
-//extension NSTextHorizontalAlignment {
-//    package init(
-//        _ alignment: TextAlignment,
-//        layoutDirection: LayoutDirection,
-//        writingMode: Text.WritingMode
-//    ) {
-//        _openSwiftUIUnimplementedFailure()
-//    }
-//
-//    package init(in environment: EnvironmentValues) {
-//        _openSwiftUIUnimplementedFailure()
-//    }
-//}
-//
-//#endif
+// MARK: - NSTextHorizontalAlignment + TextAlignment
 
-//extension NSWritingDirection {
-//    package init(_ layoutDirection: LayoutDirection) {
-//
-//    }
-//}
+extension NSTextHorizontalAlignment {
+    /// Resolves the visual alignment of a paragraph.
+    ///
+    /// A vertical writing mode maps the leading and trailing edges onto the
+    /// top and bottom of the line, so the layout direction only participates
+    /// in the resolution for a horizontal writing mode.
+    package init(
+        _ alignment: TextAlignment,
+        layoutDirection: LayoutDirection,
+        writingMode: Text.WritingMode
+    ) {
+        guard case .horizontalTopToBottom = writingMode.storage else {
+            self = switch alignment {
+            case .leading: .left
+            case .center: .center
+            case .trailing: .right
+            }
+            return
+        }
+        self = switch (alignment, layoutDirection) {
+        case (.center, _): .center
+        case (.leading, .leftToRight), (.trailing, .rightToLeft): .left
+        case (.leading, .rightToLeft), (.trailing, .leftToRight): .right
+        }
+    }
+
+    package init(in environment: EnvironmentValues) {
+        self.init(
+            environment.multilineTextAlignment,
+            layoutDirection: environment.layoutDirection,
+            writingMode: environment.writingMode
+        )
+    }
+}
+
+// MARK: - NSWritingDirection + LayoutDirection
+
+extension NSWritingDirection {
+    package init(_ layoutDirection: LayoutDirection) {
+        self = switch layoutDirection {
+        case .leftToRight: .leftToRight
+        case .rightToLeft: .rightToLeft
+        }
+    }
+}

--- a/Sources/OpenSwiftUI_SPI/Overlay/CoreGraphics/OpenSwiftUICoreColor.m
+++ b/Sources/OpenSwiftUI_SPI/Overlay/CoreGraphics/OpenSwiftUICoreColor.m
@@ -130,9 +130,9 @@ Class NSColorSpaceClass(void) {
 + (NSObject *)colorWithSystem:(OpenSwiftUICoreSystem)system cgColor: (CGColorRef)cgColor {
     Class colorClass = OpenSwiftUICoreColorClass(system);
     if (colorClass) {
-        return [colorClass colorWithCGColor: cgColor];
+        return [colorClass colorWithCGColor:cgColor];
     } else {
-        return [[OpenSwiftUICoreColor alloc] initWithCGColor: cgColor];
+        return [[OpenSwiftUICoreColor alloc] initWithCGColor:cgColor];
     }
 }
 

--- a/Sources/OpenSwiftUI_SPI/Overlay/CoreGraphics/OpenSwiftUICoreShadow.h
+++ b/Sources/OpenSwiftUI_SPI/Overlay/CoreGraphics/OpenSwiftUICoreShadow.h
@@ -13,6 +13,7 @@
 #if OPENSWIFTUI_TARGET_OS_DARWIN
 
 #include <CoreGraphics/CoreGraphics.h>
+#include "OpenSwiftUICoreSystem.h"
 
 OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 
@@ -27,6 +28,20 @@ id _Nullable OpenSwiftUICoreShadowGetPlatformColor(id shadow) OPENSWIFTUI_SWIFT_
 
 OPENSWIFTUI_EXPORT
 Class _Nullable OpenSwiftUICoreShadowClass(void) OPENSWIFTUI_SWIFT_NAME(CoreShadowClass());
+
+OPENSWIFTUI_EXPORT
+id _Nullable OpenSwiftUICoreMakeNSShadow(
+    id color,
+    CGFloat offsetX,
+    CGFloat offsetY,
+    CGFloat blurRadius
+) OPENSWIFTUI_SWIFT_NAME(CoreMakeNSShadow(color:offsetX:offsetY:blurRadius:));
+
+OPENSWIFTUI_EXPORT
+id _Nullable OpenSwiftUICoreMakeNSShadowWithCustomStyleIndex(
+    OpenSwiftUICoreSystem system,
+    CGFloat index
+) OPENSWIFTUI_SWIFT_NAME(CoreMakeNSShadowWithCustomStyleIndex(system:index:));
 
 OPENSWIFTUI_ASSUME_NONNULL_END
 

--- a/Sources/OpenSwiftUI_SPI/Overlay/CoreGraphics/OpenSwiftUICoreShadow.m
+++ b/Sources/OpenSwiftUI_SPI/Overlay/CoreGraphics/OpenSwiftUICoreShadow.m
@@ -9,6 +9,8 @@
 
 #if OPENSWIFTUI_TARGET_OS_DARWIN
 
+#include "OpenSwiftUICoreColor.h"
+
 #if OPENSWIFTUI_TARGET_OS_IOS || OPENSWIFTUI_TARGET_OS_VISION
 #include <UIKit/UIKit.h>
 #elif OPENSWIFTUI_TARGET_OS_OSX
@@ -40,6 +42,50 @@ Class _Nullable OpenSwiftUICoreShadowClass(void) {
         return shadowClass;
     }
     return nil;
+}
+
+id _Nullable OpenSwiftUICoreMakeNSShadow(
+    id color,
+    CGFloat offsetX,
+    CGFloat offsetY,
+    CGFloat blurRadius
+) {
+    NSShadow *shadow = [[OpenSwiftUICoreShadowClass() alloc] init];
+    shadow.shadowOffset = CGSizeMake(offsetX, offsetY);
+    shadow.shadowBlurRadius = blurRadius;
+    shadow.shadowColor = color;
+    return shadow;
+}
+
+static id custom_shadow_style_color(OpenSwiftUICoreSystem system) {
+    static id color;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        const CGFloat components[] = {
+            -1.0,
+            -1.0,
+            -1.0,
+            1.0 / 512.0,
+        };
+        CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(
+            kCGColorSpaceExtendedSRGB
+        );
+        CGColorRef cgColor = CGColorCreate(colorSpace, components);
+        CGColorSpaceRelease(colorSpace);
+        color = [OpenSwiftUICoreColorGetKitColorClass(system) colorWithCGColor:cgColor];
+        CGColorRelease(cgColor);
+    });
+    return color;
+}
+
+id _Nullable OpenSwiftUICoreMakeNSShadowWithCustomStyleIndex(
+    OpenSwiftUICoreSystem system,
+    CGFloat index
+) {
+    NSShadow *shadow = [[OpenSwiftUICoreShadowClass() alloc] init];
+    shadow.shadowBlurRadius = index;
+    shadow.shadowColor = custom_shadow_style_color(system);
+    return shadow;
 }
 
 #endif

--- a/Sources/OpenSwiftUI_SPI/Shims/CoreText/CoreText_Private.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/CoreText/CoreText_Private.h
@@ -7,6 +7,7 @@
 #ifndef OpenSwiftUI_SPI_CoreText_Private_h
 #define OpenSwiftUI_SPI_CoreText_Private_h
 
+#include "Private/CTAdaptiveImageGlyph.h"
 #include "Private/CTCompositionLanguage.h"
 #include "Private/CTFontSPI.h"
 #include "Private/CTFontLegibilityWeight.h"

--- a/Sources/OpenSwiftUI_SPI/Shims/CoreText/Private/CTAdaptiveImageGlyph.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/CoreText/Private/CTAdaptiveImageGlyph.h
@@ -1,0 +1,22 @@
+//
+//  CTAdaptiveImageGlyph.h
+//  OpenSwiftUI_SPI
+
+#pragma once
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN && __has_include(<CoreText/CoreText.h>)
+
+#import <CoreText/CoreText.h>
+#import <Foundation/Foundation.h>
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+API_AVAILABLE(macos(15.0), ios(18.0), tvos(18.0), watchos(11.0), visionos(2.0)) NS_SWIFT_SENDABLE
+@interface CTAdaptiveImageGlyph : NSObject <CTAdaptiveImageProviding>
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
+
+#endif

--- a/Sources/OpenSwiftUI_SPI/Shims/CoreText/Private/CTCompositionLanguage.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/CoreText/Private/CTCompositionLanguage.h
@@ -24,13 +24,9 @@ OPENSWIFTUI_EXTERN_C_BEGIN
 
 CTCompositionLanguage CTParagraphStyleGetCompositionLanguageForLanguage(CFStringRef language);
 
-static inline CTCompositionLanguage OpenSwiftUI_CTParagraphStyleGetCompositionLanguageForLanguage(CFStringRef language) {
-    return CTParagraphStyleGetCompositionLanguageForLanguage(language);
-}
-
 #else
 
-static inline CTCompositionLanguage OpenSwiftUI_CTParagraphStyleGetCompositionLanguageForLanguage(CFStringRef language) {
+static inline CTCompositionLanguage CTParagraphStyleGetCompositionLanguageForLanguage(CFStringRef language) {
     return kCTCompositionLanguageUnset;
 }
 

--- a/Sources/OpenSwiftUI_SPI/Shims/CoreText/Private/CTFontSPI.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/CoreText/Private/CTFontSPI.h
@@ -1,7 +1,6 @@
 //
 //  CTFontSPI.h
 //  OpenSwiftUI_SPI
-//
 
 #pragma once
 

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAdaptiveImageGlyph.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAdaptiveImageGlyph.h
@@ -1,0 +1,49 @@
+//
+//  NSAdaptiveImageGlyph.h
+//  OpenSwiftUI_SPI
+
+#pragma once
+
+#import "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+// Modified based on macOS 26.2 SDK and iOS 18.5/26.2 SDKs. Keep the
+// declarations aligned with AppKit and UIKit because clients can import both
+// those modules and UIFoundation_Private.
+
+#import <Foundation/Foundation.h>
+#import <CoreText/CTRunDelegate.h>
+
+@protocol CTAdaptiveImageProviding;
+@class CTAdaptiveImageGlyph;
+@class UTType;
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+FOUNDATION_EXPORT NSAttributedStringKey const NSAdaptiveImageGlyphAttributeName API_AVAILABLE(macos(15.0), ios(18.0), tvos(18.0), watchos(11.0), visionos(2.0)) NS_SWIFT_NAME(adaptiveImageGlyph);
+
+API_AVAILABLE(macos(15.0), ios(18.0), tvos(18.0), watchos(11.0), visionos(2.0)) NS_SWIFT_SENDABLE
+@interface NSAdaptiveImageGlyph : NSObject <NSCopying, NSSecureCoding, CTAdaptiveImageProviding>
+
+- (instancetype)initWithImageContent:(NSData *)imageContent NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (readonly) NSData *imageContent;
+@property (readonly) NSString *contentIdentifier;
+@property (readonly, copy) NSString *contentDescription;
+
+@property (class, readonly) UTType *contentType;
+
+@end
+
+@interface NSAdaptiveImageGlyph (OpenSwiftUICore)
+
+- (instancetype)initWithCTAdaptiveImageGlyph:(CTAdaptiveImageGlyph *)adaptiveImageGlyph;
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
+
+#endif

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSParagraphStyle.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSParagraphStyle.h
@@ -68,6 +68,17 @@ typedef NS_OPTIONS(NSUInteger, NSLineBreakStrategy) {
 
 #endif // !__NSPARAGRAPH_STYLE_SHARED_SECTION__
 
+// The resolved horizontal alignment of a paragraph. Unlike `NSTextAlignment`,
+// the leading and trailing values are expressed in visual terms, and the
+// natural value is resolved by the text engine using the base writing
+// direction of the line.
+typedef NS_ENUM(NSInteger, NSTextHorizontalAlignment) {
+    NSTextHorizontalAlignmentNatural = 0,
+    NSTextHorizontalAlignmentLeft = 2,
+    NSTextHorizontalAlignmentRight = 3,
+    NSTextHorizontalAlignmentCenter = 4,
+};
+
 // NSTextTab
 typedef NSString * NSTextTabOptionKey NS_TYPED_ENUM API_AVAILABLE(macos(10.0), ios(7.0), tvos(9.0), watchos(2.0), visionos(1.0));
 OPENSWIFTUI_EXPORT NSTextTabOptionKey NSTabColumnTerminatorsAttributeName API_AVAILABLE(macos(10.0), ios(7.0), tvos(9.0), watchos(2.0), visionos(1.0)); // An attribute for NSTextTab options.  The value is NSCharacterSet.  The character set is used to determine the tab column terminating character.  The tab and newline characters are implied even if not included in the character set.
@@ -192,6 +203,15 @@ OPENSWIFTUI_EXPORT API_AVAILABLE(macos(10.0), ios(6.0), tvos(9.0), watchos(2.0),
 
 @property (nonatomic) BOOL fullyJustified_openswiftui_safe_wrapper
     OPENSWIFTUI_SWIFT_NAME(fullyJustified);
+
+@property (nonatomic) NSTextHorizontalAlignment horizontalAlignment_openswiftui_safe_wrapper
+    OPENSWIFTUI_SWIFT_NAME(horizontalAlignment);
+
+@property (nonatomic) BOOL spansAllLines_openswiftui_safe_wrapper
+    OPENSWIFTUI_SWIFT_NAME(spansAllLines);
+
+@property (nonatomic) NSLineBreakMode secondaryLineBreakMode_openswiftui_safe_wrapper
+    OPENSWIFTUI_SWIFT_NAME(secondaryLineBreakMode);
 
 @end
 

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSParagraphStyle.m
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSParagraphStyle.m
@@ -32,6 +32,36 @@
     func(self, selector, fullyJustified);
 }
 
+- (NSTextHorizontalAlignment)horizontalAlignment_openswiftui_safe_wrapper {
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(NSTextHorizontalAlignment, @"horizontalAlignment", NSTextHorizontalAlignmentNatural);
+    return func(self, selector);
+}
+
+- (void)setHorizontalAlignment_openswiftui_safe_wrapper:(NSTextHorizontalAlignment)horizontalAlignment {
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(void, @"setHorizontalAlignment:", , NSTextHorizontalAlignment);
+    func(self, selector, horizontalAlignment);
+}
+
+- (BOOL)spansAllLines_openswiftui_safe_wrapper {
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(BOOL, @"spansAllLines", NO);
+    return func(self, selector);
+}
+
+- (void)setSpansAllLines_openswiftui_safe_wrapper:(BOOL)spansAllLines {
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(void, @"setSpansAllLines:", , BOOL);
+    func(self, selector, spansAllLines);
+}
+
+- (NSLineBreakMode)secondaryLineBreakMode_openswiftui_safe_wrapper {
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(NSLineBreakMode, @"secondaryLineBreakMode", NSLineBreakByWordWrapping);
+    return func(self, selector);
+}
+
+- (void)setSecondaryLineBreakMode_openswiftui_safe_wrapper:(NSLineBreakMode)secondaryLineBreakMode {
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(void, @"setSecondaryLineBreakMode:", , NSLineBreakMode);
+    func(self, selector, secondaryLineBreakMode);
+}
+
 @end
 
 #endif

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSTextEncapsulation.h
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSTextEncapsulation.h
@@ -29,3 +29,32 @@ typedef OPENSWIFTUI_CLOSED_ENUM(NSUInteger, NSTextEncapsulationPlatterSize) {
     NSTextEncapsulationPlatterSizeRegular = 0x0,
     NSTextEncapsulationPlatterSizeLarge = 0x1,
 };
+
+#if __has_include(<Foundation/Foundation.h>) && __has_include(<CoreGraphics/CoreGraphics.h>)
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSTextEncapsulation : NSObject
+
+@property (nonatomic) NSTextEncapsulationScale scale;
+@property (nonatomic) NSTextEncapsulationShape shape;
+@property (nonatomic) NSTextEncapsulationStyle style;
+@property (nonatomic) NSTextEncapsulationPlatterSize platterSize;
+@property (nonatomic) CGFloat lineWeight;
+@property (nonatomic, strong, nullable) NSObject *color;
+@property (nonatomic) CGFloat minimumWidth;
+
+@end
+
+@interface NSTextEncapsulation (OpenSwiftUICore)
+
+- (void)setPlatformColor:(NSObject * _Nullable)platformColor;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSTextEncapsulation.m
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSTextEncapsulation.m
@@ -1,0 +1,20 @@
+//
+//  NSTextEncapsulation.m
+//  OpenSwiftUI_SPI
+//
+//  Audited for 6.5.4
+//  Status: Complete
+
+#include "NSTextEncapsulation.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+@implementation NSTextEncapsulation (OpenSwiftUICore)
+
+- (void)setPlatformColor:(NSObject * _Nullable)platformColor {
+    self.color = platformColor;
+}
+
+@end
+
+#endif

--- a/Tests/OpenSwiftUICoreTests/Shim/CoreFoundationNonDarwinShimsTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Shim/CoreFoundationNonDarwinShimsTests.swift
@@ -1,0 +1,60 @@
+//
+//  CoreFoundationNonDarwinShimsTests.swift
+//  OpenSwiftUICoreTests
+
+#if !canImport(Darwin)
+import CoreFoundation
+import Foundation
+@testable import OpenSwiftUICore
+import Testing
+
+private final class Value: CFCompatObject {
+    let number: Int
+
+    init(_ number: Int) {
+        self.number = number
+        super.init()
+    }
+
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Value else { return false }
+        return other.number == number
+    }
+
+    override var hash: Int {
+        number.hashValue
+    }
+}
+
+private let key: NSAttributedString.Key = .init("OpenSwiftUITests.CFCompatObject")
+
+struct CoreFoundationNonDarwinShimsTests {
+    @Test
+    func cfEqualUsesIsEqual() {
+        #expect(CFEqual(Value(1), Value(1)))
+        #expect(!CFEqual(Value(1), Value(2)))
+    }
+
+    @Test
+    func cfHashUsesHash() {
+        #expect(CFHash(Value(1)) == CFHash(Value(1)))
+        #expect(CFHash(Value(1)) == CFHashCode(bitPattern: 1.hashValue))
+    }
+
+    @Test
+    func attributeRunsMergeOnEqualValues() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(key, value: Value(1), range: NSRange(location: 0, length: 2))
+        string.addAttribute(key, value: Value(1), range: NSRange(location: 2, length: 3))
+        #expect(string.runs().count == 1)
+    }
+
+    @Test
+    func attributeRunsSplitOnDifferentValues() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(key, value: Value(1), range: NSRange(location: 0, length: 2))
+        string.addAttribute(key, value: Value(2), range: NSRange(location: 2, length: 3))
+        #expect(string.runs().count == 2)
+    }
+}
+#endif

--- a/Tests/OpenSwiftUICoreTests/Util/Extension/NSAttributedString+ExtensionTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Util/Extension/NSAttributedString+ExtensionTests.swift
@@ -1,0 +1,155 @@
+//
+//  NSAttributedString+ExtensionTests.swift
+//  OpenSwiftUICoreTests
+
+import Foundation
+@testable import OpenSwiftUICore
+import Testing
+import UIFoundation_Private
+
+private let keyA: NSAttributedString.Key = .init("OpenSwiftUITests.A")
+private let keyB: NSAttributedString.Key = .init("OpenSwiftUITests.B")
+
+private func paragraphStyle(_ mode: NSLineBreakMode) -> NSParagraphStyle {
+    let style = NSMutableParagraphStyle()
+    style.lineBreakMode = mode
+    return style
+}
+
+struct NSAttributedString_ExtensionTests {
+
+    // MARK: - range
+
+    @Test
+    func range() {
+        #expect(NSAttributedString(string: "").range == NSRange(location: 0, length: 0))
+        #expect(NSAttributedString(string: "Hello").range == NSRange(location: 0, length: 5))
+    }
+
+    // MARK: - firstAttribute
+
+    @Test
+    func firstAttributeReturnsNilWhenAbsent() {
+        let string = NSAttributedString(string: "Hello")
+        #expect(string.firstAttribute(Int.self, name: keyA) == nil)
+    }
+
+    @Test
+    func firstAttributeSkipsMismatchedType() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(keyA, value: "text", range: NSRange(location: 0, length: 2))
+        #expect(string.firstAttribute(Int.self, name: keyA) == nil)
+        #expect(string.firstAttribute(String.self, name: keyA) == "text")
+    }
+
+    @Test
+    func firstAttributeReturnsEarliestValue() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(keyA, value: 1, range: NSRange(location: 1, length: 1))
+        string.addAttribute(keyA, value: 2, range: NSRange(location: 3, length: 1))
+        #expect(string.firstAttribute(Int.self, name: keyA) == 1)
+    }
+
+    // MARK: - replacingLineBreakModes
+
+    @Test
+    func replacingLineBreakModesWithoutParagraphStyle() {
+        let string = NSAttributedString(string: "Hello")
+        #expect(string.replacingLineBreakModes(.byClipping) === string)
+    }
+
+    @Test
+    func replacingLineBreakModesWithMatchingMode() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(.kitParagraphStyle, value: paragraphStyle(.byClipping), range: string.range)
+        #expect(string.replacingLineBreakModes(.byClipping) === string)
+    }
+
+    @Test
+    func replacingLineBreakModesUpdatesMatchingRanges() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(
+            .kitParagraphStyle,
+            value: paragraphStyle(.byWordWrapping),
+            range: NSRange(location: 0, length: 2)
+        )
+        string.addAttribute(
+            .kitParagraphStyle,
+            value: paragraphStyle(.byClipping),
+            range: NSRange(location: 2, length: 3)
+        )
+        let result = string.replacingLineBreakModes(.byTruncatingTail)
+        #expect(result !== string)
+        #expect(result.string == "Hello")
+        let runs = result.runs()
+        let modes = runs.compactMap { run in
+            (run.attributes[.kitParagraphStyle] as? NSParagraphStyle)?.lineBreakMode
+        }
+        #expect(modes.count == runs.count)
+        #expect(modes.allSatisfy { $0 == .byTruncatingTail })
+        // The receiver is left untouched.
+        let style = string.firstAttribute(NSParagraphStyle.self, name: .kitParagraphStyle)
+        #expect(style?.lineBreakMode == .byWordWrapping)
+    }
+
+    // MARK: - addUniformAttribute
+
+    @Test
+    func addUniformAttributes() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addUniformAttribute(keyA, value: 1)
+        string.addUniformAttributes([keyB: 2])
+        let runs = string.runs()
+        #expect(runs.count == 1)
+        #expect(runs[0].range == string.range)
+        #expect(runs[0].attributes[keyA] as? Int == 1)
+        #expect(runs[0].attributes[keyB] as? Int == 2)
+    }
+
+    // MARK: - mergeAttributes
+
+    @Test
+    func mergeAttributesWithEmptyRange() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.mergeAttributes([keyA: 1], in: NSRange(location: 0, length: 0))
+        #expect(string.runs().count == 1)
+        #expect(string.runs()[0].attributes.isEmpty)
+    }
+
+    @Test
+    func mergeAttributesPreservesExistingAttributes() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(keyA, value: 1, range: NSRange(location: 0, length: 2))
+        string.mergeAttributes([keyB: 2])
+        let runs = string.runs()
+        #expect(runs.count == 2)
+        #expect(runs[0].range == NSRange(location: 0, length: 2))
+        #expect(runs[0].attributes[keyA] as? Int == 1)
+        #expect(runs[0].attributes[keyB] as? Int == 2)
+        #expect(runs[1].range == NSRange(location: 2, length: 3))
+        #expect(runs[1].attributes[keyA] == nil)
+        #expect(runs[1].attributes[keyB] as? Int == 2)
+    }
+
+    @Test
+    func mergeAttributesInSubrange() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.mergeAttributes([keyA: 1], in: NSRange(location: 1, length: 2))
+        let runs = string.runs()
+        #expect(runs.count == 3)
+        #expect(runs[1].range == NSRange(location: 1, length: 2))
+        #expect(runs[1].attributes[keyA] as? Int == 1)
+    }
+
+    // MARK: - runs
+
+    @Test
+    func runs() {
+        let string = NSMutableAttributedString(string: "Hello")
+        string.addAttribute(keyA, value: 1, range: NSRange(location: 0, length: 3))
+        let all = string.runs()
+        #expect(all.map(\.range) == [NSRange(location: 0, length: 3), NSRange(location: 3, length: 2)])
+        let partial = string.runs(in: NSRange(location: 2, length: 2))
+        #expect(partial.map(\.range) == [NSRange(location: 2, length: 1), NSRange(location: 3, length: 1)])
+    }
+}


### PR DESCRIPTION
## Summary

Implements `Text.Style.nsAttributes` in `OpenSwiftUICore`, resolving a `Text.Style`
into `[NSAttributedString.Key: Any]`.

Covers typesetting language, language-aware line height, font, foreground/background
color, baseline offset, kerning, tracking, underline/strikethrough, encapsulation,
text scale, adaptive image glyph, shadow, transitions, paragraph style, accessibility,
custom attributes, and superscript.

## Supporting changes

- New SPI shims: `NSTextEncapsulation`, `NSAdaptiveImageGlyph`, `CTAdaptiveImageGlyph`,
  `CTCompositionLanguage`, extra `NSParagraphStyle` safe wrappers, and
  `OpenSwiftUICoreShadow` helpers.
- `ParagraphTypesetting`, `WritingMode`, and `NSTextHorizontalAlignment` /
  `NSWritingDirection` conversions.
- `NSAttributedString+Extension` helpers.
- Non-Darwin shims extended for the new code paths, including an `NDColor`-backed
  `kitColor` in `ColorNonDarwinShims`.

## Testing

- `swift build` and `swift test` on macOS.
- Added `NSAttributedString+ExtensionTests`.
