### PR TITLE
Fix CI regressions issue

### DIFF
--- a/.github/workflows/compatibility_tests.yml
+++ b/.github/workflows/compatibility_tests.yml
@@ -43,8 +43,10 @@ jobs:
         run: |
           set -o pipefail
           # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
+          # Swift 6.2 also crashes while indexing AppKit with the private framework shims.
           NSUnbufferedIO=YES swift test \
             --disable-experimental-prebuilts \
+            --disable-index-store \
             --filter OpenSwiftUICompatibilityTests \
             --build-path .build-compatibility-test-debug \
             2>&1 | xcbeautify --renderer github-actions --preserve-unbeautified
@@ -54,8 +56,10 @@ jobs:
         run: |
           set -o pipefail
           # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
+          # Swift 6.2 also crashes while indexing AppKit with the private framework shims.
           NSUnbufferedIO=YES swift test \
             --disable-experimental-prebuilts \
+            --disable-index-store \
             --filter OpenSwiftUICompatibilityTests \
             --build-path .build-compatibility-test-debug \
             2>&1 | xcbeautify --renderer github-actions --preserve-unbeautified

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,8 +46,10 @@ jobs:
         run: |
           set -o pipefail
           # Swift 6.2 can duplicate-link swift-syntax macro prebuilts; Swift 6.3 fixes this.
+          # Swift 6.2 also crashes while indexing AppKit with the private framework shims.
           NSUnbufferedIO=YES swift test \
             --disable-experimental-prebuilts \
+            --disable-index-store \
             -c debug \
             --filter OpenSwiftUITests \
             --filter OpenSwiftUICoreTests \

--- a/Renderer/Stdout/run-example.sh
+++ b/Renderer/Stdout/run-example.sh
@@ -4,10 +4,14 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+swift_run_options=()
+
 case "$(uname -s)" in
 Darwin)
     export OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH="${OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH:-1}"
     export OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE="${OPENSWIFTUI_OPENATTRIBUTESHIMS_COMPUTE:-0}"
+    # Swift 6.2 crashes while indexing AppKit with the local private framework shims.
+    swift_run_options+=(--disable-index-store)
     ;;
 *)
     export OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH="${OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH:-0}"
@@ -16,4 +20,4 @@ Darwin)
     ;;
 esac
 
-exec swift run ExampleApp "$@"
+exec swift run "${swift_run_options[@]}" ExampleApp "$@"

--- a/Scripts/build-documentation.sh
+++ b/Scripts/build-documentation.sh
@@ -256,7 +256,9 @@ if [[ "$REBUILD_NEEDED" == true ]] || [[ "$CLEAN_BUILD" == true ]]; then
     fi
 
     log_info "Generating symbol graphs..."
+    # Swift 6.2 crashes while indexing AppKit with the local private framework shims.
     swift build \
+        --disable-index-store \
         --target "$TARGET_NAME" \
         -Xswiftc -emit-symbol-graph \
         -Xswiftc -emit-symbol-graph-dir \

--- a/Tests/OpenSwiftUICoreTests/View/IDViewTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/IDViewTests.swift
@@ -39,7 +39,7 @@ struct IDViewTests {
         \(display-list
           \(item #:identity \d+ #:version \d+
             \(frame \([^)]+\)\)
-            \(effect
+            \(effect(?: #:opacity 1\.0)?
               \(item #:identity \d+ #:version \d+
                 \(frame \([^)]+\)\)
                 \(content-seed \d+\)

--- a/Tests/OpenSwiftUICoreTests/View/Text/AttributedString/NSAttributedStringTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/Text/AttributedString/NSAttributedStringTests.swift
@@ -6,6 +6,9 @@
 
 import CoreText
 import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
 import Numerics
 @_spi(ForOpenSwiftUIOnly)
 @_spi(Private)
@@ -23,13 +26,35 @@ private func attributedString(_ string: String, font: CTFont = fixedFont) -> NSA
     NSAttributedString(string: string, attributes: [.kitFont: font])
 }
 
-/// The metrics of ``fixedFont``, whose 16 point line height and 12 point
-/// baseline are already whole pixels.
+/// The metrics used by string drawing for ``fixedFont``. UIKit applies its
+/// platform font metrics to a `CTFont`, while AppKit uses the Core Text metrics.
 private enum FixedFontMetrics {
     static let ascender: CGFloat = 12.3203125
     static let descender: CGFloat = -3.6796875
-    static let lineHeight: CGFloat = 16
-    static let baseline: CGFloat = 12
+
+    #if canImport(UIKit)
+    private static let unroundedLineHeight = (fixedFont as UIFont).lineHeight
+    private static let unroundedBaseline = (fixedFont as UIFont).ascender
+    #else
+    private static let unroundedLineHeight: CGFloat = 16
+    private static let unroundedBaseline: CGFloat = 12
+    #endif
+
+    static let lineHeight = unroundedLineHeight.rounded(.up)
+    static let baseline = unroundedBaseline.rounded()
+    static let baselineAdjustment = baseline - unroundedBaseline
+
+    static func height(lineCount: Int) -> CGFloat {
+        (unroundedLineHeight * CGFloat(lineCount)).rounded(.up)
+    }
+
+    static func lastBaseline(lineCount: Int) -> CGFloat {
+        (
+            unroundedBaseline
+                + unroundedLineHeight * CGFloat(lineCount - 1)
+                + baselineAdjustment
+        ).rounded(.up)
+    }
 }
 
 private func metrics(
@@ -164,7 +189,11 @@ struct NSAttributedStringTests {
             #expect(result.size.height.isApproximatelyEqual(to: FixedFontMetrics.lineHeight))
             #expect(result.firstBaseline.isApproximatelyEqual(to: FixedFontMetrics.baseline))
             #expect(result.lastBaseline.isApproximatelyEqual(to: FixedFontMetrics.baseline))
-            #expect(result.baselineAdjustment.isApproximatelyEqual(to: 0))
+            #expect(
+                result.baselineAdjustment.isApproximatelyEqual(
+                    to: FixedFontMetrics.baselineAdjustment
+                )
+            )
         }
 
         @Test
@@ -175,9 +204,17 @@ struct NSAttributedStringTests {
             #expect(result.requestedWidth == 60)
             #expect(result.size.width <= 60)
             #expect(result.numberOfLines == 4)
-            #expect(result.size.height.isApproximatelyEqual(to: FixedFontMetrics.lineHeight * 4))
+            #expect(
+                result.size.height.isApproximatelyEqual(
+                    to: FixedFontMetrics.height(lineCount: 4)
+                )
+            )
             #expect(result.firstBaseline.isApproximatelyEqual(to: FixedFontMetrics.baseline))
-            #expect(result.lastBaseline.isApproximatelyEqual(to: FixedFontMetrics.baseline + 48))
+            #expect(
+                result.lastBaseline.isApproximatelyEqual(
+                    to: FixedFontMetrics.lastBaseline(lineCount: 4)
+                )
+            )
         }
 
         @Test
@@ -189,9 +226,17 @@ struct NSAttributedStringTests {
 
             #expect(unlimited.numberOfLines == 4)
             #expect(limited.numberOfLines == 2)
-            #expect(limited.size.height.isApproximatelyEqual(to: FixedFontMetrics.lineHeight * 2))
+            #expect(
+                limited.size.height.isApproximatelyEqual(
+                    to: FixedFontMetrics.height(lineCount: 2)
+                )
+            )
             #expect(limited.firstBaseline.isApproximatelyEqual(to: FixedFontMetrics.baseline))
-            #expect(limited.lastBaseline.isApproximatelyEqual(to: FixedFontMetrics.baseline + 16))
+            #expect(
+                limited.lastBaseline.isApproximatelyEqual(
+                    to: FixedFontMetrics.lastBaseline(lineCount: 2)
+                )
+            )
         }
 
         @Test
