### PR TITLE
Implement custom Font APIs

### DIFF
--- a/Sources/OpenSwiftUICore/View/Text/Font/CustomFont.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Font/CustomFont.swift
@@ -13,6 +13,8 @@ public import CoreText
 
 @available(OpenSwiftUI_v1_0, *)
 extension Font {
+    /// Create a custom font with the given `name` and `size` that scales with
+    /// the body text style.
     public static func custom(_ name: String, size: CGFloat) -> Font {
         Font(
             provider: NamedProvider(
@@ -23,6 +25,8 @@ extension Font {
         )
     }
 
+    /// Create a custom font with the given `name` and `size` that scales
+    /// relative to the given `textStyle`.
     @available(OpenSwiftUI_v2_0, *)
     public static func custom(
         _ name: String,
@@ -48,6 +52,8 @@ extension Font {
         custom(name, size: size, relativeTo: textStyle)
     }
 
+    /// Create a custom font with the given `name` and a fixed `size` that does
+    /// not scale with Dynamic Type.
     @available(OpenSwiftUI_v2_0, *)
     public static func custom(_ name: String, fixedSize: CGFloat) -> Font {
         Font(
@@ -65,6 +71,22 @@ extension Font {
         custom(name, fixedSize: verbatimSize)
     }
 
+    /// Creates a custom font from a platform font instance.
+    ///
+    /// Initializing ``Font`` with platform font instance
+    /// ([CTFont](https://developer.apple.com/documentation/coretext/ctfont-q6r))
+    /// can bridge OpenSwiftUI ``Font`` with
+    /// [NSFont](https://developer.apple.com/documentation/appkit/nsfont) or
+    /// [UIFont](https://developer.apple.com/documentation/uikit/uifont), both
+    /// of which are toll-free bridged to
+    /// [CTFont](https://developer.apple.com/documentation/coretext/ctfont-q6r).
+    /// For example:
+    ///
+    ///     // Use native Core Text API to create desired ctFont.
+    ///     let ctFont = CTFontCreateUIFontForLanguage(.system, 12, nil)!
+    ///
+    ///     // Create OpenSwiftUI Text with the CTFont instance.
+    ///     let text = Text("Hello").font(Font(ctFont))
     public init(_ font: CTFont) {
         self.init(provider: PlatformFontProvider(font: font))
     }

--- a/Sources/OpenSwiftUICore/View/Text/Font/CustomFont.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Font/CustomFont.swift
@@ -2,5 +2,100 @@
 //  CustomFont.swift
 //  OpenSwiftUICore
 //
-//  Status: TODO
+//  Audited for 6.5.4
+//  Status: Complete
 //  ID: A1A6E08ED7787270EADAD2AE750791A9 (SwiftUICore)
+
+public import Foundation
+#if canImport(CoreText)
+public import CoreText
+#endif
+
+@available(OpenSwiftUI_v1_0, *)
+extension Font {
+    public static func custom(_ name: String, size: CGFloat) -> Font {
+        Font(
+            provider: NamedProvider(
+                name: name,
+                size: size,
+                textStyle: .body
+            )
+        )
+    }
+
+    @available(OpenSwiftUI_v2_0, *)
+    public static func custom(
+        _ name: String,
+        size: CGFloat,
+        relativeTo textStyle: Font.TextStyle
+    ) -> Font {
+        Font(
+            provider: NamedProvider(
+                name: name,
+                size: size,
+                textStyle: textStyle
+            )
+        )
+    }
+
+    @available(OpenSwiftUI_v2_0, *)
+    @available(*, deprecated, renamed: "custom(_:size:textStyle:)")
+    public static func _custom(
+        _ name: String,
+        size: CGFloat,
+        textStyle: Font.TextStyle
+    ) -> Font {
+        custom(name, size: size, relativeTo: textStyle)
+    }
+
+    @available(OpenSwiftUI_v2_0, *)
+    public static func custom(_ name: String, fixedSize: CGFloat) -> Font {
+        Font(
+            provider: NamedProvider(
+                name: name,
+                size: fixedSize,
+                textStyle: nil
+            )
+        )
+    }
+
+    @available(OpenSwiftUI_v2_0, *)
+    @available(*, deprecated, renamed: "custom(_:fixedSize:)")
+    public static func _custom(_ name: String, verbatimSize: CGFloat) -> Font {
+        custom(name, fixedSize: verbatimSize)
+    }
+
+    public init(_ font: CTFont) {
+        self.init(provider: PlatformFontProvider(font: font))
+    }
+}
+
+extension Font {
+    private struct NamedProvider: FontProvider {
+        var name: String
+        var size: CGFloat
+        var textStyle: Font.TextStyle?
+
+        func resolve(in context: Font.Context) -> CTFontDescriptor {
+            context.fontDefinition.base
+                .resolveCustomFont(
+                    name: name,
+                    size: size,
+                    textStyle: textStyle,
+                    in: context
+                )
+        }
+    }
+
+    private struct PlatformFontProvider: FontProvider {
+        var font: CTFont
+
+        func resolve(in context: Font.Context) -> CTFontDescriptor {
+            context.fontDefinition.base.resolveFont(font)
+        }
+
+        func resolveTraits(in context: Font.Context) -> Font.ResolvedTraits {
+            context.fontDefinition.base.resolveFontInfo(font)
+        }
+    }
+}

--- a/Tests/OpenSwiftUICoreTests/View/Text/Font/FontTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/Text/Font/FontTests.swift
@@ -21,6 +21,81 @@ struct FontTests {
         let boldWeight = CTFontDescriptorGetWeight(boldDescriptor)
         #expect(boldWeight.isApproximatelyEqual(to: 0.3, absoluteTolerance: 0.01))
     }
+
+    @Test
+    func customFontIdentity() {
+        let body = Font.custom("Helvetica", size: 17.0)
+
+        #expect(body == Font.custom("Helvetica", size: 17.0))
+        #expect(body == Font.custom("Helvetica", size: 17.0, relativeTo: .body))
+        #expect(body != Font.custom("Helvetica", size: 17.0, relativeTo: .headline))
+        #expect(body != Font.custom("Helvetica", fixedSize: 17.0))
+        #expect(body != Font.custom("Helvetica Neue", size: 17.0))
+    }
+
+    @MainActor
+    @Test
+    func customFontSizing() throws {
+        try Semantics.v2.test(as: \.sdk) {
+            let size = 17.0
+            let dynamicTypeSize = DynamicTypeSize.accessibility5
+
+            let scalableDescriptor = Font.custom(
+                "Helvetica",
+                size: size
+            ).resolve(in: dynamicTypeSize)
+            let fixedDescriptor = Font.custom(
+                "Helvetica",
+                fixedSize: size
+            ).resolve(in: dynamicTypeSize)
+
+            let scalableSize = try #require(
+                CTFontDescriptorCopyAttribute(
+                    scalableDescriptor,
+                    kCTFontSizeAttribute
+                ) as? CGFloat
+            )
+            let fixedSize = try #require(
+                CTFontDescriptorCopyAttribute(
+                    fixedDescriptor,
+                    kCTFontSizeAttribute
+                ) as? CGFloat
+            )
+            let expectedScalableSize = (
+                Font.scaleFactor(
+                    textStyle: .body,
+                    in: dynamicTypeSize
+                ) * size
+            ).rounded()
+
+            #expect(
+                scalableSize.isApproximatelyEqual(
+                    to: expectedScalableSize,
+                    absoluteTolerance: 0.01
+                )
+            )
+            #expect(
+                fixedSize.isApproximatelyEqual(
+                    to: size,
+                    absoluteTolerance: 0.01
+                )
+            )
+        }
+    }
+
+    @Test
+    func platformFont() {
+        let platformFont = CTFontCreateWithName(
+            "Helvetica" as CFString,
+            23.0,
+            nil
+        )
+        let font = Font(platformFont)
+        let descriptor = font.resolve(in: .large)
+
+        #expect(CFEqual(descriptor, CTFontCopyFontDescriptor(platformFont)))
+        #expect(Set([font, Font(platformFont)]).count == 1)
+    }
 }
 
 #endif

--- a/Tests/OpenSwiftUICoreTests/View/Text/Font/FontTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/Text/Font/FontTests.swift
@@ -2,15 +2,18 @@
 //  FontTests.swift
 //  OpenSwiftUICoreTests
 
-#if canImport(Darwin)
-
-import CoreText
-import Numerics
+import Foundation
 @_spi(Private)
 import OpenSwiftUICore
 import Testing
 
+#if canImport(CoreText)
+import CoreText
+import Numerics
+#endif
+
 struct FontTests {
+    #if canImport(CoreText)
     @Test
     func fontModifier() {
         let descriptor = Font.body.resolve(in: .large)
@@ -21,6 +24,7 @@ struct FontTests {
         let boldWeight = CTFontDescriptorGetWeight(boldDescriptor)
         #expect(boldWeight.isApproximatelyEqual(to: 0.3, absoluteTolerance: 0.01))
     }
+    #endif
 
     @Test
     func customFontIdentity() {
@@ -33,6 +37,32 @@ struct FontTests {
         #expect(body != Font.custom("Helvetica Neue", size: 17.0))
     }
 
+    @Test
+    @available(*, deprecated)
+    func deprecatedCustomFontFactories() {
+        #expect(
+            Font._custom(
+                "Helvetica",
+                size: 17.0,
+                textStyle: .headline
+            ) == Font.custom(
+                "Helvetica",
+                size: 17.0,
+                relativeTo: .headline
+            )
+        )
+        #expect(
+            Font._custom(
+                "Helvetica",
+                verbatimSize: 17.0
+            ) == Font.custom(
+                "Helvetica",
+                fixedSize: 17.0
+            )
+        )
+    }
+
+    #if canImport(CoreText)
     @MainActor
     @Test
     func customFontSizing() throws {
@@ -48,6 +78,11 @@ struct FontTests {
                 "Helvetica",
                 fixedSize: size
             ).resolve(in: dynamicTypeSize)
+            let relativeDescriptor = Font.custom(
+                "Helvetica",
+                size: size,
+                relativeTo: .headline
+            ).resolve(in: dynamicTypeSize)
 
             let scalableSize = try #require(
                 CTFontDescriptorCopyAttribute(
@@ -61,9 +96,21 @@ struct FontTests {
                     kCTFontSizeAttribute
                 ) as? CGFloat
             )
+            let relativeSize = try #require(
+                CTFontDescriptorCopyAttribute(
+                    relativeDescriptor,
+                    kCTFontSizeAttribute
+                ) as? CGFloat
+            )
             let expectedScalableSize = (
                 Font.scaleFactor(
                     textStyle: .body,
+                    in: dynamicTypeSize
+                ) * size
+            ).rounded()
+            let expectedRelativeSize = (
+                Font.scaleFactor(
+                    textStyle: .headline,
                     in: dynamicTypeSize
                 ) * size
             ).rounded()
@@ -80,22 +127,36 @@ struct FontTests {
                     absoluteTolerance: 0.01
                 )
             )
+            #expect(
+                relativeSize.isApproximatelyEqual(
+                    to: expectedRelativeSize,
+                    absoluteTolerance: 0.01
+                )
+            )
         }
     }
+    #endif
 
     @Test
     func platformFont() {
+        #if canImport(CoreText)
         let platformFont = CTFontCreateWithName(
             "Helvetica" as CFString,
             23.0,
             nil
         )
-        let font = Font(platformFont)
-        let descriptor = font.resolve(in: .large)
+        #else
+        let platformFont = CTFont()
+        #endif
 
-        #expect(CFEqual(descriptor, CTFontCopyFontDescriptor(platformFont)))
+        let font = Font(platformFont)
         #expect(Set([font, Font(platformFont)]).count == 1)
+
+        #if canImport(CoreText)
+        let descriptor = font.resolve(in: .large)
+        #expect(CFEqual(descriptor, CTFontCopyFontDescriptor(platformFont)))
+        #else
+        #expect(font != Font(CTFont()))
+        #endif
     }
 }
-
-#endif


### PR DESCRIPTION
## Summary

- Add scalable and fixed-size custom font factories, including deprecated compatibility overloads.
- Add `CTFont`-backed `Font` initialization with cross-platform identity and hashing support.
- Document the public APIs and add macOS/Linux coverage for Dynamic Type sizing, descriptor bridging, deprecated aliases, and hashing behavior.

## Validation

- Custom Font unit tests pass on macOS and Linux.