### PR TITLE
Fix PropertyList mutation and comparison semantics

### DIFF
--- a/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
+++ b/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
@@ -819,12 +819,12 @@ extension PropertyList {
     @usableFromInline
     package class Element: CustomStringConvertible {
         let keyType: any Any.Type
-        let before: Element?
-        var after: Element?
-        var skip: Unmanaged<Element>?
-        let length: UInt32
-        let skipCount: UInt32
-        let skipFilter: BloomFilter
+        fileprivate let before: Element?
+        fileprivate var after: Element?
+        fileprivate var skip: Unmanaged<Element>?
+        fileprivate let length: UInt32
+        fileprivate let skipCount: UInt32
+        fileprivate let skipFilter: BloomFilter
         let id = UniqueID()
 
         fileprivate init(keyType: any Any.Type, before: Element?, after: Element?) {
@@ -910,7 +910,7 @@ extension PropertyList {
         ///   - other: The element to compare with.
         ///   - ignoredTypes: Types to ignore during comparison.
         /// - Returns: `true` if the elements match, otherwise `false`.
-        func matches(_ other: Element, ignoredTypes: inout [ObjectIdentifier]) -> Bool {
+        fileprivate func matches(_ other: Element, ignoredTypes: inout [ObjectIdentifier]) -> Bool {
             _openSwiftUIBaseClassAbstractMethod()
         }
 
@@ -920,7 +920,7 @@ extension PropertyList {
         ///   - before: The element to link before this one.
         ///   - after: The element to link after this one.
         /// - Returns: A new element with the same value but different links.
-        func copy(before: Element?, after: Element?) -> Element {
+        fileprivate func copy(before: Element?, after: Element?) -> Element {
             _openSwiftUIBaseClassAbstractMethod()
         }
 

--- a/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
+++ b/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
@@ -235,8 +235,7 @@ package struct PropertyList: CustomStringConvertible {
     /// - Parameter other: The PropertyList to compare with.
     /// - Returns: `true` if the PropertyLists might not be equal, otherwise `false`.
     package func mayNotBeEqual(to other: PropertyList) -> Bool {
-        var ignoredTypes = [ObjectIdentifier]()
-        return mayNotBeEqual(to: other, ignoredTypes: &ignoredTypes)
+        mayNotBeEqual(to: other, ignoredTypes: [])
     }
 
     /// Checks if this PropertyList might not be equal to another PropertyList, ignoring specified types.
@@ -245,11 +244,12 @@ package struct PropertyList: CustomStringConvertible {
     ///   - other: The PropertyList to compare with.
     ///   - ignoredTypes: Types to ignore during comparison.
     /// - Returns: `true` if the PropertyLists might not be equal, otherwise `false`.
-    package func mayNotBeEqual(to other: PropertyList, ignoredTypes: inout [ObjectIdentifier]) -> Bool {
+    package func mayNotBeEqual(to other: PropertyList, ignoredTypes: [ObjectIdentifier]) -> Bool {
         guard let elements,
               let otherElements = other.elements else {
             return !isEmpty || !other.isEmpty
         }
+        var ignoredTypes = ignoredTypes
         return !compareLists(
             .passUnretained(elements),
             .passUnretained(otherElements),

--- a/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
+++ b/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
@@ -179,13 +179,15 @@ package struct PropertyList: CustomStringConvertible {
             }
         }
         set {
-            guard let result = find(
-                elements.map { .passUnretained($0) },
-                key: key
-            ), K.valuesEqual(newValue, result.takeUnretainedValue().value)
-            else {
-                prependValue(newValue, for: key)
-                return
+            withExtendedLifetime(elements) {
+                guard let result = find(
+                    elements.map { .passUnretained($0) },
+                    key: key
+                ), K.valuesEqual(newValue, result.takeUnretainedValue().value)
+                else {
+                    prependValue(newValue, for: key)
+                    return
+                }
             }
         }
     }

--- a/Sources/OpenSwiftUICore/Graph/GraphReuse.swift
+++ b/Sources/OpenSwiftUICore/Graph/GraphReuse.swift
@@ -110,7 +110,7 @@ extension _GraphInputs: GraphReusable {
             return false
         }
         var ignoredTypes = reusableInputsArray + [ObjectIdentifier(ReusableInputs.self)]
-        guard !customInputs.mayNotBeEqual(to: other.customInputs, ignoredTypes: &ignoredTypes) else {
+        guard !customInputs.mayNotBeEqual(to: other.customInputs, ignoredTypes: ignoredTypes) else {
             Log.graphReuse("Reuse failed: custom inputs plist equality")
             return false
         }

--- a/Tests/OpenSwiftUICoreTests/Data/Util/PropertyListTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Util/PropertyListTests.swift
@@ -142,6 +142,22 @@ struct PropertyListTests {
         [IntKey = 42, StringKey = Hello]
         """#)
     }
+
+    @Test
+    func mayNotBeEqualDoesNotMutateIgnoredTypes() {
+        var plist1 = PropertyList()
+        plist1[IntKey.self] = 1
+        plist1[StringKey.self] = "same"
+
+        var plist2 = PropertyList()
+        plist2[IntKey.self] = 2
+        plist2[StringKey.self] = "same"
+
+        let ignoredTypes = [ObjectIdentifier(IntKey.self)]
+
+        #expect(!plist1.mayNotBeEqual(to: plist2, ignoredTypes: ignoredTypes))
+        #expect(ignoredTypes == [ObjectIdentifier(IntKey.self)])
+    }
 }
 
 struct PropertyListTrackerTests {

--- a/Tests/OpenSwiftUISymbolDualTests/Data/PropertyListTests.swift
+++ b/Tests/OpenSwiftUISymbolDualTests/Data/PropertyListTests.swift
@@ -40,7 +40,7 @@ extension PropertyList {
     func swiftUI_mayNotBeEqual(to: PropertyList) -> Bool
 
     @_silgen_name("OpenSwiftUITestStub_PropertyListMayNotBeEqualIgnoredTypes")
-    func swiftUI_mayNotBeEqual(to: PropertyList, ignoredTypes: inout [ObjectIdentifier]) -> Bool
+    func swiftUI_mayNotBeEqual(to: PropertyList, ignoredTypes: [ObjectIdentifier]) -> Bool
 
     @_silgen_name("OpenSwiftUITestStub_PropertyListSet")
     mutating func swiftUI_set(_ other: PropertyList)
@@ -204,6 +204,22 @@ struct PropertyListTests {
         #expect(plist4.swiftUI_description == #"""
         [IntKey = 42, StringKey = Hello]
         """#)
+    }
+
+    @Test
+    func mayNotBeEqualDoesNotMutateIgnoredTypes() {
+        var plist1 = PropertyList(swiftUI: ())
+        plist1[swiftUI: IntKey.self] = 1
+        plist1[swiftUI: StringKey.self] = "same"
+
+        var plist2 = PropertyList(swiftUI: ())
+        plist2[swiftUI: IntKey.self] = 2
+        plist2[swiftUI: StringKey.self] = "same"
+
+        let ignoredTypes = [ObjectIdentifier(IntKey.self)]
+
+        #expect(!plist1.swiftUI_mayNotBeEqual(to: plist2, ignoredTypes: ignoredTypes))
+        #expect(ignoredTypes == [ObjectIdentifier(IntKey.self)])
     }
 }
 


### PR DESCRIPTION
## Summary

- preserve `PropertyList` elements during value lookup and mutation
- pass ignored property types by value so comparisons do not mutate caller-owned arrays
- tighten access to `PropertyList.Element` implementation details
- add direct and symbol-dual coverage for preserving ignored type lists