### PR TITLE
Align SwiftUI SPI compatibility interfaces

### DIFF
--- a/Example/Modules/Platform/cocoa/SwiftUI_SPI.private.swiftinterface
+++ b/Example/Modules/Platform/cocoa/SwiftUI_SPI.private.swiftinterface
@@ -1,0 +1,220 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -module-name SwiftUI_SPI -module-abi-name SwiftUI
+// SPI-inclusive interface for the SwiftUI compatibility overlay.
+import CoreFoundation
+import CoreGraphics
+import QuartzCore
+import Swift
+@_exported import SwiftUI
+
+@_spi(Jindo)
+@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+@available(macOS, unavailable)
+public struct JindoTripleVStack : SwiftUI.Layout {
+  public struct Configuration {
+    public var notchSize: CoreFoundation.CGSize
+    @available(*, deprecated, message: "Use horizontalSizing")
+    public var mode: SwiftUI_SPI.JindoTripleVStack.HorizontalMode {
+      get
+      set
+    }
+    @available(*, deprecated, message: "Use layoutMargins")
+    public var defaultInsets: SwiftUI.EdgeInsets {
+      get
+      set
+    }
+    public var centerAlignment: SwiftUI.TextAlignment
+    public var bottomAlignment: SwiftUI.TextAlignment
+    public var uniformSpacing: CoreFoundation.CGFloat?
+    @available(*, deprecated, renamed: "init(notchSize:mode:layoutMargins:)")
+    public init(notchSize: CoreFoundation.CGSize, mode: SwiftUI_SPI.JindoTripleVStack.HorizontalMode, defaultInsets: SwiftUI.EdgeInsets)
+    public init(notchSize: CoreFoundation.CGSize, horizontalSizing: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing, layoutMargins: SwiftUI.EdgeInsets)
+  }
+  public init(configuration: SwiftUI_SPI.JindoTripleVStack.Configuration)
+  public struct Position : Swift.Equatable {
+    public static func == (a: SwiftUI_SPI.JindoTripleVStack.Position, b: SwiftUI_SPI.JindoTripleVStack.Position) -> Swift.Bool
+  }
+  public struct VerticalPlacement : Swift.Equatable {
+    public static let `default`: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement
+    public static let belowNotchIfTooWide: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement
+    public static func == (a: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement, b: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement) -> Swift.Bool
+  }
+  @available(*, deprecated, message: "Use HorizontalSizing")
+  public enum HorizontalMode {
+    case split
+    case leading
+    case trailing
+    public static func == (a: SwiftUI_SPI.JindoTripleVStack.HorizontalMode, b: SwiftUI_SPI.JindoTripleVStack.HorizontalMode) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public struct HorizontalSizing : Swift.Equatable {
+    public static let automatic: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
+    public static let leading: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
+    public static let trailing: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
+    public static let split: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
+    public static func == (a: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing, b: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing) -> Swift.Bool
+  }
+  public func sizeThatFits(proposal: SwiftUI.ProposedViewSize, subviews: SwiftUI_SPI.JindoTripleVStack.Subviews, cache: inout ()) -> CoreFoundation.CGSize
+  public func placeSubviews(in bounds: CoreFoundation.CGRect, proposal: SwiftUI.ProposedViewSize, subviews: SwiftUI_SPI.JindoTripleVStack.Subviews, cache: inout ())
+  public typealias AnimatableData = SwiftUI.EmptyAnimatableData
+  public typealias Cache = ()
+}
+
+@_spi(Jindo)
+@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+@available(macOS, unavailable)
+@available(*, deprecated, message: "Use HorizontalSizing")
+extension SwiftUI_SPI.JindoTripleVStack.HorizontalMode : Swift.Equatable {
+}
+
+@_spi(Jindo)
+@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+@available(macOS, unavailable)
+@available(*, deprecated, message: "Use HorizontalSizing")
+extension SwiftUI_SPI.JindoTripleVStack.HorizontalMode : Swift.Hashable {
+}
+
+@_spi(Jindo)
+@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+@available(macOS, unavailable)
+extension SwiftUI_SPI.JindoTripleVStack.Position {
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static let leading: SwiftUI_SPI.JindoTripleVStack.Position
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static func leading(inset: CoreFoundation.CGFloat? = nil) -> SwiftUI_SPI.JindoTripleVStack.Position
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static let trailing: SwiftUI_SPI.JindoTripleVStack.Position
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static func trailing(inset: CoreFoundation.CGFloat? = nil) -> SwiftUI_SPI.JindoTripleVStack.Position
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static let center: SwiftUI_SPI.JindoTripleVStack.Position
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static let bottom: SwiftUI_SPI.JindoTripleVStack.Position
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static func bottom(leadingInset: CoreFoundation.CGFloat? = nil, trailingInset: CoreFoundation.CGFloat? = nil) -> SwiftUI_SPI.JindoTripleVStack.Position
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public static let notch: SwiftUI_SPI.JindoTripleVStack.Position
+}
+
+@_spi(Jindo)
+@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+@available(macOS, unavailable)
+extension SwiftUI_SPI.JindoTripleVStack {
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  public struct ContentMargins {
+    public init(top: CoreFoundation.CGFloat? = nil, leading: CoreFoundation.CGFloat? = nil, bottom: CoreFoundation.CGFloat? = nil, trailing: CoreFoundation.CGFloat? = nil)
+  }
+}
+
+extension SwiftUI.View {
+  @_spi(Jindo)
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  nonisolated public func jindoPosition(_ position: SwiftUI_SPI.JindoTripleVStack.Position) -> some SwiftUI.View
+
+  @_spi(Jindo)
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  nonisolated public func jindoVerticalPlacement(_ verticalPlacement: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement) -> some SwiftUI.View
+
+  @_spi(Jindo)
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  nonisolated public func jindoPriority(_ priority: Swift.Double?) -> some SwiftUI.View
+
+  @_spi(Jindo)
+  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
+  @available(macOS, unavailable)
+  nonisolated public func jindoContentMargins(_ contentMargins: SwiftUI_SPI.JindoTripleVStack.ContentMargins?) -> some SwiftUI.View
+}
+
+@available(iOS 18.2, macOS 15.2, *)
+@frozen public /* package */ struct TransactionalPreferenceActionModifier<Key> : SwiftUI.ViewModifier where Key : SwiftUI.PreferenceKey, Key.Value : Swift.Equatable {
+  public var action: (Key.Value, SwiftUI.Transaction) -> Swift.Void
+  @_alwaysEmitIntoClient public /* package */ init(action: @escaping (Key.Value, SwiftUI.Transaction) -> Swift.Void) {
+    self.action = action
+  }
+  nonisolated public /* package */ static func _makeView(modifier: SwiftUI._GraphValue<SwiftUI_SPI.TransactionalPreferenceActionModifier<Key>>, inputs: SwiftUI._ViewInputs, body: @escaping (SwiftUI._Graph, SwiftUI._ViewInputs) -> SwiftUI._ViewOutputs) -> SwiftUI._ViewOutputs
+  public typealias Body = Swift.Never
+}
+
+@_spi(Private)
+@available(iOS 18.2, macOS 15.2, *)
+extension SwiftUI.View {
+  @_alwaysEmitIntoClient nonisolated public func onPreferenceChange<Key>(_ key: Key.Type = Key.self, action: @escaping @Sendable (Key.Value, SwiftUI.Transaction) -> Swift.Void) -> some SwiftUI.View where Key : SwiftUI.PreferenceKey, Key.Value : Swift.Equatable {
+    return modifier(SwiftUI_SPI.TransactionalPreferenceActionModifier<Key>(action: action))
+  }
+}
+
+@_spi(ForUIKitOnly)
+@_spi(ForAppKitOnly)
+@_hasMissingDesignatedInitializers
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public class CAHostingLayer<Content> : QuartzCore.CALayer where Content : SwiftUI.View {
+  public init(rootView: Content, environment: SwiftUI.EnvironmentValues = .init())
+  @objc override dynamic public func layoutSublayers()
+  public var rootView: Content {
+    get
+    set
+  }
+}
+
+public /* package */ struct DisplayList : Swift.CustomStringConvertible {
+  public /* package */ struct Version {}
+  public var description: Swift.String {
+    get
+  }
+}
+
+public /* package */ final class ViewGraph {
+  public /* package */ struct Outputs : Swift.OptionSet {
+    public /* package */ let rawValue: Swift.UInt8
+    public /* package */ init(rawValue: Swift.UInt8)
+    public /* package */ static var displayList: SwiftUI_SPI.ViewGraph.Outputs {
+      get
+    }
+  }
+  public /* package */ init<Root>(rootViewType: Root.Type, requestedOutputs: SwiftUI_SPI.ViewGraph.Outputs) where Root : SwiftUI.View
+  public /* package */ func instantiateOutputs()
+  public /* package */ func setRootView<Root>(_ view: Root) where Root : SwiftUI.View
+  public /* package */ func setProposedSize(_ size: CoreGraphics.CGSize)
+  public /* package */ func displayList() -> (SwiftUI_SPI.DisplayList, SwiftUI_SPI.DisplayList.Version)
+}
+
+@_spi(Private)
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *)
+extension SwiftUI.View {
+  public func variableBlur(maxRadius: CoreGraphics.CGFloat, mask: SwiftUI.Image, opaque: Swift.Bool = false) -> some SwiftUI.View
+}
+
+@_spi(Private)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension SwiftUI.MatchedGeometryProperties {
+  @_alwaysEmitIntoClient public static var clipRect: SwiftUI.MatchedGeometryProperties {
+    return SwiftUI.MatchedGeometryProperties(rawValue: 1 << 2)
+  }
+}
+
+@_spi(Private)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+extension SwiftUI.View {
+  nonisolated public func matchedGeometryEffect<ID, S>(id: ID, in namespace: SwiftUI.Namespace.ID, clipShape: S, properties: SwiftUI.MatchedGeometryProperties = .frame, anchor: SwiftUI.UnitPoint = .center, isSource: Swift.Bool = true) -> some SwiftUI.View where ID : Swift.Hashable, S : SwiftUI.Shape
+}
+
+@_spi(Private)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
+extension SwiftUI.View {
+  public func avoidsOrphans(_ flag: Swift.Bool) -> some SwiftUI.View
+}

