### PR TITLE
Implement DisplayList canonicalization

### DIFF
--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
@@ -419,28 +419,6 @@ extension DisplayList {
         case projection(ProjectionTransform)
         case rotation(_RotationEffect.Data)
         case rotation3D(_Rotation3DEffect.Data)
-
-        package var affineTransform: CGAffineTransform? {
-            switch self {
-            case let .affine(transform):
-                return transform
-            case let .rotation(data):
-                return data.transform
-            case .projection, .rotation3D:
-                return nil
-            }
-        }
-
-        package var projectionTransform: ProjectionTransform? {
-            switch self {
-            case let .projection(transform):
-                return transform
-            case let .rotation3D(data):
-                return data.transform
-            case .affine, .rotation:
-                return nil
-            }
-        }
     }
     
     package typealias AnyEffectAnimation = _DisplayList_AnyEffectAnimation
@@ -796,6 +774,32 @@ extension DisplayList.Item {
             return states.reduce(into: []) { properties, state in
                 properties.formUnion(state.1.properties)
             }
+        }
+    }
+}
+
+// MARK: - DisplayList.Transform + Extension
+
+extension DisplayList.Transform {
+    package var affineTransform: CGAffineTransform? {
+        switch self {
+        case let .affine(transform):
+            return transform
+        case let .rotation(data):
+            return data.transform
+        case .projection, .rotation3D:
+            return nil
+        }
+    }
+
+    package var projectionTransform: ProjectionTransform? {
+        switch self {
+        case let .projection(transform):
+            return transform
+        case let .rotation3D(data):
+            return data.transform
+        case .affine, .rotation:
+            return nil
         }
     }
 }

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
@@ -742,6 +742,19 @@ extension DisplayList.Item {
         // TODO eg. .opacity(1.0) -> .identity
     }
 
