### PR TITLE
Add text orphan and push-out UI test

### DIFF
--- a/Example/Modules/Platform/cocoa/SwiftUI_SPI.swiftinterface
+++ b/Example/Modules/Platform/cocoa/SwiftUI_SPI.swiftinterface
@@ -58,3 +58,8 @@ public final class ViewGraph {
 extension SwiftUI.View {
   public func variableBlur(maxRadius: CoreGraphics.CGFloat, mask: SwiftUI.Image, opaque: Swift.Bool = false) -> some SwiftUI.View
 }
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
+extension SwiftUI.View {
+  public func avoidsOrphans(_ flag: Swift.Bool) -> some SwiftUI.View
+}

--- a/Example/OpenSwiftUIUITests/View/Text/TextUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/Text/TextUITests.swift
@@ -23,4 +23,9 @@ struct TextUITests {
     func textHeight() {
         openSwiftUIAssertSnapshot(of: TextBackgroundHeightExample())
     }
+
+    @Test
+    func orphanAndPushOut() {
+        openSwiftUIAssertSnapshot(of: TextOrphanAndPushOutExample())
+    }
 }

--- a/Example/Shared/View/Text/TextOrphanAndPushOutExample.swift
+++ b/Example/Shared/View/Text/TextOrphanAndPushOutExample.swift
@@ -1,0 +1,34 @@
+//
+//  TextOrphanAndPushOutExample.swift
+//  Shared
+
+#if OPENSWIFTUI
+@_spi(Private) import OpenSwiftUI
+#else
+import SwiftUI_SPI
+#endif
+
+struct TextOrphanAndPushOutExample: View {
+    private let text = "OpenSwiftUI 开发者"
+    private let width = 150.0
+
+    @ViewBuilder
+    private func textView(avoidsOrphans: Bool? = nil) -> some View {
+        if let avoidsOrphans {
+            Text(text)
+                .frame(width: width, alignment: .leading)
+                .avoidsOrphans(avoidsOrphans)
+        } else {
+            Text(text)
+                .frame(width: width, alignment: .leading)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            textView()
+            textView(avoidsOrphans: true)
+            textView(avoidsOrphans: false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a shared text example comparing default, enabled, and disabled orphan handling.
- Expose `View.avoidsOrphans(_:)` through the SwiftUI SPI interface used by the comparison target.
- Add snapshot UI coverage for the text orphan and paragraph push-out behavior.

## Impact

The UI test now captures how short final lines are handled consistently across both renderers.

## Validation

Source diff validation passed.