--- a/Example/Modules/Platform/cocoa/SwiftUI_SPI.swiftinterface
+++ b/Example/Modules/Platform/cocoa/SwiftUI_SPI.swiftinterface
@@ -1,193 +1,37 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -module-name SwiftUI_SPI -module-abi-name SwiftUI
-import CoreFoundation
 import CoreGraphics
-import QuartzCore
 import Swift
 @_exported import SwiftUI
 
-@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-@available(macOS, unavailable)
-public struct JindoTripleVStack : SwiftUI.Layout {
-  public struct Configuration {
-    public var notchSize: CoreFoundation.CGSize
-    @available(*, deprecated, message: "Use horizontalSizing")
-    public var mode: SwiftUI_SPI.JindoTripleVStack.HorizontalMode {
-      get
-      set
-    }
-    @available(*, deprecated, message: "Use layoutMargins")
-    public var defaultInsets: SwiftUI.EdgeInsets {
-      get
-      set
-    }
-    public var centerAlignment: SwiftUI.TextAlignment
-    public var bottomAlignment: SwiftUI.TextAlignment
-    public var uniformSpacing: CoreFoundation.CGFloat?
-    @available(*, deprecated, renamed: "init(notchSize:mode:layoutMargins:)")
-    public init(notchSize: CoreFoundation.CGSize, mode: SwiftUI_SPI.JindoTripleVStack.HorizontalMode, defaultInsets: SwiftUI.EdgeInsets)
-    public init(notchSize: CoreFoundation.CGSize, horizontalSizing: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing, layoutMargins: SwiftUI.EdgeInsets)
-  }
-  public init(configuration: SwiftUI_SPI.JindoTripleVStack.Configuration)
-  public struct Position : Swift.Equatable {
-    public static func == (a: SwiftUI_SPI.JindoTripleVStack.Position, b: SwiftUI_SPI.JindoTripleVStack.Position) -> Swift.Bool
-  }
-  public struct VerticalPlacement : Swift.Equatable {
-    public static let `default`: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement
-    public static let belowNotchIfTooWide: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement
-    public static func == (a: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement, b: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement) -> Swift.Bool
-  }
-  @available(*, deprecated, message: "Use HorizontalSizing")
-  public enum HorizontalMode {
-    case split
-    case leading
-    case trailing
-    public static func == (a: SwiftUI_SPI.JindoTripleVStack.HorizontalMode, b: SwiftUI_SPI.JindoTripleVStack.HorizontalMode) -> Swift.Bool
-    public func hash(into hasher: inout Swift.Hasher)
-    public var hashValue: Swift.Int {
-      get
-    }
-  }
-  public struct HorizontalSizing : Swift.Equatable {
-    public static let automatic: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
-    public static let leading: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
-    public static let trailing: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
-    public static let split: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing
-    public static func == (a: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing, b: SwiftUI_SPI.JindoTripleVStack.HorizontalSizing) -> Swift.Bool
-  }
-  public func sizeThatFits(proposal: SwiftUI.ProposedViewSize, subviews: SwiftUI_SPI.JindoTripleVStack.Subviews, cache: inout ()) -> CoreFoundation.CGSize
-  public func placeSubviews(in bounds: CoreFoundation.CGRect, proposal: SwiftUI.ProposedViewSize, subviews: SwiftUI_SPI.JindoTripleVStack.Subviews, cache: inout ())
-  public typealias AnimatableData = SwiftUI.EmptyAnimatableData
-  public typealias Cache = ()
-}
-
-@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-@available(macOS, unavailable)
-@available(*, deprecated, message: "Use HorizontalSizing")
-extension SwiftUI_SPI.JindoTripleVStack.HorizontalMode : Swift.Equatable {
-}
-
-@available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-@available(macOS, unavailable)
-@available(*, deprecated, message: "Use HorizontalSizing")
-extension SwiftUI_SPI.JindoTripleVStack.HorizontalMode : Swift.Hashable {
-}
-
-@available(watchOS 11.0, tvOS 18.0, *)
-extension SwiftUI_SPI.JindoTripleVStack.Position {
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static let leading: SwiftUI_SPI.JindoTripleVStack.Position
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static func leading(inset: CoreFoundation.CGFloat? = nil) -> SwiftUI_SPI.JindoTripleVStack.Position
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static let trailing: SwiftUI_SPI.JindoTripleVStack.Position
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static func trailing(inset: CoreFoundation.CGFloat? = nil) -> SwiftUI_SPI.JindoTripleVStack.Position
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static let center: SwiftUI_SPI.JindoTripleVStack.Position
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static let bottom: SwiftUI_SPI.JindoTripleVStack.Position
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static func bottom(leadingInset: CoreFoundation.CGFloat? = nil, trailingInset: CoreFoundation.CGFloat? = nil) -> SwiftUI_SPI.JindoTripleVStack.Position
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public static let notch: SwiftUI_SPI.JindoTripleVStack.Position
-}
-
-@available(watchOS 11.0, tvOS 18.0, *)
-extension SwiftUI_SPI.JindoTripleVStack {
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  public struct ContentMargins {
-    public init(top: CoreFoundation.CGFloat? = nil, leading: CoreFoundation.CGFloat? = nil, bottom: CoreFoundation.CGFloat? = nil, trailing: CoreFoundation.CGFloat? = nil)
-  }
-}
-
-extension SwiftUI.View {
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  nonisolated public func jindoPosition(_ position: SwiftUI_SPI.JindoTripleVStack.Position) -> some SwiftUI.View
-
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  nonisolated public func jindoVerticalPlacement(_ verticalPlacement: SwiftUI_SPI.JindoTripleVStack.VerticalPlacement) -> some SwiftUI.View
-
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  nonisolated public func jindoPriority(_ priority: Swift.Double?) -> some SwiftUI.View
-
-  @available(iOS 16.1, tvOS 18.0, watchOS 11.0, *)
-  @available(macOS, unavailable)
-  nonisolated public func jindoContentMargins(_ contentMargins: SwiftUI_SPI.JindoTripleVStack.ContentMargins?) -> some SwiftUI.View
-}
-
 @available(iOS 18.2, macOS 15.2, *)
