### PR TITLE
Fix safe area inset resolution across coordinate spaces

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "e3ca252fe6b740be3c1429ef06f8f1cbc4e04ce5cc0321909987e852b5b3a81a",
+  "originHash" : "4323f5f3b71a8062ba947d0cf3170c8ce1ce838a0f7fac3ffa5b3fb50ff6e8d5",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/darwinprivateframeworks",
+      "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks",
       "state" : {
         "branch" : "main",
         "revision" : "d93839821ebebdab22081fbc0f3d0b8cb0e30b2f"
@@ -16,7 +16,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/OpenAttributeGraph",
       "state" : {
         "branch" : "main",
-        "revision" : "40226e38bba14a6424b01bed46aa2587a293dfb1"
+        "revision" : "d39facbf8e17afe2f60b5033dfb6522d7c961ba4"
       }
     },
     {
@@ -31,7 +31,7 @@
     {
       "identity" : "openobservation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/openobservation",
+      "location" : "https://github.com/OpenSwiftUIProject/OpenObservation",
       "state" : {
         "branch" : "main",
         "revision" : "51c52f318eb3278b1eaa8b724f50d1af9f9f8bae"
@@ -40,7 +40,7 @@
     {
       "identity" : "openrenderbox",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/openrenderbox",
+      "location" : "https://github.com/OpenSwiftUIProject/OpenRenderBox",
       "state" : {
         "branch" : "main",
         "revision" : "d6db14f180068c6813a936088e767c2ca99c308d"
@@ -67,7 +67,7 @@
     {
       "identity" : "symbollocator",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/symbollocator",
+      "location" : "https://github.com/OpenSwiftUIProject/SymbolLocator",
       "state" : {
         "revision" : "546053c03f282df1a8270853da6692e1b078be09",
         "version" : "0.2.1"

--- a/Sources/OpenSwiftUICore/Layout/SafeAreaInsets.swift
+++ b/Sources/OpenSwiftUICore/Layout/SafeAreaInsets.swift
@@ -3,15 +3,17 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: Blocked by ViewTransform+CoordinateSpace
+//  Status: Complete
 //  ID: C4DC82F2A500E9B6DEA3064A36584B42 (SwiftUICore)
 
 import Foundation
 package import OpenAttributeGraphShims
+package import OpenCoreGraphicsShims
 
 // MARK: - SafeAreaRegions
 
 /// A set of symbolic safe area regions.
+@available(OpenSwiftUI_v2_0, *)
 @frozen
 public struct SafeAreaRegions: OptionSet {
     public let rawValue: UInt
@@ -33,7 +35,7 @@ public struct SafeAreaRegions: OptionSet {
     package static let background = SafeAreaRegions(rawValue: 1 << 0)
 }
 
-// MARK: - SafeAreaInsets [WIP]
+// MARK: - SafeAreaInsets
 
 package struct SafeAreaInsets: Equatable {
     package enum OptionalValue: Equatable {
@@ -88,19 +90,70 @@ package struct SafeAreaInsets: Equatable {
         return insets
     }
 
-    // FIXME: This does not handle coordinate space conversions.
     private func adjust(
         _ rect: inout CGRect,
         regions: SafeAreaRegions,
         to context: _PositionAwarePlacementContext
     ) {
-        let (selectedInsets, _) = mergedInsets(regions: regions)
+        let (selectedInsets, totalInsets) = mergedInsets(regions: regions)
         guard !selectedInsets.isEmpty else { return }
-        // TODO: ViewTransform coordinate space conversion
-        rect.origin.x -= selectedInsets.leading
-        rect.origin.y -= selectedInsets.top
-        rect.size.width += (selectedInsets.leading + selectedInsets.trailing)
-        rect.size.height += (selectedInsets.top + selectedInsets.bottom)
+
+        var points: [CGPoint]?
+        var isInvalid = false
+        context.transform.convert(.spaceToLocal(.id(space))) { item in
+            if case let .sizedSpace(.id(id), size) = item, id == space {
+                let innerRect = CGRect(origin: .zero, size: size).inset(by: totalInsets)
+                points = innerRect.cornerPoints
+                points?.append(contentsOf: innerRect.inset(by: -selectedInsets).cornerPoints)
+            } else {
+                switch item {
+                    case let .affineTransform(transform, _):
+                        if !transform.isRectilinear {
+                            isInvalid = true
+                        }
+                    case let .projectionTransform(transform, _):
+                        if !transform.isAffine ||
+                           !CGAffineTransform(transform).isRectilinear {
+                            isInvalid = true
+                        }
+                    default:
+                        break
+                }
+                if !isInvalid {
+                    points?.applyTransform(item: item)
+                }
+            }
+        }
+        guard !isInvalid, let points else { return }
+
+        let innerRect = CGRect(cornerPoints: points[0...3])
+        let outerRect = CGRect(cornerPoints: points[4...7])
+        let minY = rect.minY
+        let maxY = rect.maxY
+        let minX = rect.minX
+        let maxX = rect.maxX
+        let epsilon = context.pixelLength * 0.5 + 0.001
+
+        if minY - epsilon < innerRect.minY,
+           outerRect.minY < minY + epsilon {
+            let delta = minY - outerRect.minY
+            rect.origin.y -= delta
+            rect.size.height += delta
+        }
+        if innerRect.maxY < maxY + epsilon,
+           maxY - epsilon < outerRect.maxY {
+            rect.size.height += outerRect.maxY - maxY
+        }
+        if minX - epsilon < innerRect.minX,
+           outerRect.minX < minX + epsilon {
+            let delta = minX - outerRect.minX
+            rect.origin.x -= delta
+            rect.size.width += delta
+        }
+        if innerRect.maxX < maxX + epsilon,
+           maxX - epsilon < outerRect.maxX {
+            rect.size.width += outerRect.maxX - maxX
+        }
     }
 
     private func mergedInsets(regions: SafeAreaRegions) -> (selected: EdgeInsets, total: EdgeInsets) {
@@ -110,14 +163,12 @@ package struct SafeAreaInsets: Equatable {
         var selected: EdgeInsets = .zero
         var total: EdgeInsets = .zero
 
-        // Track which edges can still contribute to the selected insets.
-        // This prevents inner safe area modifiers from overriding outer ones.
-        // For example, if an outer modifier sets a top inset for a different region,
-        // an inner modifier matching our region shouldn't override that top edge.
+        // Track which edges can still contribute to the selected insets after
+        // later elements in the array have been considered.
         var availableEdges: Edge.Set = .all
 
-        // Iterate through elements in reverse order (from innermost to outermost modifier).
-        // This ensures that outer modifiers take precedence over inner ones for each edge.
+        // A disjoint element with a nonzero inset consumes that edge, preventing
+        // earlier elements from contributing it to the selected region.
         for element in elements.reversed() {
             let insets = element.insets
             if element.regions.isDisjoint(with: regions) {
@@ -153,8 +204,10 @@ package struct SafeAreaInsets: Equatable {
     }
 }
 
-// MARK: - _SafeAreaInsetsModifier [6.4.41]
+// MARK: - _SafeAreaInsetsModifier
 
+@MainActor
+@preconcurrency
 package struct _SafeAreaInsetsModifier: MultiViewModifier, PrimitiveViewModifier, Equatable {
     var elements: [SafeAreaInsets.Element]
     var nextInsets: SafeAreaInsets.OptionalValue?
@@ -249,10 +302,11 @@ extension _PositionAwarePlacementContext {
     }
 }
 
-// MARK: - SafeAreaInsetsModifier [6.4.41]
+// MARK: - SafeAreaInsetsModifier
 
 package typealias SafeAreaInsetsModifier = ModifiedContent<_PaddingLayout, _SafeAreaInsetsModifier>
 
+@available(OpenSwiftUI_v2_0, *)
 extension View {
     @MainActor
     @preconcurrency
@@ -270,7 +324,7 @@ extension View {
     }
 }
 
-// MARK: - ResolvedSafeAreaInsets [6.4.41]
+// MARK: - ResolvedSafeAreaInsets
 
 package struct ResolvedSafeAreaInsets: Rule, AsyncAttribute {
     let regions: SafeAreaRegions

--- a/Sources/OpenSwiftUICore/Util/Extension/CGRect+Extension.swift
+++ b/Sources/OpenSwiftUICore/Util/Extension/CGRect+Extension.swift
@@ -156,10 +156,11 @@ extension CGRect {
     }
     
     package init(cornerPoints p: ArraySlice<CGPoint>) {
-        let p0 = p[0]
-        let p1 = p[1]
-        let p2 = p[2]
-        let p3 = p[3]
+        let startIndex = p.startIndex
+        let p0 = p[startIndex]
+        let p1 = p[startIndex + 1]
+        let p2 = p[startIndex + 2]
+        let p3 = p[startIndex + 3]
         
         let minX = min(min(p0.x, p1.x), min(p2.x, p3.x))
         let minY = min(min(p0.y, p1.y), min(p2.y, p3.y))

--- a/Tests/OpenSwiftUICoreTests/Layout/SafeAreaInsetsTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Layout/SafeAreaInsetsTests.swift
@@ -3,6 +3,7 @@
 //  OpenSwiftUICoreTests
 
 import OpenAttributeGraphShims
+import OpenCoreGraphicsShims
 @_spi(ForOpenSwiftUIOnly)
 import OpenSwiftUICore
 import Testing
@@ -11,29 +12,159 @@ import Testing
 @Suite(.disabled(if: attributeGraphVendor == .oag))
 struct SafeAreaInsetsTests {
     @Test
-    func insets() {
-        let insets = SafeAreaInsets(
-            space: .init(),
+    func centeredRectDoesNotResolveInsets() {
+        let space = CoordinateSpace.ID()
+        let resolved = resolve(
+            insets: safeAreaInsets(space: space),
+            transform: transform(
+                space: space,
+                spaceSize: .init(width: 400, height: 800),
+                localOrigin: .init(x: 150, y: 390)
+            )
+        )
+
+        #expect(resolved == .zero)
+    }
+
+    @Test
+    func edgeAlignedRectsResolveMatchingInset() {
+        let space = CoordinateSpace.ID()
+        let insets = EdgeInsets(top: 10, leading: 20, bottom: 30, trailing: 40)
+        let safeAreaInsets = safeAreaInsets(space: space, insets: insets)
+        func resolved(at localOrigin: CGPoint) -> EdgeInsets {
+            resolve(
+                insets: safeAreaInsets,
+                transform: transform(
+                    space: space,
+                    spaceSize: .init(width: 400, height: 800),
+                    localOrigin: localOrigin
+                )
+            )
+        }
+
+        #expect(
+            resolved(at: .init(x: 150, y: 10)) ==
+                .init(top: 10, leading: 0, bottom: 0, trailing: 0)
+        )
+        #expect(
+            resolved(at: .init(x: 150, y: 750)) ==
+                .init(top: 0, leading: 0, bottom: 30, trailing: 0)
+        )
+        #expect(
+            resolved(at: .init(x: 20, y: 100)) ==
+                .init(top: 0, leading: 20, bottom: 0, trailing: 0)
+        )
+        #expect(
+            resolved(at: .init(x: 260, y: 100)) ==
+                .init(top: 0, leading: 0, bottom: 0, trailing: 40)
+        )
+    }
+
+    @Test
+    func rightToLeftFlipsResolvedHorizontalInsets() {
+        let space = CoordinateSpace.ID()
+        let insets = EdgeInsets(top: 10, leading: 20, bottom: 30, trailing: 40)
+        let safeAreaInsets = safeAreaInsets(space: space, insets: insets)
+        func resolved(at localOrigin: CGPoint) -> EdgeInsets {
+            resolve(
+                layoutDirection: .rightToLeft,
+                insets: safeAreaInsets,
+                transform: transform(
+                    space: space,
+                    spaceSize: .init(width: 400, height: 800),
+                    localOrigin: localOrigin
+                )
+            )
+        }
+
+        #expect(
+            resolved(at: .init(x: 20, y: 100)) ==
+                .init(top: 0, leading: 0, bottom: 0, trailing: 20)
+        )
+        #expect(
+            resolved(at: .init(x: 260, y: 100)) ==
+                .init(top: 0, leading: 40, bottom: 0, trailing: 0)
+        )
+    }
+
+    @Test
+    func missingCoordinateSpaceDoesNotResolveInsets() {
+        let insetsSpace = CoordinateSpace.ID()
+        let transformSpace = CoordinateSpace.ID()
+        let resolved = resolve(
+            insets: safeAreaInsets(space: insetsSpace),
+            transform: transform(
+                space: transformSpace,
+                spaceSize: .init(width: 400, height: 800),
+                localOrigin: .init(x: 150, y: 60)
+            )
+        )
+
+        #expect(resolved == .zero)
+    }
+
+    @Test
+    func unmatchedRegionsDoNotResolveInsets() {
+        let space = CoordinateSpace.ID()
+        let resolved = resolve(
+            regions: .keyboard,
+            insets: safeAreaInsets(space: space),
+            transform: transform(
+                space: space,
+                spaceSize: .init(width: 400, height: 800),
+                localOrigin: .init(x: 150, y: 60)
+            )
+        )
+
+        #expect(resolved == .zero)
+    }
+
+    private func safeAreaInsets(
+        space: CoordinateSpace.ID,
+        insets: EdgeInsets = .init(top: 60, leading: 0, bottom: 0, trailing: 0)
+    ) -> SafeAreaInsets {
+        SafeAreaInsets(
+            space: space,
             elements: [.init(
-                regions: .all,
-                insets: .init(top: 1, leading: 2, bottom: 3, trailing: 4)
+                regions: .container,
+                insets: insets
             )]
         )
+    }
+
+    private func transform(
+        space: CoordinateSpace.ID,
+        spaceSize: CGSize,
+        localOrigin: CGPoint
+    ) -> ViewTransform {
+        var transform = ViewTransform()
+        transform.appendSizedSpace(id: space, size: spaceSize)
+        transform.appendTranslation(-CGSize(localOrigin))
+        return transform
+    }
+
+    private func resolve(
+        regions: SafeAreaRegions = .container,
+        layoutDirection: LayoutDirection = .leftToRight,
+        insets: SafeAreaInsets,
+        transform: ViewTransform
+    ) -> EdgeInsets {
         let graph = ViewGraph(rootViewType: EmptyView.self)
-        let resolved = graph.rootSubgraph.apply {
+        var environment = graph.environment
+        environment.layoutDirection = layoutDirection
+        return graph.rootSubgraph.apply {
             insets
                 .resolve(
-                    regions: .all,
+                    regions: regions,
                     in: .init(
                         context: AnyRuleContext(attribute: graph.rootView),
-                        size: .init(value: graph.size),
-                        environment: .init(value: graph.environment),
-                        transform: .init(value: graph.transform),
+                        size: .init(value: .fixed(.init(width: 100, height: 20))),
+                        environment: .init(value: environment),
+                        transform: .init(value: transform),
                         position: .init(value: graph.zeroPoint),
                         safeAreaInsets: .init()
                     )
                 )
         }
-        #expect(resolved == .init(top: 1, leading: 2, bottom: 3, trailing: 4))
     }
 }

--- a/Tests/OpenSwiftUICoreTests/Util/Extension/CGRect+ExtensionTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Util/Extension/CGRect+ExtensionTests.swift
@@ -8,6 +8,24 @@ import OpenSwiftUICore
 import Testing
 
 struct CGRect_ExtensionTests {
+    @Test
+    func cornerPointsWithNonZeroBasedSlice() {
+        let points = [
+            CGPoint(x: 100, y: 100),
+            CGPoint(x: 200, y: 100),
+            CGPoint(x: 200, y: 200),
+            CGPoint(x: 100, y: 200),
+            CGPoint(x: 3, y: 8),
+            CGPoint(x: -2, y: 4),
+            CGPoint(x: 6, y: -1),
+            CGPoint(x: 1, y: 10),
+        ]
+
+        let rect = CGRect(cornerPoints: points[4...7])
+
+        #expect(rect == CGRect(x: -2, y: -1, width: 8, height: 11))
+    }
+
     @Test(arguments: [
         (CGRect(x: 0, y: 0, width: 2, height: 1), CGPoint(x: 1, y: 1), 0.0, 0.0),
         (CGRect(x: 0, y: 0, width: 2, height: 1), CGPoint(x: 1, y: 2), 1.0, 1.0),


### PR DESCRIPTION
## Summary

- Convert safe-area boundaries into the local coordinate space before resolving insets.
- Fix corner-point rectangle construction for non-zero-based `ArraySlice` values.

Fixes #964.