### PR TITLE
Add line limit UI tests

### DIFF
--- a/Example/OpenSwiftUIUITests/View/Text/LineLimitsUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/Text/LineLimitsUITests.swift
@@ -1,0 +1,21 @@
+//
+//  LineLimitsUITests.swift
+//  OpenSwiftUIUITests
+
+import SnapshotTesting
+import Testing
+@testable import TestingHost
+
+@MainActor
+@Suite(.snapshots(record: .never, diffTool: diffTool))
+struct LineLimitsUITests {
+    @Test
+    func lineLimit() {
+        openSwiftUIAssertSnapshot(of: LineLimitExample())
+    }
+
+    @Test
+    func lineLimitReservesSpace() {
+        openSwiftUIAssertSnapshot(of: LineLimitReservesSpaceExample())
+    }
+}

--- a/Example/OpenSwiftUIUITests/View/Text/TextUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/Text/TextUITests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @MainActor
 @Suite(.snapshots(record: .never, diffTool: diffTool))
-struct TextHeightUITests {
+struct TextUITests {
     @Test
     func foregroundColor() {
         openSwiftUIAssertSnapshot(of: TextForegroundExample())

--- a/Example/Shared/View/Text/LineLimitsExample.swift
+++ b/Example/Shared/View/Text/LineLimitsExample.swift
@@ -1,0 +1,32 @@
+//
+//  LineLimitsExample.swift
+//  Shared
+
+#if OPENSWIFTUI
+import OpenSwiftUI
+#else
+import SwiftUI
+#endif
+
+struct LineLimitExample: View {
+    var body: some View {
+        Text(
+            "This is a long string that demonstrates the effect of OpenSwiftUI's lineLimit(:_) operator."
+        )
+        .frame(width: 200, height: 200, alignment: .leading)
+        .lineLimit(2)
+    }
+}
+
+struct LineLimitReservesSpaceExample: View {
+    var body: some View {
+        VStack {
+            Text("Title")
+                .font(.headline)
+                .lineLimit(2, reservesSpace: true)
+            Text("Subtitle")
+                .font(.subheadline)
+                .lineLimit(4, reservesSpace: true)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add snapshot coverage for fixed line limits and reserved line space
- Move reusable line-limit examples into the shared text examples
- Rename `TextHeightUITests` to `TextUITests` to reflect the full suite scope

## Impact

The UI test suite now covers line-limit layout behavior and can catch regressions in truncation and reserved text space.