-@frozen public struct TransactionalPreferenceActionModifier<Key> : SwiftUI.ViewModifier where Key : SwiftUI.PreferenceKey, Key.Value : Swift.Equatable {
+@frozen public /* package */ struct TransactionalPreferenceActionModifier<Key> : SwiftUI.ViewModifier where Key : SwiftUI.PreferenceKey, Key.Value : Swift.Equatable {
   public var action: (Key.Value, SwiftUI.Transaction) -> Swift.Void
-  @_alwaysEmitIntoClient public init(action: @escaping (Key.Value, SwiftUI.Transaction) -> Swift.Void) {
+  @_alwaysEmitIntoClient public /* package */ init(action: @escaping (Key.Value, SwiftUI.Transaction) -> Swift.Void) {
     self.action = action
   }
-  nonisolated public static func _makeView(modifier: SwiftUI._GraphValue<SwiftUI_SPI.TransactionalPreferenceActionModifier<Key>>, inputs: SwiftUI._ViewInputs, body: @escaping (SwiftUI._Graph, SwiftUI._ViewInputs) -> SwiftUI._ViewOutputs) -> SwiftUI._ViewOutputs
+  nonisolated public /* package */ static func _makeView(modifier: SwiftUI._GraphValue<SwiftUI_SPI.TransactionalPreferenceActionModifier<Key>>, inputs: SwiftUI._ViewInputs, body: @escaping (SwiftUI._Graph, SwiftUI._ViewInputs) -> SwiftUI._ViewOutputs) -> SwiftUI._ViewOutputs
   public typealias Body = Swift.Never
 }
 
-@available(iOS 18.2, macOS 15.2, *)
-extension SwiftUI.View {
-  @_alwaysEmitIntoClient nonisolated public func onPreferenceChange<Key>(_ key: Key.Type = Key.self, action: @escaping @Sendable (Key.Value, SwiftUI.Transaction) -> Swift.Void) -> some SwiftUI.View where Key : SwiftUI.PreferenceKey, Key.Value : Swift.Equatable {
-    return modifier(SwiftUI_SPI.TransactionalPreferenceActionModifier<Key>(action: action))
-  }
-}
-
-@_hasMissingDesignatedInitializers @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-public class CAHostingLayer<Content> : QuartzCore.CALayer where Content : SwiftUI.View {
-  public init(rootView: Content, environment: SwiftUI.EnvironmentValues = .init())
-  @objc override dynamic public func layoutSublayers()
-  public var rootView: Content {
-    get
-    set
-  }
-}
-
-public struct DisplayList : Swift.CustomStringConvertible {
-  public struct Version {}
+public /* package */ struct DisplayList : Swift.CustomStringConvertible {
+  public /* package */ struct Version {}
   public var description: Swift.String {
     get
   }
 }
 
-public final class ViewGraph {
-  public struct Outputs : Swift.OptionSet {
-    public let rawValue: Swift.UInt8
-    public init(rawValue: Swift.UInt8)
-    public static var displayList: ViewGraph.Outputs {
+public /* package */ final class ViewGraph {
+  public /* package */ struct Outputs : Swift.OptionSet {
+    public /* package */ let rawValue: Swift.UInt8
+    public /* package */ init(rawValue: Swift.UInt8)
+    public /* package */ static var displayList: SwiftUI_SPI.ViewGraph.Outputs {
       get
     }
   }
-  public init<Root>(rootViewType: Root.Type, requestedOutputs: ViewGraph.Outputs) where Root : SwiftUI.View
-  public func instantiateOutputs()
-  public func setRootView<Root>(_ view: Root) where Root : SwiftUI.View
-  public func setProposedSize(_ size: CoreGraphics.CGSize)
-  public func displayList() -> (DisplayList, DisplayList.Version)
-}
-
-@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *)
-extension SwiftUI.View {
-  public func variableBlur(maxRadius: CoreGraphics.CGFloat, mask: SwiftUI.Image, opaque: Swift.Bool = false) -> some SwiftUI.View
-}
-
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
-extension SwiftUI.View {
-  nonisolated public func matchedGeometryEffect<ID, S>(id: ID, in namespace: SwiftUI.Namespace.ID, clipShape: S, properties: SwiftUI.MatchedGeometryProperties = .frame, anchor: SwiftUI.UnitPoint = .center, isSource: Swift.Bool = true) -> some SwiftUI.View where ID : Swift.Hashable, S : SwiftUI.Shape
-}
-
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
-extension SwiftUI.View {
-  public func avoidsOrphans(_ flag: Swift.Bool) -> some SwiftUI.View
+  public /* package */ init<Root>(rootViewType: Root.Type, requestedOutputs: SwiftUI_SPI.ViewGraph.Outputs) where Root : SwiftUI.View
+  public /* package */ func instantiateOutputs()
+  public /* package */ func setRootView<Root>(_ view: Root) where Root : SwiftUI.View
+  public /* package */ func setProposedSize(_ size: CoreGraphics.CGSize)
+  public /* package */ func displayList() -> (SwiftUI_SPI.DisplayList, SwiftUI_SPI.DisplayList.Version)
 }

--- a/Example/Shared/Integration/Hosting/CAHostingLayerExample.swift
+++ b/Example/Shared/Integration/Hosting/CAHostingLayerExample.swift
@@ -9,7 +9,11 @@
 @_spi(ForAppKitOnly) import OpenSwiftUI
 #endif
 #else
-import SwiftUI_SPI
+#if canImport(UIKit)
+@_spi(ForUIKitOnly) import SwiftUI_SPI
+#else
+@_spi(ForAppKitOnly) import SwiftUI_SPI
+#endif
 #endif
 
 import QuartzCore

--- a/Example/Shared/Layout/Stack/JindoKit/DynamicIsland.swift
+++ b/Example/Shared/Layout/Stack/JindoKit/DynamicIsland.swift
@@ -2,10 +2,12 @@
 //  DynamicIsland.swift
 //  JindoKit
 
+#if !os(macOS)
+
 #if OPENSWIFTUI
 @_spi(Jindo) import OpenSwiftUI
 #else
-import SwiftUI_SPI
+@_spi(Jindo) import SwiftUI_SPI
 #endif
 
 /// A view that previews the layout and configuration of a Live Activity in the
@@ -304,3 +306,5 @@ private struct JindoExpandedLayout<Content>: View where Content: View {
         .padding(configuration.layoutMargins)
     }
 }
+
+#endif

--- a/Example/Shared/Layout/Stack/JindoKit/DynamicIslandExpandedContent.swift
+++ b/Example/Shared/Layout/Stack/JindoKit/DynamicIslandExpandedContent.swift
@@ -2,10 +2,12 @@
 //  DynamicIslandExpandedContent.swift
 //  JindoKit
 
+#if !os(macOS)
+
 #if OPENSWIFTUI
 @_spi(Jindo) import OpenSwiftUI
 #else
-import SwiftUI_SPI
+@_spi(Jindo) import SwiftUI_SPI
 #endif
 
 /// A view that describes the expanded presentation of a Live Activity in the
@@ -302,3 +304,5 @@ private struct JindoRegionContentMargins: Sendable {
         )
     }
 }
+
+#endif

--- a/Example/Shared/Layout/Stack/JindoKit/DynamicIslandMode.swift
+++ b/Example/Shared/Layout/Stack/JindoKit/DynamicIslandMode.swift
@@ -2,6 +2,8 @@
 //  DynamicIslandMode.swift
 //  JindoKit
 
+#if !os(macOS)
+
 #if OPENSWIFTUI
 import OpenSwiftUI
 #else
@@ -166,3 +168,5 @@ struct DynamicIslandContentMargins: Equatable {
         explicitEdges.formUnion(edges)
     }
 }
+
+#endif

--- a/Example/Shared/Layout/Stack/JindoKit/JindoKitExample.swift
+++ b/Example/Shared/Layout/Stack/JindoKit/JindoKitExample.swift
@@ -2,6 +2,8 @@
 //  JindoKitExample.swift
 //  Shared
 
+#if !os(macOS)
+
 #if OPENSWIFTUI
 import OpenSwiftUI
 #else
@@ -80,3 +82,5 @@ struct JindoKitExample: View {
         .previewMode(mode)
     }
 }