+    private mutating func canonicalizeIdentityEffect(list: DisplayList) {
+        guard list.items.count == 1 else {
+            return
+        }
+        let item = list.items[0]
+        frame = item.frame.offset(by: CGSize(frame.origin))
+        version.combine(with: item.version)
+        value = item.value
+        if item.identity != .none {
+            identity = item.identity
+        }
+    }
+
     fileprivate func opaqueContentPath() -> (Path, FillStyle)? {
         guard case let .content(content) = value else {
             return nil

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
@@ -739,7 +739,111 @@ package protocol _DisplayList_AnyEffectAnimator {
 
 extension DisplayList.Item {
     package mutating func canonicalize(options: DisplayList.Options = .init()) {
-        // TODO eg. .opacity(1.0) -> .identity
+        guard !options.contains(.disableCanonicalization) else {
+            return
+        }
+        switch value {
+        case .empty, .states:
+            return
+        case let .content(content):
+            if frame.isEmpty && !features.contains(.required) {
+                value = .empty
+                return
+            }
+            switch content.value {
+            case let .color(color):
+                if color == .clear {
+                    value = .empty
+                }
+            case let .shape(path, _, _):
+                if path.isEmpty {
+                    value = .empty
+                }
+            case let .shadow(path, shadow):
+                if path.isEmpty || shadow.color.opacity == 0 {
+                    value = .empty
+                }
+            case let .text(text, _):
+                if text.text.isEmpty {
+                    value = .empty
+                }
+            case let .flattened(list, _, _):
+                if list.isEmpty {
+                    value = .empty
+                }
+            default:
+                break
+            }
+        case let .effect(effect, list):
+            guard !list.isEmpty || effect.features.contains(.required) else {
+                value = .empty
+                return
+            }
+            switch effect {
+            case let .opacity(opacity) where opacity >= 1:
+                value = .effect(.identity, list)
+                canonicalizeIdentityEffect(list: list)
+            case let .clip(path, fillStyle, clipOptions):
+                if clipOptions.isEmpty,
+                   list.items.count == 1,
+                   let paint = list.items[0].paint(in: CGRect(origin: .zero, size: frame.size)) {
+                    value = .content(DisplayList.Content(
+                        .shape(path, paint, fillStyle),
+                        seed: DisplayList.Seed(version)
+                    ))
+                }
+            case let .mask(mask, maskOptions):
+                if maskOptions.isEmpty,
+                   list.items.count == 1,
+                   let filter = list.items[0].backdropFilter(size: frame.size) {
+                    value = .effect(.filter(filter), mask)
+                } else if mask.items.count == 1,
+                    let (path, fillStyle) = mask.items[0].opaqueContentPath() {
+                    value = .effect(.clip(path, fillStyle, maskOptions), list)
+                    canonicalize(options: options)
+                }
+            case let .transform(transform):
+                if case let .affine(t) = transform, t == .identity {
+                    value = .effect(.identity, list)
+                    canonicalizeIdentityEffect(list: list)
+                }
+            case let .filter(filter):
+                if filter.isIdentity {
+                    value = .effect(.identity, list)
+                    canonicalizeIdentityEffect(list: list)
+                } else if let outerMatrix = _ColorMatrix(filter, premultiplied: false),
+                       list.items.count == 1,
+                       let (innerMatrix, innerList) = list.items[0].colorMatrix(size: frame.size) {
+                    value = .effect(
+                        .filter(.colorMatrix(outerMatrix * innerMatrix, premultiplied: false)),
+                        innerList
+                    )
+                }
+            case .identity:
+                canonicalizeIdentityEffect(list: list)
+            default:
+                break
+            }
+            guard !list.features.contains(.required) else {
+                return
+            }
+            switch effect {
+            case let .opacity(opacity):
+                if opacity <= 0 {
+                    value = .empty
+                }
+            case let .clip(path, _, _):
+                if path.isEmpty {
+                    value = .empty
+                }
+            case let .mask(mask, _):
+                if mask.isEmpty {
+                    value = .empty
+                }
+            default:
+                break
+            }
+        }
     }
 
     private mutating func canonicalizeIdentityEffect(list: DisplayList) {
@@ -776,6 +880,52 @@ extension DisplayList.Item {
         default:
             return nil
         }
+    }
+
+    private func paint(in rect: CGRect) -> AnyResolvedPaint? {
+        guard case let .content(content) = value else {
+            return nil
+        }
+        switch content.value {
+        case let .color(color):
+            guard rect == frame else {
+                return nil
+            }
+            return _AnyResolvedPaint(color)
+        case let .shape(path, paint, _):
+            guard rect == frame,
+                path == Path(CGRect(origin: .zero, size: rect.size)) else {
+                return nil
+            }
+            return paint
+        default:
+            return nil
+        }
+    }
+
+    private func colorMatrix(size: CGSize) -> (_ColorMatrix, DisplayList)? {
+        guard frame == CGRect(origin: .zero, size: size),
+              case let .effect(.filter(filter), list) = value,
+              let matrix = _ColorMatrix(filter, premultiplied: false) else {
+            return nil
+        }
+        return (matrix, list)
+    }
+
+    private func backdropFilter(size: CGSize) -> GraphicsFilter? {
+        guard let (matrix, list) = colorMatrix(size: size),
+              list.items.count == 1 else {
+            return nil
+        }
+        let item = list.items[0]
+        guard item.frame == CGRect(origin: .zero, size: size),
+              case let .content(content) = item.value,
+              case let .backdrop(backdrop) = content.value,
+              backdrop.color.opacity == 0
+        else {
+            return nil
+        }
+        return .vibrantColorMatrix(matrix)
     }
 
     package func matchesTopLevelStructure(of other: DisplayList.Item) -> Bool {

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
@@ -742,6 +742,29 @@ extension DisplayList.Item {
         // TODO eg. .opacity(1.0) -> .identity
     }
 
+    fileprivate func opaqueContentPath() -> (Path, FillStyle)? {
+        guard case let .content(content) = value else {
+            return nil
+        }
+        switch content.value {
+        case let .color(color):
+            guard color.opacity == 1 else {
+                return nil
+            }
+            return (Path(frame), FillStyle())
+        case let .shape(path, paint, fillStyle):
+            guard paint.isOpaque else {
+                return nil
+            }
+            return (
+                frame.origin != .zero ? path.applying(.init(translationX: frame.x, y: frame.y)) : path,
+                fillStyle
+            )
+        default:
+            return nil
+        }
+    }
+
     package func matchesTopLevelStructure(of other: DisplayList.Item) -> Bool {
         switch (value, other.value) {
         case (.empty, .empty):
@@ -801,6 +824,17 @@ extension DisplayList.Item {
                 properties.formUnion(state.1.properties)
             }
         }
+    }
+}
+
+// MARK: - DisplayList + Extension
+
+extension DisplayList {
+    package func opaqueContentPath() -> (Path, FillStyle)? {
+        guard items.count == 1 else {
+            return nil
+        }
+        return items[0].opaqueContentPath()
     }
 }
 

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
@@ -709,6 +709,32 @@ extension PreferencesOutputs {
     }
 }
 
+// MARK: - DisplayList + AnyEffectAnimator
+
+package protocol _DisplayList_AnyEffectAnimation: ProtobufMessage {
+    static var leafProtobufTag: CodableEffectAnimation.Tag? { get }
+    func makeAnimator() -> any _DisplayList_AnyEffectAnimator
+}
+
+package protocol _DisplayList_AnyEffectAnimator {
+    /// Evaluates the effect animation at the given time and viewport size.
+    ///
+    /// - Parameters:
+    ///   - animation: The existential effect animation. Must be castable to
+    ///     `Animation`; otherwise the method returns
+    ///     ``DisplayList/Effect/identity`` with `finished: true`.
+    ///   - time: The current render time.
+    ///   - size: The viewport size passed to
+    ///     ``EffectAnimation/effect(value:size:)``.
+    /// - Returns: A tuple of the resolved display list effect and a Boolean
+    ///   indicating whether the animation has completed.
+    mutating func evaluate(
+        _ animation: any DisplayList.AnyEffectAnimation,
+        at time: Time,
+        size: CGSize
+    ) -> (DisplayList.Effect, finished: Bool)
+}
+
 // MARK: - DisplayList.Item + Extension
 
 extension DisplayList.Item {
@@ -987,30 +1013,6 @@ extension DisplayList.Item {
 }
 
 package struct AccessibilityNodeAttachment {}
-
-package protocol _DisplayList_AnyEffectAnimation: ProtobufMessage {
-    static var leafProtobufTag: CodableEffectAnimation.Tag? { get }
-    func makeAnimator() -> any _DisplayList_AnyEffectAnimator
-}
-
-package protocol _DisplayList_AnyEffectAnimator {
-    /// Evaluates the effect animation at the given time and viewport size.
-    ///
-    /// - Parameters:
-    ///   - animation: The existential effect animation. Must be castable to
-    ///     `Animation`; otherwise the method returns
-    ///     ``DisplayList/Effect/identity`` with `finished: true`.
-    ///   - time: The current render time.
-    ///   - size: The viewport size passed to
-    ///     ``EffectAnimation/effect(value:size:)``.
-    /// - Returns: A tuple of the resolved display list effect and a Boolean
-    ///   indicating whether the animation has completed.
-    mutating func evaluate(
-        _ animation: any DisplayList.AnyEffectAnimation,
-        at time: Time,
-        size: CGSize
-    ) -> (DisplayList.Effect, finished: Bool)
-}
 
 extension DisplayList.Item {
     func addDrawingGroup(contentSeed: DisplayList.Seed) {

--- a/Sources/OpenSwiftUISymbolDualTestsSupport/Render/DisplayList/DisplayListCanonicalizationTestsStub.c
+++ b/Sources/OpenSwiftUISymbolDualTestsSupport/Render/DisplayList/DisplayListCanonicalizationTestsStub.c
@@ -1,0 +1,13 @@
+//
+//  DisplayListCanonicalizationTestsStub.c
+//  OpenSwiftUISymbolDualTestsSupport
+
+#include "OpenSwiftUIBase.h"
+
+#if OPENSWIFTUI_TARGET_OS_DARWIN
+
+#import <SymbolLocator.h>
+
+DEFINE_SL_STUB_SLF(OpenSwiftUITestStub_DisplayListItemCanonicalize, SwiftUICore, $s7SwiftUI11DisplayListV4ItemV12canonicalize7optionsyAC7OptionsV_tF);
+
+#endif

--- a/Tests/OpenSwiftUISymbolDualTests/Render/DisplayList/DisplayListCanonicalizationDualTests.swift
+++ b/Tests/OpenSwiftUISymbolDualTests/Render/DisplayList/DisplayListCanonicalizationDualTests.swift
@@ -1,0 +1,594 @@
+//
+//  DisplayListCanonicalizationDualTests.swift
+//  OpenSwiftUISymbolDualTests
+
+#if canImport(SwiftUI, _underlyingVersion: 6.5.4)
+import Foundation
+@_spi(Private) @testable import OpenSwiftUICore
+import Testing
+
+extension DisplayList.Item {
+    @_silgen_name("OpenSwiftUITestStub_DisplayListItemCanonicalize")
+    mutating func swiftUI_canonicalize(options: DisplayList.Options)
+}
+
+@MainActor
+@Suite(.serialized)
+struct DisplayListCanonicalizationDualTests {
+    @Test(arguments: CanonicalizationFixture.allCases)
+    fileprivate func canonicalize(_ fixture: CanonicalizationFixture) {
+        var openSwiftUIItem = fixture.makeItem()
+        openSwiftUIItem.canonicalize(options: fixture.options)
+        #expect(CanonicalizedItem(openSwiftUIItem) == fixture.expected)
+
+        guard isSwiftUIVersionAtLeast65AndBefore70 else {
+            return
+        }
+        var swiftUIItem = fixture.makeItem()
+        swiftUIItem.swiftUI_canonicalize(options: fixture.options)
+        #expect(CanonicalizedItem(swiftUIItem) == fixture.expected)
+    }
+}
+
+private enum CanonicalizationFixture: String, CaseIterable, Equatable, Sendable, CustomTestStringConvertible {
+    case disabled
+    case empty
+    case states
+    case clearColor
+    case opaqueColor
+    case emptyFrame
+    case requiredEmptyFrame
+    case emptyShape
+    case emptyShadowPath
+    case transparentShadow
+    case emptyText
+    case emptyFlattenedContent
+    case unhandledContent
+    case emptyEffect
+    case requiredEmptyEffect
+    case identity
+    case identityMultipleChildren
+    case identityChildWithoutIdentity
+    case unitOpacity
+    case zeroOpacity
+    case partialOpacity
+    case requiredZeroOpacity
+    case clipColorPaint
+    case clipShapePaint
+    case inverseClip
+    case emptyClip
+    case requiredEmptyClip
+    case maskedBackdrop
+    case opaqueColorMask
+    case opaqueShapeMask
+    case inverseMask
+    case nonOpaqueMask
+    case emptyMask
+    case requiredEmptyMask
+    case identityAffineTransform
+    case translatedAffineTransform
+    case identityFilter
+    case unsupportedFilter
+    case colorMatrixFusion
+    case unhandledEffect
+
+    var testDescription: String { rawValue }
+
+    var options: DisplayList.Options {
+        self == .disabled ? .disableCanonicalization : []
+    }
+
+    @MainActor
+    func makeItem() -> DisplayList.Item {
+        switch self {
+        case .disabled:
+            return effectItem(.opacity(1), child: child, frame: outerFrame)
+        case .empty:
+            return item(.empty, frame: outerFrame)
+        case .states:
+            return item(.states([(StrongHash(), child)]), frame: outerFrame)
+        case .clearColor:
+            return contentItem(.color(.clear), frame: outerFrame)
+        case .opaqueColor:
+            return contentItem(.color(.white), frame: outerFrame)
+        case .emptyFrame:
+            return contentItem(.color(.white))
+        case .requiredEmptyFrame:
+            return contentItem(.platformView(EmptyViewFactory()))
+        case .emptyShape:
+            return contentItem(
+                .shape(
+                    Path(),
+                    OpenSwiftUICore._AnyResolvedPaint(Color.Resolved.white),
+                    FillStyle()
+                ),
+                frame: outerFrame
+            )
+        case .emptyShadowPath:
+            return contentItem(.shadow(Path(), visibleResolvedShadow), frame: outerFrame)
+        case .transparentShadow:
+            return contentItem(.shadow(testPath, transparentResolvedShadow), frame: outerFrame)
+        case .emptyText:
+            return contentItem(
+                .text(StyledTextContentView(text: resolvedStyledText(nil)), .zero),
+                frame: outerFrame
+            )
+        case .emptyFlattenedContent:
+            return contentItem(.flattened(DisplayList(), .zero, .init()), frame: outerFrame)
+        case .unhandledContent:
+            return contentItem(.backdrop(.init(color: .white)), frame: outerFrame)
+        case .emptyEffect:
+            return effectItem(.opacity(0.5), frame: outerFrame)
+        case .requiredEmptyEffect:
+            return effectItem(.properties(.privacySensitive), frame: outerFrame)
+        case .identity:
+            return effectItem(.identity, child: child, frame: outerFrame)
+        case .identityMultipleChildren:
+            return effectItem(.identity, child: multipleChildren, frame: outerFrame)
+        case .identityChildWithoutIdentity:
+            return effectItem(.identity, child: childWithoutIdentity, frame: outerFrame)
+        case .unitOpacity:
+            return effectItem(.opacity(1), child: child, frame: outerFrame)
+        case .zeroOpacity:
+            return effectItem(.opacity(0), child: child, frame: outerFrame)
+        case .partialOpacity:
+            return effectItem(.opacity(0.5), child: child, frame: outerFrame)
+        case .requiredZeroOpacity:
+            return effectItem(.opacity(0), child: requiredChild, frame: outerFrame)
+        case .clipColorPaint:
+            return effectItem(.clip(testPath, FillStyle()), child: colorPaintChild, frame: outerFrame)
+        case .clipShapePaint:
+            return effectItem(.clip(testPath, FillStyle()), child: shapePaintChild, frame: outerFrame)
+        case .inverseClip:
+            return effectItem(
+                .clip(testPath, FillStyle(), .inverse),
+                child: colorPaintChild,
+                frame: outerFrame
+            )
+        case .emptyClip:
+            return effectItem(.clip(Path(), FillStyle()), child: child, frame: outerFrame)
+        case .requiredEmptyClip:
+            return effectItem(.clip(Path(), FillStyle()), child: requiredChild, frame: outerFrame)
+        case .maskedBackdrop:
+            let backdrop = contentItem(.backdrop(.init(color: .clear)), frame: sizeFrame)
+            let filteredBackdrop = effectItem(
+                .filter(.brightness(0.25)),
+                child: DisplayList(backdrop),
+                frame: sizeFrame
+            )
+            let mask = DisplayList(contentItem(.color(.white), frame: sizeFrame))
+            return effectItem(
+                .mask(mask),
+                child: DisplayList(filteredBackdrop),
+                frame: outerFrame
+            )
+        case .opaqueColorMask:
+            let mask = DisplayList(contentItem(.color(.white), frame: sizeFrame))
+            return effectItem(.mask(mask), child: colorPaintChild, frame: outerFrame)
+        case .opaqueShapeMask:
+            let mask = DisplayList(contentItem(
+                .shape(
+                    fullSizePath,
+                    OpenSwiftUICore._AnyResolvedPaint(Color.Resolved.white),
+                    FillStyle()
+                ),
+                frame: CGRect(origin: CGPoint(x: 2, y: 3), size: outerFrame.size)
+            ))
+            return effectItem(.mask(mask), child: colorPaintChild, frame: outerFrame)
+        case .inverseMask:
+            let mask = DisplayList(contentItem(.color(.white), frame: sizeFrame))
+            return effectItem(.mask(mask, .inverse), child: colorPaintChild, frame: outerFrame)
+        case .nonOpaqueMask:
+            let mask = DisplayList(contentItem(.color(translucentColor), frame: sizeFrame))
+            return effectItem(.mask(mask), child: colorPaintChild, frame: outerFrame)
+        case .emptyMask:
+            return effectItem(.mask(DisplayList()), child: child, frame: outerFrame)
+        case .requiredEmptyMask:
+            return effectItem(.mask(DisplayList()), child: requiredChild, frame: outerFrame)
+        case .identityAffineTransform:
+            return effectItem(.transform(.affine(.identity)), child: child, frame: outerFrame)
+        case .translatedAffineTransform:
+            return effectItem(
+                .transform(.affine(.init(translationX: 1, y: 2))),
+                child: child,
+                frame: outerFrame
+            )
+        case .identityFilter:
+            return effectItem(.filter(.brightness(0)), child: child, frame: outerFrame)
+        case .unsupportedFilter:
+            return effectItem(.filter(.blur(.init(radius: 1))), child: child, frame: outerFrame)
+        case .colorMatrixFusion:
+            let innerList = DisplayList(contentItem(.color(.white), frame: outerFrame))
+            let innerFilter = effectItem(
+                .filter(.contrast(2)),
+                child: innerList,
+                frame: CGRect(origin: .zero, size: outerFrame.size)
+            )
+            return effectItem(
+                .filter(.brightness(0.25)),
+                child: DisplayList(innerFilter),
+                frame: outerFrame
+            )
+        case .unhandledEffect:
+            return effectItem(.blendMode(.normal), child: child, frame: outerFrame)
+        }
+    }
+
+    var expected: CanonicalizedItem {
+        switch self {
+        case .disabled:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .opacity(1, childCount: 1)
+            )
+        case .identity, .unitOpacity, .identityAffineTransform, .identityFilter:
+            return CanonicalizedItem(
+                frame: CGRect(x: 11, y: 22, width: 3, height: 4),
+                version: 5,
+                identity: 8,
+                value: .content(.color)
+            )
+        case .identityChildWithoutIdentity:
+            return CanonicalizedItem(
+                frame: CGRect(x: 11, y: 22, width: 3, height: 4),
+                version: 5,
+                identity: 7,
+                value: .content(.color)
+            )
+        case .requiredEmptyEffect:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .properties(.privacySensitive, childCount: 0)
+            )
+        case .maskedBackdrop:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .vibrantColorMatrix(
+                    _ColorMatrix(
+                        row1: (1, 0, 0, 0, 0.25),
+                        row2: (0, 1, 0, 0, 0.25),
+                        row3: (0, 0, 1, 0, 0.25),
+                        row4: (0, 0, 0, 1, 0)
+                    ),
+                    childCount: 1
+                )
+            )
+        case .colorMatrixFusion:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .colorMatrix(
+                    _ColorMatrix(
+                        row1: (2, 0, 0, 0, -0.25),
+                        row2: (0, 2, 0, 0, -0.25),
+                        row3: (0, 0, 2, 0, -0.25),
+                        row4: (0, 0, 0, 1, 0)
+                    ),
+                    premultiplied: false,
+                    childCount: 1
+                )
+            )
+        case .empty, .clearColor, .emptyShape, .emptyShadowPath, .transparentShadow,
+             .emptyText, .emptyFlattenedContent, .emptyEffect, .zeroOpacity, .emptyClip,
+             .emptyMask:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .empty
+            )
+        case .emptyFrame:
+            return CanonicalizedItem(frame: .zero, version: 3, identity: 7, value: .empty)
+        case .states:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .states(1))
+        case .opaqueColor:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .content(.color))
+        case .requiredEmptyFrame:
+            return CanonicalizedItem(frame: .zero, version: 3, identity: 7, value: .content(.platformView))
+        case .unhandledContent:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .content(.backdrop))
+        case .identityMultipleChildren:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .identity(childCount: 2))
+        case .partialOpacity:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .opacity(0.5, childCount: 1))
+        case .requiredZeroOpacity:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .opacity(0, childCount: 1))
+        case .clipColorPaint, .clipShapePaint, .opaqueColorMask, .opaqueShapeMask:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .content(.shape(pathIsEmpty: false)))
+        case .inverseClip, .inverseMask:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .clip(pathIsEmpty: false, options: 1, childCount: 1)
+            )
+        case .requiredEmptyClip:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .clip(pathIsEmpty: true, options: 0, childCount: 1)
+            )
+        case .nonOpaqueMask:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .mask(maskCount: 1, options: 0, childCount: 1)
+            )
+        case .requiredEmptyMask:
+            return CanonicalizedItem(
+                frame: outerFrame,
+                version: 3,
+                identity: 7,
+                value: .mask(maskCount: 0, options: 0, childCount: 1)
+            )
+        case .translatedAffineTransform:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .transform(childCount: 1))
+        case .unsupportedFilter:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .filter(childCount: 1))
+        case .unhandledEffect:
+            return CanonicalizedItem(frame: outerFrame, version: 3, identity: 7, value: .blendMode(childCount: 1))
+        }
+    }
+}
+
+private struct CanonicalizedItem: Equatable {
+    enum ContentValue: Equatable {
+        case backdrop
+        case color
+        case shape(pathIsEmpty: Bool)
+        case shadow
+        case platformView
+        case text
+        case flattened(childCount: Int)
+        case other
+    }
+
+    enum Value: Equatable {
+        case empty
+        case content(ContentValue)
+        case states(Int)
+        case identity(childCount: Int)
+        case opacity(Float, childCount: Int)
+        case clip(pathIsEmpty: Bool, options: UInt32, childCount: Int)
+        case mask(maskCount: Int, options: UInt32, childCount: Int)
+        case transform(childCount: Int)
+        case properties(DisplayList.Properties, childCount: Int)
+        case colorMatrix(_ColorMatrix, premultiplied: Bool, childCount: Int)
+        case vibrantColorMatrix(_ColorMatrix, childCount: Int)
+        case filter(childCount: Int)
+        case blendMode(childCount: Int)
+        case other
+    }
+
+    var frame: CGRect
+    var version: Int
+    var identity: UInt32
+    var value: Value
+
+    init(frame: CGRect, version: Int, identity: UInt32, value: Value) {
+        self.frame = frame
+        self.version = version
+        self.identity = identity
+        self.value = value
+    }
+
+    init(_ item: DisplayList.Item) {
+        frame = item.frame
+        version = item.version.value
+        identity = item.identity.value
+        value = switch item.value {
+        case .empty:
+            .empty
+        case let .content(content):
+            switch content.value {
+            case .backdrop:
+                .content(.backdrop)
+            case .color:
+                .content(.color)
+            case let .shape(path, _, _):
+                .content(.shape(pathIsEmpty: path.isEmpty))
+            case .shadow:
+                .content(.shadow)
+            case .platformView:
+                .content(.platformView)
+            case .text:
+                .content(.text)
+            case let .flattened(list, _, _):
+                .content(.flattened(childCount: list.items.count))
+            default:
+                .content(.other)
+            }
+        case let .effect(effect, list):
+            switch effect {
+            case .identity:
+                .identity(childCount: list.items.count)
+            case let .opacity(opacity):
+                .opacity(opacity, childCount: list.items.count)
+            case let .clip(path, _, options):
+                .clip(
+                    pathIsEmpty: path.isEmpty,
+                    options: options.rawValue,
+                    childCount: list.items.count
+                )
+            case let .mask(mask, options):
+                .mask(
+                    maskCount: mask.items.count,
+                    options: options.rawValue,
+                    childCount: list.items.count
+                )
+            case .transform:
+                .transform(childCount: list.items.count)
+            case let .properties(properties):
+                .properties(properties, childCount: list.items.count)
+            case let .filter(.colorMatrix(matrix, premultiplied)):
+                .colorMatrix(
+                    matrix,
+                    premultiplied: premultiplied,
+                    childCount: list.items.count
+                )
+            case let .filter(.vibrantColorMatrix(matrix)):
+                .vibrantColorMatrix(matrix, childCount: list.items.count)
+            case .filter:
+                .filter(childCount: list.items.count)
+            case .blendMode:
+                .blendMode(childCount: list.items.count)
+            default:
+                .other
+            }
+        case let .states(states):
+            .states(states.count)
+        }
+    }
+}
+
+private let outerFrame = CGRect(x: 10, y: 20, width: 100, height: 200)
+private let sizeFrame = CGRect(origin: .zero, size: outerFrame.size)
+private let testPath = Path(CGRect(x: 1, y: 2, width: 3, height: 4))
+private let fullSizePath = Path(sizeFrame)
+private let translucentColor = Color.Resolved(
+    linearRed: 1,
+    linearGreen: 1,
+    linearBlue: 1,
+    opacity: 0.5
+)
+private let visibleResolvedShadow = ResolvedShadowStyle(
+    color: .black,
+    radius: 2,
+    offset: CGSize(width: 3, height: 4)
+)
+private let transparentResolvedShadow = ResolvedShadowStyle(
+    color: .clear,
+    radius: 2,
+    offset: CGSize(width: 3, height: 4)
+)
+
+@MainActor
+private var child: DisplayList {
+    DisplayList(contentItem(
+        .color(.white),
+        frame: CGRect(x: 1, y: 2, width: 3, height: 4),
+        identity: 8,
+        version: 5
+    ))
+}
+
+@MainActor
+private var childWithoutIdentity: DisplayList {
+    DisplayList(contentItem(
+        .color(.white),
+        frame: CGRect(x: 1, y: 2, width: 3, height: 4),
+        identity: 0,
+        version: 5
+    ))
+}
+
+@MainActor
+private var multipleChildren: DisplayList {
+    DisplayList([
+        contentItem(
+            .color(.white),
+            frame: CGRect(x: 1, y: 2, width: 3, height: 4),
+            identity: 8,
+            version: 5
+        ),
+        contentItem(
+            .color(.black),
+            frame: CGRect(x: 5, y: 6, width: 7, height: 8),
+            identity: 9,
+            version: 6
+        ),
+    ])
+}
+
+@MainActor
+private var requiredChild: DisplayList {
+    DisplayList(effectItem(.properties(.privacySensitive), frame: sizeFrame))
+}
+
+@MainActor
+private var colorPaintChild: DisplayList {
+    DisplayList(contentItem(.color(.white), frame: sizeFrame))
+}
+
+@MainActor
+private var shapePaintChild: DisplayList {
+    DisplayList(contentItem(
+        .shape(
+            fullSizePath,
+            OpenSwiftUICore._AnyResolvedPaint(Color.Resolved.white),
+            FillStyle()
+        ),
+        frame: sizeFrame
+    ))
+}
+
+@MainActor
+private func item(
+    _ value: DisplayList.Item.Value,
+    frame: CGRect = .zero,
+    identity: UInt32 = 7,
+    version: Int = 3
+) -> DisplayList.Item {
+    DisplayList.Item(
+        value,
+        frame: frame,
+        identity: .init(decodedValue: identity),
+        version: .init(decodedValue: version)
+    )
+}
+
+@MainActor
+private func contentItem(
+    _ value: DisplayList.Content.Value,
+    frame: CGRect = .zero,
+    identity: UInt32 = 7,
+    version: Int = 3
+) -> DisplayList.Item {
+    item(
+        .content(.init(value, seed: .init(decodedValue: 1))),
+        frame: frame,
+        identity: identity,
+        version: version
+    )
+}
+
+@MainActor
+private func effectItem(
+    _ effect: DisplayList.Effect,
+    child: DisplayList = DisplayList(),
+    frame: CGRect = .zero
+) -> DisplayList.Item {
+    item(
+        .effect(effect, child),
+        frame: frame
+    )
+}
+
+@MainActor
+private func resolvedStyledText(_ string: String?) -> ResolvedStyledText {
+    ResolvedStyledText(
+        storage: string.map { NSAttributedString(string: $0) },
+        layoutProperties: TextLayoutProperties(EnvironmentValues()),
+        layoutMargins: nil,
+        stylePadding: .zero,
+        archiveOptions: .init(),
+        isCollapsible: false,
+        features: [],
+        suffix: .none,
+        attachments: .init(),
+        styles: [],
+        transitions: [],
+        scaleFactorOverride: nil
+    )
+}
+
+#endif

