### PR TITLE
Refine Protobuf encoding and decoding

### DIFF
--- a/Sources/OpenSwiftUICore/Data/Protobuf/ProtobufDecoder.swift
+++ b/Sources/OpenSwiftUICore/Data/Protobuf/ProtobufDecoder.swift
@@ -2,7 +2,7 @@
 //  ProtobufDecoder.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 //  ID: FFA06CAF6B06DC3E21EC75547A0CD421 (SwiftUICore)
 
@@ -48,7 +48,7 @@ package struct ProtobufDecoder {
         self.data = nsData
         let ptr = nsData.bytes
         self.ptr = ptr
-        self.end = ptr + nsData.length
+        self.end = ptr + data.count
         self.packedEnd = ptr
     }
 }
@@ -60,7 +60,7 @@ extension ProtobufDecoder {
             packedField = Field(rawValue: 0)
             return nil
         }
-        if packedField.rawValue != 0 {
+        if !packedField._isEmpty {
             if ptr < packedEnd {
                 return packedField
             } else if packedEnd < ptr {
@@ -69,7 +69,7 @@ extension ProtobufDecoder {
                 packedField = Field(rawValue: 0)
             }
         }
-        let result = try decodeVariant()
+        let result = try decodeVarint()
         let field = Field(rawValue: result)
         guard field.tag > 0 else {
             throw DecodingError.failed
@@ -81,11 +81,11 @@ extension ProtobufDecoder {
     package mutating func skipField(_ field: ProtobufDecoder.Field) throws {
         switch field.wireType {
         case .varint:
-            _ = try decodeVariant()
+            _ = try decodeVarint()
         case .fixed64:
             let newPtr = ptr.advanced(by: 8)
             guard newPtr <= end else {
-                return
+                throw DecodingError.failed
             }
             ptr = newPtr
         case .lengthDelimited:
@@ -93,7 +93,7 @@ extension ProtobufDecoder {
         case .fixed32:
             let newPtr = ptr.advanced(by: 4)
             guard newPtr <= end else {
-                return
+                throw DecodingError.failed
             }
             ptr = newPtr
         default:
@@ -110,7 +110,7 @@ extension ProtobufDecoder {
         case .varint:
             break
         case .lengthDelimited:
-            let offset = try decodeVariant()
+            let offset = try decodeVarint()
             let offsetPtr = ptr.advanced(by: Int(offset))
             guard offsetPtr <= end else {
                 throw DecodingError.failed
@@ -120,7 +120,7 @@ extension ProtobufDecoder {
         default:
             throw DecodingError.failed
         }
-        return try decodeVariant() != 0
+        return try decodeVarint() != 0
     }
     
     /// Decodes an unsigned integer(UInt) value field from the data.
@@ -128,23 +128,9 @@ extension ProtobufDecoder {
     /// - Parameter field: The field to decode.
     /// - Returns: An unsigned integer(UInt) value.
     package mutating func uintField(_ field: ProtobufDecoder.Field) throws -> UInt {
-        switch field.wireType {
-        case .varint:
-            break
-        case .lengthDelimited:
-            let offset = try decodeVariant()
-            let offsetPtr = ptr.advanced(by: Int(offset))
-            guard offsetPtr <= end else {
-                throw DecodingError.failed
-            }
-            packedField = Field(field.tag, wireType: .varint)
-            packedEnd = offsetPtr
-        default:
-            throw DecodingError.failed
-        }
-        return try decodeVariant()
+        try UInt(uint64Field(field))
     }
-    
+
     /// Decodes an enum field from the data.
     ///
     /// - Parameter field: The field to decode.
@@ -176,13 +162,27 @@ extension ProtobufDecoder {
     package mutating func uint32Field(_ field: ProtobufDecoder.Field) throws -> UInt32 {
         try UInt32(uintField(field))
     }
-    
+
     /// Decodes an unsigned 64-bit integer(UInt64) value field from the data.
     ///
     /// - Parameter field: The field to decode.
     /// - Returns: An unsigned 64-bit integer(UInt64) value.
     package mutating func uint64Field(_ field: ProtobufDecoder.Field) throws -> UInt64 {
-        try UInt64(uintField(field))
+        switch field.wireType {
+        case .varint:
+            break
+        case .lengthDelimited:
+            let offset = try decodeVarint()
+            let offsetPtr = ptr.advanced(by: Int(offset))
+            guard offsetPtr <= end else {
+                throw DecodingError.failed
+            }
+            packedField = Field(field.tag, wireType: .varint)
+            packedEnd = offsetPtr
+        default:
+            throw DecodingError.failed
+        }
+        return try UInt64(decodeVarint())
     }
     
     /// Decodes a signed integer(Int) value field from the data.
@@ -190,7 +190,21 @@ extension ProtobufDecoder {
     /// - Parameter field: The field to decode.
     /// - Returns: A signed integer(Int) value.
     package mutating func intField(_ field: ProtobufDecoder.Field) throws -> Int {
-        let value = Int(bitPattern: try uintField(field))
+        switch field.wireType {
+        case .varint:
+            break
+        case .lengthDelimited:
+            let offset = try decodeVarint()
+            let offsetPtr = ptr.advanced(by: Int(offset))
+            guard offsetPtr <= end else {
+                throw DecodingError.failed
+            }
+            packedField = Field(field.tag, wireType: .varint)
+            packedEnd = offsetPtr
+        default:
+            throw DecodingError.failed
+        }
+        let value = Int(bitPattern: try decodeVarint())
         return Int(bitPattern: UInt(bitPattern: (value >> 1)) ^ UInt(bitPattern: -(value & 1)))
     }
     
@@ -201,7 +215,7 @@ extension ProtobufDecoder {
     package mutating func fixed32Field(_ field: ProtobufDecoder.Field) throws -> UInt32 {
         switch field.wireType {
         case .lengthDelimited:
-            let offset = try decodeVariant()
+            let offset = try decodeVarint()
             let offsetPtr = ptr.advanced(by: Int(offset))
             guard offsetPtr <= end else {
                 throw DecodingError.failed
@@ -229,7 +243,7 @@ extension ProtobufDecoder {
     package mutating func fixed64Field(_ field: ProtobufDecoder.Field) throws -> UInt64 {
         switch field.wireType {
         case .lengthDelimited:
-            let offset = try decodeVariant()
+            let offset = try decodeVarint()
             let offsetPtr = ptr.advanced(by: Int(offset))
             guard offsetPtr <= end else {
                 throw DecodingError.failed
@@ -257,7 +271,7 @@ extension ProtobufDecoder {
     package mutating func floatField(_ field: ProtobufDecoder.Field) throws -> Float {
         switch field.wireType {
         case .lengthDelimited:
-            let offset = try decodeVariant()
+            let offset = try decodeVarint()
             let offsetPtr = ptr.advanced(by: Int(offset))
             guard offsetPtr <= end else {
                 throw DecodingError.failed
@@ -287,7 +301,7 @@ extension ProtobufDecoder {
         case .fixed64:
             break
         case .lengthDelimited:
-            let offset = try decodeVariant()
+            let offset = try decodeVarint()
             let offsetPtr = ptr.advanced(by: Int(offset))
             guard offsetPtr <= end else {
                 throw DecodingError.failed
@@ -402,27 +416,28 @@ extension ProtobufDecoder {
 }
 
 extension ProtobufDecoder {
-    /// Decodes a variant from the data.
-    private mutating func decodeVariant() throws -> UInt {
+    /// Decodes a varint from the data.
+    private mutating func decodeVarint() throws -> UInt {
         var value: UInt = 0
         var shift: UInt = 0
-        var shouldContinue = false
-        repeat {
-            guard ptr < end else {
+        while true {
+            let nextPtr = ptr + 1
+            guard nextPtr <= end else {
                 throw DecodingError.failed
             }
             let byte = ptr.loadUnaligned(as: UInt8.self)
-            ptr += 1
+            ptr = nextPtr
             value |= UInt(byte & 0x7f) << shift
-            shift += 7
-            shouldContinue = (byte & 0x80 != 0)
-        } while shouldContinue
-        return value
+            if byte < 0x80 {
+                return value
+            }
+            shift &+= 7
+        }
     }
     
     /// Decodes a data buffer from the data.
     private mutating func decodeDataBuffer() throws -> UnsafeRawBufferPointer {
-        let count = try Int(decodeVariant())
+        let count = try Int(decodeVarint())
         let oldPtr = ptr
         let newPtr = ptr.advanced(by: count)
         guard newPtr <= end else {
@@ -435,7 +450,7 @@ extension ProtobufDecoder {
     /// Begins decoding a message.
     private mutating func beginMessage() throws {
         stack.append(end)
-        let count = try Int(decodeVariant())
+        let count = try Int(decodeVarint())
         let newPtr = ptr.advanced(by: count)
         guard newPtr <= end else {
             throw DecodingError.failed

--- a/Sources/OpenSwiftUICore/Data/Protobuf/ProtobufEncoder.swift
+++ b/Sources/OpenSwiftUICore/Data/Protobuf/ProtobufEncoder.swift
@@ -2,7 +2,7 @@
 //  ProtobufEncoder.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 //  ID: C7B3AAD101AF9EA76FC322BD6EF713E6 (SwiftUICore)
 
@@ -112,11 +112,24 @@ package struct ProtobufEncoder {
     /// Ends a length-delimited field.
     private mutating func endLengthDelimited() {
         let lengthPosition = stack.removeLast()
-        let length = size - (lengthPosition + 1)
-        let highBit = 64 - (length | 1).leadingZeroBitCount
-        let count = (highBit + 6) / 7
+        let length = size - (lengthPosition &+ 1)
+        if length <= 0x7F, size < capacity {
+            buffer.advanced(by: lengthPosition).storeBytes(
+                of: UInt8(truncatingIfNeeded: length),
+                as: UInt8.self
+            )
+            return
+        }
+
+        let count: Int
+        if length <= 0x7F {
+            count = 1
+        } else {
+            let highBit = 64 - length.leadingZeroBitCount
+            count = (highBit + 6) / 7
+        }
         let oldSize = size
-        let newSize = size - 1 + count
+        let newSize = size + (count - 1)
         var pointer: UnsafeMutableRawPointer
         if capacity < newSize {
             pointer = growBufferSlow(to: newSize)
@@ -125,9 +138,11 @@ package struct ProtobufEncoder {
             pointer = buffer.advanced(by: oldSize)
         }
         let firstLengthBytePointer = pointer.advanced(by: -(length + 1))
-        if count != 1 {
-            memmove(firstLengthBytePointer.advanced(by: count), firstLengthBytePointer.advanced(by: 1), length)
-        }
+        memmove(
+            firstLengthBytePointer.advanced(by: count),
+            firstLengthBytePointer.advanced(by: 1),
+            length
+        )
         var currentPointer = firstLengthBytePointer
         var currentValue = length
         while currentValue >= 0x80 {
@@ -714,8 +729,18 @@ extension ProtobufEncoder {
     /// - Parameters:
     ///   - value: The value to encode.
     package mutating func encodeVarint(_ value: UInt) {
-        let highBit = 64 - (value | 1).leadingZeroBitCount
-        let count = (highBit + 6) / 7
+        if value <= 0x7F, size < capacity {
+            buffer.advanced(by: size).storeBytes(of: UInt8(value), as: UInt8.self)
+            size &+= 1
+            return
+        }
+        let count: Int
+        if value <= 0x7F {
+            count = 1
+        } else {
+            let highBit = 64 - value.leadingZeroBitCount
+            count = (highBit + 6) / 7
+        }
         let oldSize = size
         let newSize = size + count
         var pointer: UnsafeMutableRawPointer
@@ -822,7 +847,7 @@ extension ProtobufEncoder {
     package mutating func encodeData(_ dataBuffer: UnsafeRawBufferPointer) {
         // Encode LEN
         let dataBufferCount = dataBuffer.count
-        encodeVarint(UInt(bitPattern: dataBufferCount))
+        encodeVarint(UInt(dataBufferCount))
         guard let baseAddress = dataBuffer.baseAddress,
               !dataBuffer.isEmpty else {
             return

--- a/Sources/OpenSwiftUICore/Data/Protobuf/ProtobufMessage.swift
+++ b/Sources/OpenSwiftUICore/Data/Protobuf/ProtobufMessage.swift
@@ -2,7 +2,7 @@
 //  ProtobufMessage.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
+//  Audited for 6.5.4
 //  Status: Complete
 
 import Foundation
@@ -131,6 +131,11 @@ package enum ProtobufFormat {
         /// The wire type of the field.
         package var wireType: WireType {
             WireType(rawValue: rawValue & 7)
+        }
+
+        /// Whether the field has no encoded value.
+        package var _isEmpty: Bool {
+            rawValue == 0
         }
         
         /// Converts the tag to a specific type.

--- a/Tests/OpenSwiftUICoreTests/Data/Protobuf/ProtobufDecoderTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Protobuf/ProtobufDecoderTests.swift
@@ -37,10 +37,15 @@ struct ProtobufDecoderTests {
         #expect(try "3506000000".decodePBHexString(IntegerMessage.self) == IntegerMessage(unsignedInt32Value: 6))
         #expect(try "08021002180620042d050000003506000000".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: 1, unsignedIntValue: 2, int64Value: 3, unsignedInt64Value: 4, int32Value: 5, unsignedInt32Value: 6))
         #expect(try "0890a204".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: 0x8888))
+        #expect(try "107f".decodePBHexString(IntegerMessage.self) == IntegerMessage(unsignedIntValue: 0x7F))
+        #expect(try "108001".decodePBHexString(IntegerMessage.self) == IntegerMessage(unsignedIntValue: 0x80))
+        #expect(try "20ffffffffffffffffff01".decodePBHexString(IntegerMessage.self) == IntegerMessage(unsignedInt64Value: .max))
     }
     
     @Test
     func skipInvalidTagDecode() throws {
+        #expect(try "3900000000000000000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
+        #expect(try "3d000000000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
         #expect(try "38000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
         #expect(try "40000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
         #expect(try "48000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
@@ -51,6 +56,16 @@ struct ProtobufDecoderTests {
         #expect(try "70000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
         #expect(try "78000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
         #expect(try "8001000801".decodePBHexString(IntegerMessage.self) == IntegerMessage(intValue: -1))
+    }
+
+    @Test
+    func skipTruncatedFixedFieldDecode() {
+        #expect(throws: Error.self) {
+            try "39".decodePBHexString(IntegerMessage.self)
+        }
+        #expect(throws: Error.self) {
+            try "3d".decodePBHexString(IntegerMessage.self)
+        }
     }
     
     @Test
@@ -69,6 +84,11 @@ struct ProtobufDecoderTests {
         #expect(try "".decodePBHexString(DataMessage.self) == DataMessage())
         #expect(try "0a04ffffffff".decodePBHexString(DataMessage.self) == DataMessage(data: .init(repeating: UInt8(0xFF), count: 4)))
         #expect(try "0a028888".decodePBHexString(DataMessage.self) == DataMessage(data: .init(repeating: UInt8(0x88), count: 2)))
+
+        let payload127 = String(repeating: "ff", count: 0x7F)
+        let payload128 = String(repeating: "ff", count: 0x80)
+        #expect(try "0a7f\(payload127)".decodePBHexString(DataMessage.self) == DataMessage(data: .init(repeating: 0xFF, count: 0x7F)))
+        #expect(try "0a8001\(payload128)".decodePBHexString(DataMessage.self) == DataMessage(data: .init(repeating: 0xFF, count: 0x80)))
     }
     
     @Test

--- a/Tests/OpenSwiftUICoreTests/Data/Protobuf/ProtobufEncoderTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Protobuf/ProtobufEncoderTests.swift
@@ -35,6 +35,9 @@ struct ProtobufEncoderTests {
         #expect((try IntegerMessage(unsignedInt32Value: 6).pbHexString) == "3506000000")
         #expect(try IntegerMessage(intValue: 1, unsignedIntValue: 2, int64Value: 3, unsignedInt64Value: 4, int32Value: 5, unsignedInt32Value: 6).pbHexString == "08021002180620042d050000003506000000")
         #expect((try IntegerMessage(intValue: 0x8888).pbHexString) == "0890a204")
+        #expect((try IntegerMessage(unsignedIntValue: 0x7F).pbHexString) == "107f")
+        #expect((try IntegerMessage(unsignedIntValue: 0x80).pbHexString) == "108001")
+        #expect((try IntegerMessage(unsignedInt64Value: .max).pbHexString) == "20ffffffffffffffffff01")
     }
     
     @Test
@@ -56,6 +59,11 @@ struct ProtobufEncoderTests {
     func dataEncode() throws {
         #expect((try DataMessage(data: .init(repeating: UInt8(0xFF), count: 4)).pbHexString) == "0a04ffffffff")
         #expect((try DataMessage(data: .init(repeating: UInt8(0x88), count: 2)).pbHexString) == "0a028888")
+
+        let payload127 = String(repeating: "ff", count: 0x7F)
+        let payload128 = String(repeating: "ff", count: 0x80)
+        #expect((try DataMessage(data: .init(repeating: 0xFF, count: 0x7F)).pbHexString) == "0a7f\(payload127)")
+        #expect((try DataMessage(data: .init(repeating: 0xFF, count: 0x80)).pbHexString) == "0a8001\(payload128)")
     }
     
     @Test


### PR DESCRIPTION
## Summary

- add fast paths for single-byte varints and short length-delimited fields
- make `UInt64` the canonical unsigned decode path and keep signed decoding on the full-width varint path
- reject truncated fixed-width fields instead of silently accepting them
- expand boundary and malformed-input coverage