### PR TITLE
Fix Xcode Previews for binary framework distributions

### DIFF
--- a/Docs/Preview.md
+++ b/Docs/Preview.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-OpenSwiftUI supports Xcode Preview rendering as of [PR #829](https://github.com/OpenSwiftUIProject/OpenSwiftUI/pull/829).
+OpenSwiftUI supports Xcode Preview rendering through the shim introduced in [PR #829](https://github.com/OpenSwiftUIProject/OpenSwiftUI/pull/829). Source builds and binary distributions must also satisfy the linkage requirements below.
 
 ### How It Works
 
@@ -17,6 +17,14 @@ Since OpenSwiftUI cannot use SwiftUI's `#Preview` macro directly (it targets `Sw
 }
 ```
 
+### Binary XCFramework Requirements
+
+Xcode Preview's XOJIT loading model requires both `OpenSwiftUI.framework` and `OpenSwiftUICore.framework` to be dynamic. Packaging `OpenSwiftUICore` as a static framework allows Preview to relink another copy of Core into the preview product, which can duplicate runtime metadata and crash the Preview process.
+
+Link `OpenSwiftUICore` with `-ObjC` when building the framework so Objective-C categories from the static `OpenSwiftUI_SPI` dependency are retained in the Core dylib. This is a framework-build setting; consumers of the resulting XCFrameworks do not need to add `-ObjC`.
+
+This layout was validated with locally built XCFrameworks consumed through `OpenSwiftUI-spm` local binary targets: the Tuist Example's `HostingVC` Preview rendered without consumer-side linker flags.
+
 ### The `waitingForPreviewThunks` Problem
 
 In Xcode Preview mode, SwiftUI gates graph instantiation behind a `waitingForPreviewThunks` flag (checked via `XCODE_RUNNING_FOR_PREVIEWS` env var). After all preview dylibs are loaded, `PreviewsInjection.framework` calls `SwiftUI.__previewThunksHaveFinishedLoading()` to unblock graph hosts.
@@ -25,7 +33,9 @@ In Xcode Preview mode, SwiftUI gates graph instantiation behind a `waitingForPre
 
 **Current fix**: `waitingForPreviewThunks` is hardcoded to `false`, bypassing the blocking entirely. This is semantically correct because OpenSwiftUI has no preview thunk producers today.
 
-## PreviewsInjection Sequence
+## SwiftUI PreviewsInjection Reference Sequence
+
+The following sequence describes SwiftUI's reference path. OpenSwiftUI currently bypasses the initial wait as described above.
 
 ```mermaid
 sequenceDiagram

--- a/Docs/XCFrameworkPackaging.md
+++ b/Docs/XCFrameworkPackaging.md
@@ -197,10 +197,17 @@ modules.
 Use multiple xcframeworks, one per Swift module, and expose them through one
 Swift package product.
 
-Prefer static frameworks for these xcframeworks:
+Build `OpenSwiftUI` and `OpenSwiftUICore` as dynamic frameworks. Xcode
+Preview's XOJIT loading model can relink a static Core into the preview product,
+creating a second copy of its Swift runtime metadata. Keeping both modules
+dynamic gives Core one runtime identity. Link `OpenSwiftUICore` with `-ObjC`
+while building the framework so Objective-C categories from its static SPI
+dependency are retained.
+
+Prefer static frameworks for the remaining support xcframeworks:
 
 - They preserve the Swift module graph for the compiler.
-- They avoid embedding many dynamic frameworks into client apps.
+- They avoid embedding additional dynamic frameworks into client apps.
 - They let the final app link the implementation code into the app binary.
 - They keep the user-facing API as one package product.
 
@@ -283,6 +290,7 @@ So the source-backend release shape still publishes the same OpenSwiftUI
 xcframework set. It does not require consumers to embed or load a separate
 Compute dynamic framework.
 
-Dynamic frameworks should be avoided unless there is a runtime reason to share
-or load the frameworks dynamically. They make embedding, signing, launch-time
-loading, and artifact management more complicated.
+Dynamic frameworks should be limited to modules with a runtime reason to share
+one loaded identity. `OpenSwiftUI` and `OpenSwiftUICore` are the intentional
+exceptions; the remaining support frameworks stay static to minimize embedding,
+signing, launch-time loading, and artifact-management overhead.

--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -69,10 +69,14 @@ let openSwiftUIPackageConfigurations: [Configuration] = [
 let openSwiftUITargetSettings: SettingsDictionary = [
     "DYLIB_INSTALL_NAME_BASE": "@rpath",
 ]
+let openSwiftUICoreTargetSettings: SettingsDictionary = [
+    "DYLIB_INSTALL_NAME_BASE": "@rpath",
+    "OTHER_LDFLAGS": "$(inherited) -ObjC",
+]
 
 var packageProductTypes: [String: ProjectDescription.Product] = [
     "OpenSwiftUI": ProjectDescription.Product.framework,
-    "OpenSwiftUICore": ProjectDescription.Product.staticFramework,
+    "OpenSwiftUICore": ProjectDescription.Product.framework,
     "OpenSwiftUI_SPI": ProjectDescription.Product.staticFramework,
     "COpenSwiftUI": ProjectDescription.Product.staticFramework,
     "OpenSwiftUIMacros": ProjectDescription.Product.macro,
@@ -119,6 +123,12 @@ let packageSettings = PackageSettings(
     targetSettings: [
         "OpenSwiftUI": .settings(
             base: openSwiftUITargetSettings,
+            configurations: openSwiftUIPackageConfigurations,
+            defaultSettings: .essential,
+            defaultConfiguration: "OpenSwiftUIDebug"
+        ),
+        "OpenSwiftUICore": .settings(
+            base: openSwiftUICoreTargetSettings,
             configurations: openSwiftUIPackageConfigurations,
             defaultSettings: .essential,
             defaultConfiguration: "OpenSwiftUIDebug"

--- a/Package.swift
+++ b/Package.swift
@@ -968,11 +968,15 @@ let openSwiftUITargetSettings: SettingsDictionary = [
     "OPENSWIFTUI_BUILD_LIBRARY_TYPE": .string(openSwiftUIBuildLibraryType),
     "OPENSWIFTUI_BUILD_USES_LOCAL_DEPENDENCIES": .string(useLocalDeps ? "YES" : "NO"),
 ]
+let openSwiftUICoreTargetSettings: SettingsDictionary = [
+    "DYLIB_INSTALL_NAME_BASE": "@rpath",
+    "OTHER_LDFLAGS": "$(inherited) -ObjC",
+]
 
 let packageSettings = PackageSettings(
     productTypes: [
         "OpenSwiftUI": ProjectDescription.Product.framework,
-        "OpenSwiftUICore": ProjectDescription.Product.staticFramework,
+        "OpenSwiftUICore": ProjectDescription.Product.framework,
         "OpenSwiftUI_SPI": ProjectDescription.Product.staticFramework,
         "COpenSwiftUI": ProjectDescription.Product.staticFramework,
         "OpenSwiftUIMacros": ProjectDescription.Product.macro,
@@ -988,6 +992,7 @@ let packageSettings = PackageSettings(
     baseProductType: ProjectDescription.Product.staticFramework,
     targetSettings: [
         "OpenSwiftUI": .settings(base: openSwiftUITargetSettings),
+        "OpenSwiftUICore": .settings(base: openSwiftUICoreTargetSettings),
     ]
 )
 #endif


### PR DESCRIPTION
## Summary

- Build `OpenSwiftUICore` as a dynamic framework in both Tuist package configurations.
- Give the Core framework an `@rpath` install name and link it with `-ObjC` so Objective-C categories from the static SPI dependency are retained.
- Document the framework layout required by binary XCFramework distributions and clarify the existing Preview injection behavior.

## Why

Packaging `OpenSwiftUICore` as a static framework allows Xcode Preview's XOJIT product to load another copy of Core alongside `OpenSwiftUI`. The duplicated Swift runtime metadata can crash the Preview process. Keeping both UI modules dynamic gives Core a single loaded runtime identity, while the remaining support frameworks can stay static.

## Impact

Binary distributions can render OpenSwiftUI previews without requiring consumer-side linker flags. Source package behavior remains unchanged outside the Tuist product configuration.

## Validation

Locally built XCFrameworks were consumed through `OpenSwiftUI-spm` local binary targets. The Tuist Example's `HostingVC` Preview rendered successfully without additional consumer linker settings.