### PR TITLE
Fix preference bridge ownership and align preference internals

### DIFF
--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceBridge.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceBridge.swift
@@ -2,7 +2,7 @@
 //  PreferenceBridge.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 //  ID: A9FAE381E99529D5274BA37A9BC9B074 (SwiftUI)
 //  ID: DF57A19C61B44C613EB77C1D47FC679A (SwiftUICore)
@@ -32,9 +32,9 @@ package final class PreferenceBridge {
         requestedPreferences = PreferenceKeys()
         bridgedViewInputs = PropertyList()
         for child in children {
-            let viewGraph = child.takeRetainedValue()
-            viewGraph.invalidatePreferenceBridge()
-            child.release()
+            child._withUnsafeGuaranteedRef { viewGraph in
+                viewGraph.invalidatePreferenceBridge()
+            }
         }
         viewGraph = nil
         isValid = false
@@ -105,9 +105,9 @@ package final class PreferenceBridge {
     
     package func removedStateDidChange() {
         for child in children {
-            let viewGraph = child.takeUnretainedValue()
-            viewGraph.updateRemovedState()
-            child.release()
+            child._withUnsafeGuaranteedRef { viewGraph in
+                viewGraph.updateRemovedState()
+            }
         }
     }
     

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceCombiner.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceCombiner.swift
@@ -2,10 +2,10 @@
 //  PreferenceCombiner.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 //  ID: 59D15989E597719355BF0EAE6CB41FF9 (SwiftUI)
-//  ID: EAF68AEE5E08E2f44FEB886FE6A27001 (SwiftUICore)
+//  ID: EAF68AEE5E08E2F44FEB886FE6A27001 (SwiftUICore)
 
 package import OpenAttributeGraphShims
 
@@ -108,9 +108,9 @@ private struct PairPreferenceCombiner<K>: Rule, AsyncAttribute where K: Preferen
     }
 }
 
-// MARK: - PreferencesAggregator
+// MARK: - PreferenceAggregator
 
-package struct PreferencesAggregator<K>: Rule, AsyncAttribute where K: PreferenceKey {
+package struct PreferenceAggregator<K>: Rule, AsyncAttribute where K: PreferenceKey {
     package var attributes: [WeakAttribute<K.Value>]
 
     package init(attributes: [Attribute<K.Value>]) {

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceKey.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceKey.swift
@@ -2,7 +2,7 @@
 //  PreferenceKey.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 //  ID: 3D8838A231BB2CC7FC00E7880D8B2FC4 (SwiftUICore)
 
@@ -71,6 +71,9 @@ extension PreferenceKey {
         if name.isEmpty {
             let fullname = _typeName(Self.self, qualified: true)
             let results = fullname.split(maxSplits: 1) { $0 == "." }
+            guard results.count >= 2 else {
+                return fullname
+            }
             return String(results[1])
         } else {
             return name
@@ -88,7 +91,7 @@ package protocol PreferenceKeyVisitor {
     mutating func visit<K>(key: K.Type) where K: PreferenceKey
 }
 
-// MARK: - PreferenceKeys [6.5.4]
+// MARK: - PreferenceKeys
 
 package struct PreferenceKeys: Equatable, RandomAccessCollection, MutableCollection {
     var keys: [any PreferenceKey.Type] = []

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceList.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceList.swift
@@ -3,7 +3,7 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: Copmlete
+//  Status: Complete
 //  ID: C1C63C2F6F2B9F3EB30DD747F0605FBD (SwiftUI)
 //  ID: 7B694C05291EA7AF22785AB458D1BC2F (SwiftUICore)
 

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceTransformModifier.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceTransformModifier.swift
@@ -14,8 +14,6 @@ package import OpenAttributeGraphShims
 /// preference key.
 @available(OpenSwiftUI_v1_0, *)
 @frozen
-@MainActor
-@preconcurrency
 public struct _PreferenceTransformModifier<Key>: ViewModifier, MultiViewModifier, PrimitiveViewModifier where Key: PreferenceKey {
 
     /// The transform function to apply to `Key`.

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceWritingModifier.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceWritingModifier.swift
@@ -73,7 +73,10 @@ extension View {
 
     /// Sets a value for the given preference.
     @inlinable
-    public func preference<K>(key: K.Type = K.self, value: K.Value) -> some View where K : PreferenceKey {
+    nonisolated public func preference<K>(
+        key: K.Type = K.self,
+        value: K.Value
+    ) -> some View where K: PreferenceKey {
         modifier(_PreferenceWritingModifier<K>(value: value))
     }
 }

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferencesInputs.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferencesInputs.swift
@@ -2,7 +2,7 @@
 //  PreferencesInputs.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 
 package import OpenAttributeGraphShims

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferencesOutputs.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferencesOutputs.swift
@@ -2,12 +2,13 @@
 //  PreferencesOutputs.swift
 //  OpenSwiftUICore
 //
+//  Audited for 6.5.4
 //  Status: Complete
 //  ID: 639FD567E11A491423DEEA5A95A52B4C (SwiftUICore)
 
 package import OpenAttributeGraphShims
 
-// MARK: - PreferencesOutputs [6.5.4]
+// MARK: - PreferencesOutputs
 
 package struct PreferencesOutputs {
     private var preferences: [KeyValue]

--- a/Sources/OpenSwiftUICore/Data/Preference/View_Indirect.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/View_Indirect.swift
@@ -2,7 +2,7 @@
 //  View_Indirect.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 
 package import OpenAttributeGraphShims

--- a/Sources/OpenSwiftUICore/Render/PlatformViewFactory.swift
+++ b/Sources/OpenSwiftUICore/Render/PlatformViewFactory.swift
@@ -177,7 +177,7 @@ package struct ViewDecoders {
     ) where T: Decodable, T: AnyViewFactory {
         registerDecodableFactoryType(
             factoryType,
-            forID: _typeName(type, qualified: true)
+            forID: _typeName(type)
         )
     }
 


### PR DESCRIPTION
## Summary

- Borrow unmanaged `ViewGraph` children without consuming ownership during preference bridge updates
- Align preference modifier isolation and preference API signatures
- Rename `PreferencesAggregator` to `PreferenceAggregator`
- Improve unqualified type-name handling and simplify decoder identifiers
- Correct minor internal metadata typos