### PR TITLE
Update EnvironmentValues config

### DIFF
--- a/Sources/OpenSwiftUI/App/App/AppGraph.swift
+++ b/Sources/OpenSwiftUI/App/App/AppGraph.swift
@@ -115,7 +115,7 @@ package final class AppGraph: GraphHost {
                 RootEnvironment(
                     environment: graphInputs.environment,
                     phase: $rootScenePhase,
-                    sceneKeyboardShorts: $sceneKeyboardShortcuts
+                    sceneKeyboardShortcuts: $sceneKeyboardShortcuts
                 )
             )
             inputs.preferences.add(HostPreferencesKey.self)
@@ -253,9 +253,14 @@ private struct AppBodyAccessor<Application>: BodyAccessor where Application: App
 private struct RootEnvironment: Rule {
     @Attribute var environment: EnvironmentValues
     @Attribute var phase: ScenePhase
-    @Attribute var sceneKeyboardShorts: [SceneID: KeyboardShortcut]
+    @Attribute var sceneKeyboardShortcuts: [SceneID: KeyboardShortcut]
 
     var value: EnvironmentValues {
-        environment
+        var env = environment
+        env.configureForRoot()
+        env.scenePhase = phase
+        env.configureForPlatform(traitCollection: nil)
+        env.sceneKeyboardShortcuts = sceneKeyboardShortcuts
+        return env
     }
 }

--- a/Sources/OpenSwiftUI/Data/Environment/PlatformEnvironment.swift
+++ b/Sources/OpenSwiftUI/Data/Environment/PlatformEnvironment.swift
@@ -2,6 +2,7 @@
 //  PlatformEnvironment.swift
 //  OpenSwiftUI
 //
+//  Audited for 6.5.4
 //  Status: WIP
 //  ID: C3D4386B65791FA87065FFB821A7CBCF (SwiftUI)
 
@@ -17,7 +18,7 @@ typealias TraitCollection = Void
 typealias TraitCollection = Void
 #endif
 