+
+#endif

--- a/Example/Shared/Render/GeometryEffect/MatchedGeometryEffectExample.swift
+++ b/Example/Shared/Render/GeometryEffect/MatchedGeometryEffectExample.swift
@@ -5,13 +5,7 @@
 #if OPENSWIFTUI
 @_spi(Private) import OpenSwiftUI
 #else
-import SwiftUI_SPI
-extension MatchedGeometryProperties {
-    // NOTE: SwiftUI_SPI somehow not work here
-    fileprivate static var clipRect: MatchedGeometryProperties {
-        .init(rawValue: 1 << 2)
-    }
-}
+@_spi(Private) import SwiftUI_SPI
 #endif
 
 struct MatchedGeometryEffectExample: View {

--- a/Example/Shared/Render/RendererEffect/VariableBlurEffectExample.swift
+++ b/Example/Shared/Render/RendererEffect/VariableBlurEffectExample.swift
@@ -5,7 +5,7 @@
 #if OPENSWIFTUI
 @_spi(Private) import OpenSwiftUI
 #else
-import SwiftUI_SPI
+@_spi(Private) import SwiftUI_SPI
 #endif
 
 struct VariableBlurEffectExample: View {

--- a/Example/Shared/View/Text/TextOrphanAndPushOutExample.swift
+++ b/Example/Shared/View/Text/TextOrphanAndPushOutExample.swift
@@ -5,7 +5,7 @@
 #if OPENSWIFTUI
 @_spi(Private) import OpenSwiftUI
 #else
-import SwiftUI_SPI
+@_spi(Private) import SwiftUI_SPI
 #endif
 
 struct TextOrphanAndPushOutExample: View {

--- a/Example/Shared/ViewModifier/TransactionalPreferenceActionModifierExample.swift
+++ b/Example/Shared/ViewModifier/TransactionalPreferenceActionModifierExample.swift
@@ -5,7 +5,7 @@
 #if OPENSWIFTUI
 @_spi(Private) import OpenSwiftUI
 #else
-import SwiftUI_SPI
+@_spi(Private) import SwiftUI_SPI
 #endif
 
 #if OPENSWIFTUI


### PR DESCRIPTION
## Summary

- Split the SwiftUI SPI compatibility declarations into public and private Swift interfaces.
- Align package-facing declarations and SPI annotations with the OpenSwiftUI API surface.
- Update SUI example imports to use the appropriate SPI access.
- Avoid unavailable Jindo linkage on macOS and provide a client-emitted `clipRect` compatibility implementation.

## Motivation

The SUI examples need a stable SwiftUI compatibility module that supports both package and SPI imports without relying on project-generation scripts. The previous combined interface also allowed unavailable Jindo code and an unresolved `clipRect` declaration to reach the macOS linker.

## Validation

- The SUI example builds successfully with the SwiftUIDebug configuration on macOS.
- The DisplayListUtil compatibility test passes.
- Interface import probes pass for the public, Private, Jindo, ForUIKitOnly, and ForAppKitOnly surfaces.