### PR TITLE
Preserve generated Swift flags in Example projects

### DIFF
--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -72,7 +72,6 @@ let openSwiftUITargetSettings: SettingsDictionary = [
 let openSwiftUICoreTargetSettings: SettingsDictionary = [
     "DYLIB_INSTALL_NAME_BASE": "@rpath",
     "OTHER_LDFLAGS": "$(inherited) -ObjC",
-    "OTHER_SWIFT_FLAGS": "$(inherited) -module-abi-name OpenSwiftUI",
 ]
 
 var packageProductTypes: [String: ProjectDescription.Product] = [

--- a/Package.swift
+++ b/Package.swift
@@ -971,7 +971,6 @@ let openSwiftUITargetSettings: SettingsDictionary = [
 let openSwiftUICoreTargetSettings: SettingsDictionary = [
     "DYLIB_INSTALL_NAME_BASE": "@rpath",
     "OTHER_LDFLAGS": "$(inherited) -ObjC",
-    "OTHER_SWIFT_FLAGS": "$(inherited) -module-abi-name OpenSwiftUI",
 ]
 
 let packageSettings = PackageSettings(


### PR DESCRIPTION
## Summary

Remove the target-level `OTHER_SWIFT_FLAGS` overrides from both Example package manifests.

## Why

The overrides replaced the Swift flags generated from the package target settings. This dropped the `AvailabilityMacro` feature flags when generating the Example project after the OpenSwiftUI ABI namespace flag was added.

Allowing Tuist to use the package-generated settings preserves both the availability feature flags and `-module-abi-name OpenSwiftUI` for `OpenSwiftUICore`.

## Validation

The Example workspace regenerates successfully, and the resolved `OpenSwiftUICore` build settings contain both the availability macro flags and the OpenSwiftUI module ABI name.