### PR TITLE
Fix rounded shape containment during clip discard

### DIFF
--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewModel.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewModel.swift
@@ -678,33 +678,43 @@ extension DisplayList.Item {
                 index &+= 1
                 continue
             }
-            var localClipRect = clipRect.applying(inverseTransform)
-            let sectionRect: CGRect
+            let clipRectInItemSpace = clipRect.applying(inverseTransform)
             switch content.value {
             case .backdrop, .color, .chameleonColor, .image, .text, .flattened, .drawing:
-                sectionRect = frame
-            case let .shape(path, _, _):
-                sectionRect = path.boundingRect.offsetBy(dx: frame.origin.x, dy: frame.origin.y)
-            case .shadow, .platformView, .platformLayer, .view, .placeholder:
-                return true
-            }
-            guard localClipRect.hasIntersection(sectionRect) else {
-                return false
-            }
-            let resolvedEffectOutset = effectOutset ?? state.clipDiscardEffectOutset
-            effectOutset = resolvedEffectOutset
-            if resolvedEffectOutset != 0 {
-                guard let insetClipRect = localClipRect.insetBy(dx: resolvedEffectOutset, dy: resolvedEffectOutset) else {
+                guard clipRectInItemSpace.hasIntersection(frame) else {
+                    return false
+                }
+                let resolvedEffectOutset = effectOutset ?? state.clipDiscardEffectOutset
+                effectOutset = resolvedEffectOutset
+                guard let insetClipRect = clipRectInItemSpace.insetBy(
+                    dx: resolvedEffectOutset,
+                    dy: resolvedEffectOutset
+                ), insetClipRect.contains(rect: frame) else {
                     index &+= 1
                     continue
                 }
-                localClipRect = insetClipRect
+            case let .shape(path, _, _):
+                let sectionRect = path.boundingRect.offset(by: CGSize(frame.origin))
+                guard clipRectInItemSpace.hasIntersection(sectionRect) else {
+                    return false
+                }
+                let resolvedEffectOutset = effectOutset ?? state.clipDiscardEffectOutset
+                effectOutset = resolvedEffectOutset
+                guard let insetClipRect = clipRectInItemSpace.insetBy(
+                    dx: resolvedEffectOutset,
+                    dy: resolvedEffectOutset
+                ), insetClipRect.contains(
+                    path: path,
+                    offsetBy: CGSize(frame.origin)
+                ) else {
+                    index &+= 1
+                    continue
+                }
+            case .shadow, .platformView, .platformLayer, .view, .placeholder:
+                return true
             }
-            guard localClipRect.contains(rect: sectionRect) else {
-                index &+= 1
-                continue
-            }
-            state.clips.remove(at: index)
+            state.clips.swapAt(index, state.clips.endIndex - 1)
+            state.clips.removeLast()
         }
         return true
     }

--- a/Sources/OpenSwiftUICore/Shape/RoundedCornerStyle.swift
+++ b/Sources/OpenSwiftUICore/Shape/RoundedCornerStyle.swift
@@ -126,8 +126,9 @@ package struct FixedRoundedRect: Equatable {
         guard !(cornerSize.width <= rhs.cornerSize.width && cornerSize.height <= rhs.cornerSize.height) else {
             return true
         }
-        let minCornerWidth = min(abs(rect.size.width) / 2, cornerSize.width)
-        let minCornerHeight = min(abs(rect.size.height) / 2, cornerSize.height)
+        let halfMinDimension = min(abs(rect.size.width) / 2, abs(rect.size.height) / 2)
+        let minCornerWidth = min(halfMinDimension, cornerSize.width)
+        let minCornerHeight = min(halfMinDimension, cornerSize.height)
         let factor = 1 - cos(45 * Double.pi / 180)
         return rect.insetBy(dx: minCornerWidth * factor, dy: minCornerHeight * factor).contains(rhs.rect)
     }

--- a/Tests/OpenSwiftUICoreTests/Shape/Path/FixedRoundedRectTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Shape/Path/FixedRoundedRectTests.swift
@@ -172,6 +172,20 @@ struct FixedRoundedRectTests {
     }
 
     @Test
+    func containsFixedRoundedRectUsesShortestDimension() {
+        let outer = FixedRoundedRect(
+            CGRect(x: 0, y: 0, width: 100, height: 20),
+            cornerSize: CGSize(width: 50, height: 10),
+            style: .circular
+        )
+        let inner = FixedRoundedRect(
+            CGRect(x: 4, y: 4, width: 92, height: 12)
+        )
+
+        #expect(outer.contains(inner))
+    }
+
+    @Test
     func containsRect() {
         let roundedRect = FixedRoundedRect(
             CGRect(x: 0, y: 0, width: 100, height: 100),


### PR DESCRIPTION
## Background

This issue was found while validating the not-yet-merged `JindoKitOpenSwiftUIContentView`.

In its minimal Dynamic Island presentation, the symbol was positioned correctly,
but the capsule background was rendered at the top-left corner. The example code
is not included in this pull request.

The rounded shape was being tested using its rectangular bounding box. Because
the bounding box corners extend outside an equivalent rounded clip, the clip was
incorrectly retained. This introduced an unnecessary inherited rendering
boundary and caused the shape to lose its accumulated position.

## Changes

- Preserve rounded shape geometry when checking whether a clip fully contains
  display-list content.
- Keep rectangular content on the existing rectangle-containment path.
- Clamp rounded-corner containment using the rectangle’s shortest dimension.
- Recheck swapped clip entries after removing a redundant clip.
- Add regression coverage for non-square rounded rectangles.