### PR TITLE
Fix selector handling in Objective-C shims

### DIFF
--- a/Sources/COpenSwiftUI/Overlay/UIKit/OpenSwiftUI+UIApplication.m
+++ b/Sources/COpenSwiftUI/Overlay/UIKit/OpenSwiftUI+UIApplication.m
@@ -6,22 +6,15 @@
 //  Status: Complete
 
 #include "OpenSwiftUI+UIApplication.h"
+#include "Shims/OpenSwiftUIShims.h"
 
 #if OPENSWIFTUI_TARGET_OS_IOS || OPENSWIFTUI_TARGET_OS_VISION
 #include <objc/runtime.h>
 
 UIContentSizeCategory _UIApplicationDefaultContentSizeCategory() {
-    typedef UIContentSizeCategory (*Func)(Class, SEL);
-    SEL selector = NSSelectorFromString(@"_defaultContentSizeCategory");
-    Func func = nil;
-    if ([UIApplication resolveClassMethod:selector]) {
-        IMP impl = class_getMethodImplementation(UIApplication.class, selector);
-        func = (Func)impl;
-    }
-    if (func == nil) {
-        return UIContentSizeCategoryLarge;
-    }
-    return func(UIApplication.class, selector);
+    Class self = UIApplication.class;
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(UIContentSizeCategory, @"_defaultContentSizeCategory", UIContentSizeCategoryLarge);
+    return func(self, selector);
 }
 
 #endif /* OPENSWIFTUI_TARGET_OS_IOS || OPENSWIFTUI_TARGET_OS_VISION */

--- a/Sources/COpenSwiftUI/Overlay/UIKit/OpenSwiftUITesting_Swizzles+UIKit.m
+++ b/Sources/COpenSwiftUI/Overlay/UIKit/OpenSwiftUITesting_Swizzles+UIKit.m
@@ -30,7 +30,7 @@
 @implementation UICollectionView (OpenSwiftUITesting_Swizzles)
 + (void)_performOpenSwiftUITestingOverrides {
     #if !OPENSWIFTUI_TARGET_OS_VISION
-    _SwizzleMethods(UIScreen.class, @selector(_viewAnimationsForCurrentUpdateWithCollectionViewAnimator:), @selector(_OpenSwiftUITesting__viewAnimationsForCurrentUpdateWithCollectionViewAnimator:));
+    _SwizzleMethods(UICollectionView.class, @selector(_viewAnimationsForCurrentUpdateWithCollectionViewAnimator:), @selector(_OpenSwiftUITesting__viewAnimationsForCurrentUpdateWithCollectionViewAnimator:));
     #endif
 }
 

--- a/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAttributedString.m
+++ b/Sources/OpenSwiftUI_SPI/Shims/UIFoundation/NSAttributedString.m
@@ -22,7 +22,7 @@ OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 }
 
 - (NSAttributedString *)_ui_attributedSubstringFromRange_openswiftui_safe_wrapper:(NSRange)range scaledByScaleFactor:(CGFloat)factor {
-    OPENSWIFTUI_SAFE_WRAPPER_IMP(NSAttributedString *, @"_ui_attributedSubstringFromRange:scaledByScaleFactor", nil, NSRange, CGFloat);
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(NSAttributedString *, @"_ui_attributedSubstringFromRange:scaledByScaleFactor:", nil, NSRange, CGFloat);
     return func(self, selector, range, factor);
 }
 
@@ -31,7 +31,7 @@ OPENSWIFTUI_ASSUME_NONNULL_BEGIN
 @implementation NSMutableAttributedString (OpenSwiftUI_SPI)
 
 - (BOOL)isEmptyOrTerminatedByParagraphSeparator_openswiftui_safe_wrapper {
-    OPENSWIFTUI_SAFE_WRAPPER_IMP(BOOL, @"isEmptyOrTerminatedByParagraphSeparator:scaledByScaleFactor", false);
+    OPENSWIFTUI_SAFE_WRAPPER_IMP(BOOL, @"isEmptyOrTerminatedByParagraphSeparator", false);
     return func(self, selector);
 }
 


### PR DESCRIPTION
## Summary

- Correct UIFoundation selector names and argument delimiters.
- Use the shared safe-wrapper path for the UIApplication class selector.
- Apply the collection-view testing swizzle to UICollectionView.

## Impact

This prevents missing-selector warnings and ensures dynamic dispatch and testing overrides target the intended runtime methods and classes.

## Root cause

Two selector strings had incorrect argument delimiters, the collection-view override targeted `UIScreen`, and the UIApplication helper duplicated class-method lookup instead of using the shared wrapper.

## Validation

Validated Objective-C syntax for the affected UIKit sources and checked the complete diff for formatting errors.