-// MARK: - Environment + Platform [6.4.41]
+// MARK: - Environment + Platform
 
 extension EnvironmentValues {
     static let configuredForPlatform: EnvironmentValues = {
@@ -27,14 +28,17 @@ extension EnvironmentValues {
     }()
 
     mutating func configureForPlatform(traitCollection: TraitCollection?) {
-        guard let traitCollection else {
-            plist.set(Self.configuredForPlatform.plist)
-            return
-        }
         if plist.isIdentical(to: Self.configuredForPlatform.plist) {
+            guard traitCollection != nil else {
+                return
+            }
             plist = .init()
         }
-        _configureForPlatform(traitCollection: traitCollection)
+        if plist.isEmpty, traitCollection == nil {
+            plist = Self.configuredForPlatform.plist
+        } else {
+            _configureForPlatform(traitCollection: traitCollection)
+        }
     }
 
     private mutating func _configureForPlatform(traitCollection: TraitCollection?) {

--- a/Sources/OpenSwiftUI/Data/Environment/PlatformEnvironment.swift
+++ b/Sources/OpenSwiftUI/Data/Environment/PlatformEnvironment.swift
@@ -8,6 +8,7 @@
 
 import COpenSwiftUI
 import OpenSwiftUICore
+import UIFoundation_Private
 #if os(iOS) || os(visionOS)
 import UIKit
 typealias TraitCollection = UITraitCollection
@@ -46,18 +47,15 @@ extension EnvironmentValues {
         #if OPENSWIFTUI_LINK_COREUI
         cuiNamedColorProvider = KitCoreUINamedColorProvider.self
         #endif
-
+        accessibilityTextAttributeResolver = OpenSwiftUIAccessibilityTextResolver()
         #if os(macOS)
-        // accessibilityTextAttributeResolver =
-        // fallbackFontProvider =
+        fallbackFontProvider = OpenSwiftUIFallbackFontProvider()
         systemAccentValueProvider = MacSystemAccentValueProvider.self
         #endif
-
-        // resolvedTextProvider = OpenSwiftUIResolvedTextProvider.self
+        resolvedTextProvider = OpenSwiftUIResolvedTextProvider.self
         hasSystemOpenURLAction = true
-
         #if os(iOS) || os(visionOS)
-        // bridgedEnvironmentResolver = UITraitBridgedEnvironmentResolver.self
+        bridgedEnvironmentResolver = UITraitBridgedEnvironmentResolver.self
         #if OPENSWIFTUI_LINK_COREUI
         let idiom = traitCollection?.userInterfaceIdiom ?? UIDevice.current.userInterfaceIdiom
         cuiAssetIdiom = _CUIIdiomForIdiom(idiom).rawValue
@@ -67,3 +65,86 @@ extension EnvironmentValues {
         #endif
     }
 }
+
+// FIXME
+
+struct OpenSwiftUIAccessibilityTextResolver: AccessibilityTextAttributeResolver {
+    func resolveDefaultAttributes(
+        _ attributes: inout [NSAttributedString.Key: Any]
+    ) {
+        _openSwiftUIUnimplementedWarning()
+    }
+
+    func resolveTextStyleAttributes(
+        _ attributes: inout [NSAttributedString.Key: Any],
+        textStyle: Text.Style,
+        environment: EnvironmentValues
+    ) {
+        _openSwiftUIUnimplementedWarning()
+    }
+
+    func resolveAccessibilitySpeechAttributes(
+        into attributes: inout [NSAttributedString.Key: Any],
+        speechAttr: AccessibilitySpeechAttributes,
+        environment: EnvironmentValues,
+        includeDefaultAttributes: Bool
+    ) {
+        _openSwiftUIUnimplementedWarning()
+    }
+}
+
+struct OpenSwiftUIResolvedTextProvider: ResolvedTextProvider {
+    static func defaultLinkColor(
+        for environment: EnvironmentValues
+    ) -> Color {
+        .accentColor
+    }
+
+    static func updateImageTextAttachment(
+        in attachment: NSTextAttachment,
+        image: Image.Resolved
+    ) {
+        _openSwiftUIUnimplementedWarning()
+    }
+
+    static func updateWidgetTextAttachment(
+        _ attachment: NSTextAttachment,
+        namedImage: Image.NamedResolved
+    ) {
+        _openSwiftUIUnimplementedWarning()
+    }
+}
+
+#if os(macOS)
+struct OpenSwiftUIFallbackFontProvider: FallbackFontProvider {
+    func makeFont(in env: EnvironmentValues) -> Font {
+        Font._system(controlSize: env.controlSize)
+    }
+}
+
+extension Font {
+    static func _system(controlSize: ControlSize) -> Font {
+        let nsControlSize: NSControl.ControlSize = switch controlSize {
+        case .mini: .mini
+        case .small: .small
+        case .regular: .regular
+        case .large: .large
+        case .extraLarge:
+            if #available(macOS 26, *) {
+                .extraLarge
+            } else {
+                .large
+            }
+        }
+        let size = NSFont.systemFontSize(for: nsControlSize)
+        return Font.system(size: size)
+    }
+}
+
+// ID: F50FEC7433F4F726B3FD7F77709599DA
+private struct TouchbarFallbackFontProvider: FallbackFontProvider {
+    func makeFont(in env: EnvironmentValues) -> Font {
+        Font.system(size: 15.0)
+    }
+}
+#endif

--- a/Sources/OpenSwiftUI/Event/InputEvent/KeyboardShortcut/TODO/KeyboardShortcut.swift
+++ b/Sources/OpenSwiftUI/Event/InputEvent/KeyboardShortcut/TODO/KeyboardShortcut.swift
@@ -4,6 +4,7 @@
 //
 //  Audited for 3.5.2
 //  Status: Blocked by EnvironmentValues
+//  ID: 254C3FE5924A018B482F2F0C0D49154 (SwiftUI)
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
@@ -99,5 +100,19 @@ extension KeyboardShortcut: Hashable {
         key.character.hash(into: &hasher)
         hasher.combine(modifiers.rawValue)
         hasher.combine(localization.style)
+    }
+}
+
+// MARK: EnvironmentValues + sceneKeyboardShortcuts
+
+extension EnvironmentValues {
+    private struct SceneKeyboardShortcutsKey: EnvironmentKey {
+        static var defaultValue: [SceneID: KeyboardShortcut] { [:] }
+    }
+
+    @inline(__always)
+    var sceneKeyboardShortcuts: [SceneID: KeyboardShortcut] {
+        get { self[SceneKeyboardShortcutsKey] }
+        set { self[SceneKeyboardShortcutsKey] = newValue }
     }
 }

--- a/Sources/OpenSwiftUI/Integration/Hosting/AppKit/View/NSHostingView.swift
+++ b/Sources/OpenSwiftUI/Integration/Hosting/AppKit/View/NSHostingView.swift
@@ -912,6 +912,7 @@ extension NSHostingView {
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)
 extension NSHostingView: ViewRendererHost {
+    // FIXME
     package func updateEnvironment() {
         var environment: EnvironmentValues
         if let inheritedEnvironment {
@@ -920,6 +921,7 @@ extension NSHostingView: ViewRendererHost {
             environment = initialInheritedEnvironment
         } else {
             environment = EnvironmentValues()
+            environment.configureForRoot()
         }
         if let environmentOverride {
             environment.plist.override(with: environmentOverride.plist)

--- a/Sources/OpenSwiftUICore/Data/Environment/EnvironmentKey.swift
+++ b/Sources/OpenSwiftUICore/Data/Environment/EnvironmentKey.swift
@@ -4,6 +4,7 @@
 //
 //  Audited for 6.5.4
 //  Status: Complete
+//  ID: 6C8C95D62F88AD34FB6AA150854F1BBB (SwiftUICore)
 
 import OpenAttributeGraphShims
 
@@ -145,4 +146,15 @@ package protocol BridgedEnvironmentResolver {
     static func read<K>(for key: K.Type, from environment: EnvironmentValues) -> K.Value where K: EnvironmentKey
 
     static func write<K>(for key: K.Type, to environment: inout EnvironmentValues, value: K.Value) where K: EnvironmentKey
+}
+
+extension EnvironmentValues {
+    private struct BridgedEnvironmentResolverKey: EnvironmentKey {
+        static var defaultValue: (any BridgedEnvironmentResolver.Type)? { nil }
+    }
+
+    package var bridgedEnvironmentResolver: (any BridgedEnvironmentResolver.Type)? {
+        get { self[BridgedEnvironmentResolverKey.self] }
+        set { self[BridgedEnvironmentResolverKey.self] = newValue }
+    }
 }

--- a/Sources/OpenSwiftUICore/View/Text/Accessibility/NSAttributedString+Accessibility.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Accessibility/NSAttributedString+Accessibility.swift
@@ -144,7 +144,9 @@ extension Text.Style {
 // MARK: - AccessibilityTextAttributeResolver
 
 package protocol AccessibilityTextAttributeResolver {
-    func resolveDefaultAttributes(_: inout [NSAttributedString.Key: Any])
+    func resolveDefaultAttributes(
+        _: inout [NSAttributedString.Key: Any]
+    )
 
     func resolveTextStyleAttributes(
         _: inout [NSAttributedString.Key: Any],

--- a/Sources/OpenSwiftUICore/View/Text/Resolve/ResolvedText.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Resolve/ResolvedText.swift
@@ -722,7 +722,9 @@ extension EnvironmentValues {
 // MARK: - EnvironmentValues + resolvedTextProvider
 
 package protocol ResolvedTextProvider {
-    static func defaultLinkColor(for environment: EnvironmentValues) -> Color
+    static func defaultLinkColor(
+        for environment: EnvironmentValues
+    ) -> Color
 
     static func updateImageTextAttachment(
         in attachment: NSTextAttachment,
@@ -737,7 +739,7 @@ package protocol ResolvedTextProvider {
 
 extension EnvironmentValues {
     private struct ResolvedTextProviderKey: EnvironmentKey {
-        static var defaultValue: (any ResolvedTextProvider.Type)?
+        static var defaultValue: (any ResolvedTextProvider.Type)? { nil }
     }
 
     package var resolvedTextProvider: (any ResolvedTextProvider.Type)? {


### PR DESCRIPTION
## Summary

- Configure root environment values before they enter app and hosting view graphs
- Install platform providers for text attributes, resolved text, fallback fonts, and bridged traits
- Initialize standalone macOS hosting roots so date formatting inherits the current locale, calendar, and time zone

## Impact

macOS root views now use the current system locale when no explicit locale is provided, restoring the expected date format behavior.

Fixes #968