### PR TITLE
Enable Preview examples on macOS

### DIFF
--- a/Docs/Preview.md
+++ b/Docs/Preview.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-OpenSwiftUI supports Xcode Preview rendering through the shim introduced in [PR #829](https://github.com/OpenSwiftUIProject/OpenSwiftUI/pull/829). Source builds and binary distributions must also satisfy the linkage requirements below.
+OpenSwiftUI supports Xcode Preview rendering through the shim introduced in [PR #829](https://github.com/OpenSwiftUIProject/OpenSwiftUI/pull/829). macOS Preview support was enabled by the binary framework fixes in [PR #952](https://github.com/OpenSwiftUIProject/OpenSwiftUI/pull/952). Source builds and binary distributions must also satisfy the linkage requirements below.
 
 ### How It Works
 
@@ -16,6 +16,8 @@ Since OpenSwiftUI cannot use SwiftUI's `#Preview` macro directly (it targets `Sw
     ContentView()._previewVC()
 }
 ```
+
+The same preview declaration works on both supported targets. Native macOS targets return an `NSViewController` backed by `NSHostingController`; iOS and Mac Catalyst targets return a `UIViewController` backed by `UIHostingController`.
 
 ### Binary XCFramework Requirements
 

--- a/Example/Shared/PreviewShims.swift
+++ b/Example/Shared/PreviewShims.swift
@@ -21,18 +21,21 @@ extension SwiftUI.View {
 }
 #endif
 
-#if canImport(UIKit)
-// FIXME: Not working on macOS yet
-
 #Preview("HostingVC") {
     ContentView()
         ._previewVC()
 }
 
 #Preview("CAHostingLayerExample") {
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    CAHostingLayerExample(
+        content: ContentView(),
+        size: CGSize(width: 500, height: 300)
+    ).makeViewController()
+    #else
     CAHostingLayerExample(
         content: ContentView(),
         size: UIScreen.main.bounds.size
     ).makeViewController()
+    #endif
 }
-#endif


### PR DESCRIPTION
## Summary

- enable the shared Preview examples for native macOS targets
- use an AppKit-compatible size for the Core Animation hosting preview
- document macOS Preview support enabled by #952

## Motivation

The shared Preview declarations remained limited to UIKit even after the binary framework linkage fixes made macOS Preview available. This enables the same hosting previews for AppKit while preserving the existing UIKit behavior.

## Validation

- verified the final diff is clean