@@ -287,7 +332,7 @@ struct NSAttributedStringTests {
                     spacing.minima[.init(category: .textBaseline, edge: .bottom)],
                     .distance(FixedFontMetrics.baseline - FixedFontMetrics.lineHeight)
                 )
-                // The 16 point line height gives a 1.6 point default text spacing,
+                // The 16 point Core Text metrics give a 1.6 point default text spacing,
                 // which rounds up to the pixel length only once TextSpacingUIKit0059v2
                 // is enabled, and to 4 points before that.
                 expectApproximatelyEqual(

--- a/Tests/OpenSwiftUICoreTests/View/VariadicView/VariadicViewTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/VariadicView/VariadicViewTests.swift
@@ -48,17 +48,17 @@ struct VariadicViewTests {
             \(display-list
               \(item #:identity \d+ #:version \d+
                 \(frame \([^)]+\)\)
-                \(effect
+                \(effect(?: #:opacity 1\.0)?
                   \(item #:identity \d+ #:version \d+
                     \(frame \([^)]+\)\)
-                    \(effect
+                    \(effect(?: #:opacity 1\.0)?
                       \(item #:identity \d+ #:version \d+
                         \(frame \([^)]+\)\)
                         \(content-seed \d+\)
                         \(color #[0-9A-F]{8}\)\)\)\)
                   \(item #:identity \d+ #:version \d+
                     \(frame \([^)]+\)\)
-                    \(effect
+                    \(effect(?: #:opacity 1\.0)?
                       \(item #:identity \d+ #:version \d+
                         \(frame \([^)]+\)\)
                         \(content-seed \d+\)
@@ -99,14 +99,14 @@ struct VariadicViewTests {
             \(display-list
               \(item #:identity \d+ #:version \d+
                 \(frame \([^)]+\)\)
-                \(effect
+                \(effect(?: #:opacity 1\.0)?
                   \(item #:identity \d+ #:version \d+
                     \(frame \([^)]+\)\)
                     \(content-seed \d+\)
                     \(color #[0-9A-F]{8}\)\)\)\)
               \(item #:identity \d+ #:version \d+
                 \(frame \([^)]+\)\)
-                \(effect
+                \(effect(?: #:opacity 1\.0)?
                   \(item #:identity \d+ #:version \d+
                     \(frame \([^)]+\)\)
                     \(content-seed \d+\)

--- a/Tests/OpenSwiftUITests/View/Configuration/ViewAliasTests.swift
+++ b/Tests/OpenSwiftUITests/View/Configuration/ViewAliasTests.swift
@@ -197,7 +197,7 @@ struct ViewAliasTests {
         \(display-list
           \(item #:identity \d+ #:version \d+
             \(frame \([^)]+\)\)
-            \(effect
+            \(effect(?: #:opacity 1\.0)?
               \(item #:identity \d+ #:version \d+
                 \(frame \([^)]+\)\)
                 \(content-seed \d+\)


### PR DESCRIPTION
## Summary

- Disable SwiftPM index-store generation in affected macOS build paths to avoid Swift 6.2 compiler crashes while indexing AppKit with the private framework shims.
- Derive attributed string metric expectations from UIKit font metrics while preserving existing non-UIKit expectations.
- Update DisplayList test expectations to accept the default opacity attribute.

## CI status

As of August 4, 2026:

- Passed: iOS, macOS compatibility tests, Ubuntu, Stdout Renderer (Compute), PR Triage, and Codecov.
- In progress: iOS compatibility tests and macOS tests.
- Queued: Stdout Renderer (AttributeGraph).