### PR TITLE
Pin Compute source in stdout renderer and update Tuist

### DIFF
--- a/.github/workflows/stdout_renderer.yml
+++ b/.github/workflows/stdout_renderer.yml
@@ -47,6 +47,7 @@ jobs:
       OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH: ${{ matrix.attributegraph }}
       OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE: ${{ matrix.compute }}
       OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE_BINARY: 0
+      OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE_SOURCE_VERSION: "0.4.1-bugfix.2"
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4

--- a/mise.compute.toml
+++ b/mise.compute.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.203.0-rc.1"
+tuist = "4.203.0"
 
 [env]
 TUIST_USE_SWIFTERPM=1

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.203.0-rc.1"
+tuist = "4.203.0"
 
 [env]
 TUIST_USE_SWIFTERPM=1


### PR DESCRIPTION
## Summary

- Pin the stdout renderer Compute source backend to `0.4.1-bugfix.2`.
- Update both mise configurations to the stable Tuist `4.203.0` release.

## Details

Without an explicit source version, the stdout renderer resolves OpenAttributeGraph's default Compute `0.4.1`, whose Swift tools version is incompatible with the Xcode 26.3 job. The explicit pin keeps CI and SwiftPM resolution on the compatible patched source release.

Both the standard and Compute-specific development environments now use the stable Tuist release.