--- a/Tests/OpenSwiftUISymbolDualTests/Render/DisplayList/DisplayListPrinterDualTests.swift
+++ b/Tests/OpenSwiftUISymbolDualTests/Render/DisplayList/DisplayListPrinterDualTests.swift
@@ -39,15 +39,7 @@ struct DisplayListPrinterDualTests {
         let displayList = fixture.makeDisplayList()
         #expect(displayList.description == expectedDescription.openSwiftUI)
         #expect(displayList.minimalDescription == expectedMinimalDescription.openSwiftUI)
-
-        guard #available(iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5, *) else {
-            // Stop if below SwiftUI 6.5.4 version
-            return
-        }
-        guard #unavailable(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0) else {
-            // Stop if appleOS 26.0 or above
-            return
-        }
+        guard isSwiftUIVersionAtLeast65AndBefore70 else { return }
         // Projected payloads can retain OpenSwiftUI type metadata in SwiftUI's description.
         #expect(displayList.swiftUI_description.normalizeSwiftUI == expectedDescription.swiftUI)
         #expect(displayList.swiftUI_minimalDescription == expectedMinimalDescription.swiftUI)
@@ -60,15 +52,7 @@ struct DisplayListPrinterDualTests {
     ) {
         let item = fixture.makeItem()
         #expect(item.description == expectedDescription.openSwiftUI)
-
-        guard #available(iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5, *) else {
-            // Stop if below SwiftUI 6.5.4 version
-            return
-        }
-        guard #unavailable(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0) else {
-            // Stop if appleOS 26.0 or above
-            return
-        }
+        guard isSwiftUIVersionAtLeast65AndBefore70 else { return }
         // Projected payloads can retain OpenSwiftUI type metadata in SwiftUI's description.
         #expect(item.swiftUI_description.normalizeSwiftUI == expectedDescription.swiftUI)
     }


### PR DESCRIPTION
## Summary

- normalize empty and identity display-list items while preserving required content
- collapse compatible paint, clip, mask, and color-filter paths
- add dual coverage across canonicalization branches and reuse the shared SwiftUI version gate

## Validation

- all 40 parameterized canonicalization fixtures pass
- the DisplayList printer dual-test suite passes