### PR TITLE
Implement line limit APIs

### DIFF
--- a/Sources/OpenSwiftUICore/View/Text/LineLimits.swift
+++ b/Sources/OpenSwiftUICore/View/Text/LineLimits.swift
@@ -12,11 +12,51 @@ import OpenAttributeGraphShims
 
 @available(OpenSwiftUI_v1_0, *)
 extension View {
+    /// Sets the maximum number of lines that text can occupy in this view.
+    ///
+    /// Use this modifier to cap the number of lines that an individual text
+    /// element can display.
+    ///
+    /// The line limit applies to all ``Text`` instances within a hierarchy. For
+    /// example, an ``HStack`` with multiple pieces of text longer than three
+    /// lines caps each piece of text to three lines rather than capping the
+    /// total number of lines across the ``HStack``.
+    ///
+    /// In the example below, the modifier limits the very long
+    /// line in the ``Text`` element to the 2 lines that fit within the view's
+    /// bounds:
+    ///
+    ///     Text("This is a long string that demonstrates the effect of OpenSwiftUI's lineLimit(:_) operator.")
+    ///         .frame(width: 200, height: 200, alignment: .leading)
+    ///         .lineLimit(2)
+    ///
+    /// ![A screenshot showing showing the effect of the line limit operator on
+    /// a very long string in a view.](OpenSwiftUI-view-lineLimit.png)
+    ///
+    /// - Parameter number: The line limit. If `nil`, no line limit applies.
+    ///
+    /// - Returns: A view that limits the number of lines that ``Text``
+    ///   instances display.
     @inlinable
     nonisolated public func lineLimit(_ number: Int?) -> some View {
         environment(\.lineLimit, number)
     }
 
+    /// Sets to a partial range the number of lines that text can occupy in
+    /// this view.
+    ///
+    /// Use this modifier to specify a partial range of lines that a ``Text``
+    /// view or a vertical ``TextField`` can occupy. When the text of such
+    /// views occupies less space than the provided limit, that view expands to
+    /// occupy the minimum number of lines.
+    ///
+    ///     Form {
+    ///         TextField("Title", text: $model.title)
+    ///         TextField("Notes", text: $model.notes, axis: .vertical)
+    ///             .lineLimit(3...)
+    ///     }
+    ///
+    /// - Parameter limit: The line limit.
     @available(OpenSwiftUI_v4_0, *)
     nonisolated public func lineLimit(_ limit: PartialRangeFrom<Int>) -> some View {
         modifier(
@@ -27,6 +67,21 @@ extension View {
         )
     }
 
+    /// Sets to a partial range the number of lines that text can occupy
+    /// in this view.
+    ///
+    /// Use this modifier to specify a partial range of lines that a
+    /// ``Text`` view or a vertical ``TextField`` can occupy. When the text of
+    /// such views occupies more space than the provided limit, a ``Text`` view
+    /// truncates its content while a ``TextField`` becomes scrollable.
+    ///
+    ///     Form {
+    ///         TextField("Title", text: $model.title)
+    ///         TextField("Notes", text: $model.notes, axis: .vertical)
+    ///             .lineLimit(...3)
+    ///     }
+    ///
+    /// - Parameter limit: The line limit.
     @available(OpenSwiftUI_v4_0, *)
     nonisolated public func lineLimit(_ limit: PartialRangeThrough<Int>) -> some View {
         modifier(
@@ -37,6 +92,21 @@ extension View {
         )
     }
 
+    /// Sets to a closed range the number of lines that text can occupy in
+    /// this view.
+    ///
+    /// Use this modifier to specify a closed range of lines that a ``Text``
+    /// view or a vertical ``TextField`` can occupy. When the text of such
+    /// views occupies more space than the provided limit, a ``Text`` view
+    /// truncates its content while a ``TextField`` becomes scrollable.
+    ///
+    ///     Form {
+    ///         TextField("Title", text: $model.title)
+    ///         TextField("Notes", text: $model.notes, axis: .vertical)
+    ///             .lineLimit(1...3)
+    ///     }
+    ///
+    /// - Parameter limit: The line limit.
     @available(OpenSwiftUI_v4_0, *)
     nonisolated public func lineLimit(_ limit: ClosedRange<Int>) -> some View {
         modifier(
@@ -47,6 +117,29 @@ extension View {
         )
     }
 
+    /// Sets a limit for the number of lines text can occupy in this view.
+    ///
+    /// Use this modifier to specify a limit to the lines that a
+    /// ``Text`` or a vertical ``TextField`` may occupy. If passed a
+    /// value of true for the `reservesSpace` parameter, and the text of such
+    /// views occupies less space than the provided limit, that view expands
+    /// to occupy the minimum number of lines. When the text occupies
+    /// more space than the provided limit, a ``Text`` view truncates its
+    /// content while a ``TextField`` becomes scrollable.
+    ///
+    ///     GroupBox {
+    ///         Text("Title")
+    ///             .font(.headline)
+    ///             .lineLimit(2, reservesSpace: true)
+    ///         Text("Subtitle")
+    ///             .font(.subheadline)
+    ///             .lineLimit(4, reservesSpace: true)
+    ///     }
+    ///
+    /// - Parameter limit: The line limit.
+    /// - Parameter reservesSpace: Whether text reserves space so that
+    ///   it always occupies the height required to display the specified
+    ///   number of lines.
     @available(OpenSwiftUI_v4_0, *)
     nonisolated public func lineLimit(_ limit: Int, reservesSpace: Bool) -> some View {
         modifier(
@@ -85,6 +178,11 @@ extension EnvironmentValues {
         static var defaultValue: Int? { nil }
     }
 
+    /// The maximum number of lines that text can occupy in a view.
+    ///
+    /// The maximum number of lines is `1` if the value is less than `1`. If the
+    /// value is `nil`, the text uses as many lines as required. The default is
+    /// `nil`.
     public var lineLimit: Int? {
         get { self[LineLimitKey.self] }
         set { self[LineLimitKey.self] = newValue }

--- a/Sources/OpenSwiftUICore/View/Text/LineLimits.swift
+++ b/Sources/OpenSwiftUICore/View/Text/LineLimits.swift
@@ -1,0 +1,97 @@
+//
+//  LineLimits.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+//  ID: 32CC33FA2019BEDFCE31FB4066945274 (SwiftUICore)
+
+import OpenAttributeGraphShims
+
+// MARK: - View + Line Limits
+
+@available(OpenSwiftUI_v1_0, *)
+extension View {
+    @inlinable
+    nonisolated public func lineLimit(_ number: Int?) -> some View {
+        environment(\.lineLimit, number)
+    }
+
+    @available(OpenSwiftUI_v4_0, *)
+    nonisolated public func lineLimit(_ limit: PartialRangeFrom<Int>) -> some View {
+        modifier(
+            LineLimitModifier(
+                lowerLimit: limit.lowerBound,
+                upperLimit: nil
+            )
+        )
+    }
+
+    @available(OpenSwiftUI_v4_0, *)
+    nonisolated public func lineLimit(_ limit: PartialRangeThrough<Int>) -> some View {
+        modifier(
+            LineLimitModifier(
+                lowerLimit: nil,
+                upperLimit: limit.upperBound
+            )
+        )
+    }
+
+    @available(OpenSwiftUI_v4_0, *)
+    nonisolated public func lineLimit(_ limit: ClosedRange<Int>) -> some View {
+        modifier(
+            LineLimitModifier(
+                lowerLimit: limit.lowerBound,
+                upperLimit: limit.upperBound
+            )
+        )
+    }
+
+    @available(OpenSwiftUI_v4_0, *)
+    nonisolated public func lineLimit(_ limit: Int, reservesSpace: Bool) -> some View {
+        modifier(
+            LineLimitModifier(
+                lowerLimit: reservesSpace ? limit : nil,
+                upperLimit: limit
+            )
+        )
+    }
+}
+
+// MARK: - LineLimitModifier
+
+struct LineLimitModifier: ViewModifier, PrimitiveViewModifier, EnvironmentModifier {
+    var lowerLimit: Int?
+    var upperLimit: Int?
+
+    static func makeEnvironment(
+        modifier: Attribute<LineLimitModifier>,
+        environment: inout EnvironmentValues
+    ) {
+        environment.lineLimit = modifier.value.upperLimit
+        environment.lowerLineLimit = modifier.value.lowerLimit
+    }
+}
+
+// MARK: - EnvironmentValues + Line Limits
+
+@available(OpenSwiftUI_v1_0, *)
+extension EnvironmentValues {
+    private struct LowerLineLimitKey: EnvironmentKey {
+        static var defaultValue: Int? { nil }
+    }
+
+    private struct LineLimitKey: EnvironmentKey {
+        static var defaultValue: Int? { nil }
+    }
+
+    public var lineLimit: Int? {
+        get { self[LineLimitKey.self] }
+        set { self[LineLimitKey.self] = newValue }
+    }
+
+    package var lowerLineLimit: Int? {
+        get { self[LowerLineLimitKey.self] }
+        set { self[LowerLineLimitKey.self] = newValue }
+    }
+}

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+View.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+View.swift
@@ -1299,25 +1299,3 @@ struct StyledTextLayoutEngine: LayoutEngine {
         text.storage?.string
     }
 }
-
-// FIXME
-
-extension EnvironmentValues {
-    private struct LineLimitKey: EnvironmentKey {
-        static var defaultValue: Int? { nil }
-    }
-
-    public var lineLimit: Int? {
-        get { self[LineLimitKey.self] }
-        set { self[LineLimitKey.self] = newValue }
-    }
-
-    private struct LowerLineLimitKey: EnvironmentKey {
-        static var defaultValue: Int? { nil }
-    }
-
-    package var lowerLineLimit: Int? {
-        get { self[LowerLineLimitKey.self] }
-        set { self[LowerLineLimitKey.self] = newValue }
-    }
-}

--- a/Tests/OpenSwiftUICoreTests/View/Text/LineLimitsTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/Text/LineLimitsTests.swift
@@ -1,0 +1,149 @@
+//
+//  LineLimitsTests.swift
+//  OpenSwiftUICoreTests
+
+import OpenAttributeGraphShims
+@_spi(ForOpenSwiftUIOnly)
+@testable
+import OpenSwiftUICore
+import Testing
+
+@MainActor
+struct LineLimitsTests {
+    private func modifier<V: View>(_ view: V) throws -> LineLimitModifier {
+        let modified = try #require(
+            view as? ModifiedContent<EmptyView, LineLimitModifier>
+        )
+        return modified.modifier
+    }
+
+    private func applying(
+        _ modifier: LineLimitModifier,
+        to initial: EnvironmentValues = .init()
+    ) -> EnvironmentValues {
+        let graph = ViewGraph(rootViewType: EmptyView.self)
+        return graph.globalSubgraph.apply {
+            var environment = initial
+            let attribute = Attribute(value: modifier)
+            LineLimitModifier.makeEnvironment(
+                modifier: attribute,
+                environment: &environment
+            )
+            return environment
+        }
+    }
+
+    @Test
+    func modifierLayout() {
+        #expect(
+            MemoryLayout<LineLimitModifier>.size
+                == MemoryLayout<Int?>.stride + MemoryLayout<Int?>.size
+        )
+        #expect(
+            MemoryLayout<LineLimitModifier>.stride
+                == 2 * MemoryLayout<Int?>.stride
+        )
+        #expect(
+            MemoryLayout<LineLimitModifier>.alignment
+                == MemoryLayout<Int?>.alignment
+        )
+        #expect(
+            MemoryLayout<LineLimitModifier>.offset(of: \.lowerLimit) == 0
+        )
+        #expect(
+            MemoryLayout<LineLimitModifier>.offset(of: \.upperLimit)
+                == MemoryLayout<Int?>.stride
+        )
+    }
+
+    @Test
+    func environmentValues() {
+        var environment = EnvironmentValues()
+        #expect(environment.lineLimit == nil)
+        #expect(environment.lowerLineLimit == nil)
+
+        environment.lineLimit = 4
+        environment.lowerLineLimit = 2
+        #expect(environment.lineLimit == 4)
+        #expect(environment.lowerLineLimit == 2)
+
+        environment.lineLimit = nil
+        environment.lowerLineLimit = nil
+        #expect(environment.lineLimit == nil)
+        #expect(environment.lowerLineLimit == nil)
+    }
+
+    @Test
+    func optionalOverload() throws {
+        let set = try #require(
+            EmptyView().lineLimit(5) as?
+                ModifiedContent<
+                    EmptyView,
+                    _EnvironmentKeyWritingModifier<Int?>
+                >
+        )
+        #expect(set.modifier.keyPath == \EnvironmentValues.lineLimit)
+        #expect(set.modifier.value == 5)
+
+        let clear = try #require(
+            EmptyView().lineLimit(nil) as?
+                ModifiedContent<
+                    EmptyView,
+                    _EnvironmentKeyWritingModifier<Int?>
+                >
+        )
+        #expect(clear.modifier.keyPath == \EnvironmentValues.lineLimit)
+        #expect(clear.modifier.value == nil)
+    }
+
+    @Test
+    func rangeOverloads() throws {
+        var value = try modifier(EmptyView().lineLimit(2...))
+        #expect(value.lowerLimit == 2)
+        #expect(value.upperLimit == nil)
+
+        value = try modifier(EmptyView().lineLimit(...4))
+        #expect(value.lowerLimit == nil)
+        #expect(value.upperLimit == 4)
+
+        value = try modifier(EmptyView().lineLimit(2...4))
+        #expect(value.lowerLimit == 2)
+        #expect(value.upperLimit == 4)
+    }
+
+    @Test
+    func reservesSpaceOverload() throws {
+        var value = try modifier(
+            EmptyView().lineLimit(3, reservesSpace: false)
+        )
+        #expect(value.lowerLimit == nil)
+        #expect(value.upperLimit == 3)
+
+        value = try modifier(
+            EmptyView().lineLimit(3, reservesSpace: true)
+        )
+        #expect(value.lowerLimit == 3)
+        #expect(value.upperLimit == 3)
+    }
+
+    @Test(.disabled(if: attributeGraphVendor == .oag))
+    func modifierOverwritesBothEnvironmentValues() {
+        var initial = EnvironmentValues()
+        initial.lineLimit = 9
+        initial.lowerLineLimit = 8
+
+        var result = applying(
+            .init(lowerLimit: nil, upperLimit: 4),
+            to: initial
+        )
+        #expect(result.lineLimit == 4)
+        #expect(result.lowerLineLimit == nil)
+
+        result = applying(
+            .init(lowerLimit: 2, upperLimit: nil),
+            to: initial
+        )
+        #expect(result.lineLimit == nil)
+        #expect(result.lowerLineLimit == 2)
+    }
+}


### PR DESCRIPTION
## Summary

- implement optional, ranged, and reserved-space `lineLimit` overloads
- propagate upper and lower line limits through `EnvironmentValues`
- add DocC documentation and focused unit coverage for modifier layout and environment behavior

This completes the line-limit API surface and lets text layout receive both minimum and maximum line constraints through the environment.