### PR TITLE
Add terminal view mode to stdout renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ for various platforms:
 
 ### Current supported feature
 
-- Color/Image/Path rendering (Text is not supported yet)
+- Color/Image/Path rendering
+- Basic `Text` output in the macOS stdout renderer; non-Darwin text layout is
+  not supported yet
 - Layout system
 - Animation system
 - onAppear/onDisappear modifier

--- a/Renderer/README.md
+++ b/Renderer/README.md
@@ -6,8 +6,8 @@ kept outside the main OpenSwiftUI package manifest.
 ## Stdout
 
 `Stdout/` contains a small executable package that launches an OpenSwiftUI app
-with the stdout renderer enabled. It is useful for checking display-list output
-without adding demo targets to the main package.
+with the stdout renderer enabled. It can write display-list commands or render a
+single-frame ANSI terminal view without adding demo targets to the main package.
 
 Run it from this repository:
 

--- a/Renderer/Stdout/ExampleApp/ExampleApp.swift
+++ b/Renderer/Stdout/ExampleApp/ExampleApp.swift
@@ -2,11 +2,18 @@
 
 @main
 struct ExampleApp: App {
-    static var rendererConfiguration: _RendererConfiguration? { .stdout() }
+    static var rendererConfiguration: _RendererConfiguration? {
+        var options = _RendererConfiguration.StdoutOptions()
+        options.viewMode = .terminal
+        options.terminalSize = .init(columns: 48, rows: 16)
+        return .stdout(options)
+    }
 
     var body: some Scene {
         WindowGroup {
             VStack(spacing: 10.0) {
+                Text("OpenSwiftUI stdout renderer")
+                    .foregroundStyle(.green)
                 Color.red
                 Color.blue
             }

--- a/Renderer/Stdout/README.md
+++ b/Renderer/Stdout/README.md
@@ -30,10 +30,64 @@ Swift package directly. Its package settings mirror the generated Example
 project's local OpenSwiftUI product destinations, keeping AttributeGraph
 enabled on macOS while preserving valid generated target platforms.
 
-The example configures the app renderer with:
+The example configures the app renderer with terminal view mode:
 
 ```swift
 @_spi(StdoutRenderer) import OpenSwiftUI
 
-static var rendererConfiguration: _RendererConfiguration? { .stdout() }
+static var rendererConfiguration: _RendererConfiguration? {
+    var options = _RendererConfiguration.StdoutOptions()
+    options.viewMode = .terminal
+    return .stdout(options)
+}
 ```
+
+## View modes
+
+The default `displayList` mode writes one line for each supported display-list
+command. It includes resolved frames and colors, and now includes resolved text
+runs on macOS.
+
+Terminal mode maps the logical surface into terminal cells. Solid colors become
+cell backgrounds and text becomes cell content. Set `terminalSize` for
+deterministic output, or leave it as `nil` to use `TIOCGWINSZ`, followed by the
+`COLUMNS` and `LINES` environment variables, and finally an 80 by 24 fallback.
+
+```swift
+var options = _RendererConfiguration.StdoutOptions()
+options.viewMode = .terminal
+options.terminalSize = .init(columns: 80, rows: 24)
+```
+
+`colorMode` defaults to `automatic`. Automatic detection emits no ANSI color
+when standard output is not a terminal, when `TERM=dumb`, or when a nonempty
+`NO_COLOR` value is present. It recognizes `COLORTERM=truecolor` / `24bit`,
+direct-color terminal names, and `TERM` values containing `256color`; other
+named terminals use the ANSI 16-color palette. An explicit `colorMode` overrides
+automatic detection.
+
+Available explicit modes are `monochrome`, `ansi16`, `ansi256`, and
+`trueColor`. Monochrome output uses block characters for solid color regions so
+the view remains visible when output is redirected.
+
+## Text support
+
+On macOS, resolved `Text` display-list content is emitted as text commands and
+rendered into terminal cells. Foreground colors are preserved for individual
+attributed-string runs. Text command extraction is currently compiled only on
+macOS.
+
+On Linux, string and color resolution already use the non-Darwin shims, but
+`NSAttributedString` measurement in
+`Sources/OpenSwiftUICore/View/Text/Text/Text+StringDrawingContext.swift` still
+returns zero-sized metrics. The display-list commit therefore removes the empty
+text frame before the stdout renderer can see it.
+
+A full Linux implementation should add a platform text-layout provider rather
+than assigning fixed terminal widths in the generic SwiftUI layout engine.
+[Pango](https://docs.gtk.org/Pango/) is the most direct candidate because it
+provides shaping, bidirectional layout, wrapping, ellipsizing, baselines, and
+logical/ink extents, with HarfBuzz and FreeType integrations. A smaller
+terminal-only provider would still need Unicode cell-width handling, including
+[East Asian Width](https://www.unicode.org/reports/tr11/), and would not provide
+general SwiftUI-compatible measurement.

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
@@ -243,7 +243,7 @@ private func stdoutFormat(_ value: CGFloat) -> String {
     return String(format: "%.1f", number == -0.0 ? 0.0 : number)
 }
 
-// MARK: - Terminal support [TBA]
+// MARK: - Terminal support
 
 package enum StdoutTerminalSupport {
     package static var stdoutIsTerminal: Bool {
@@ -644,9 +644,53 @@ private func stdoutColorDistance(
     return red * red + green * green + blue * blue
 }
 
-// MARK: - StdoutDisplayListRenderer
+// MARK: - Stdout output formatting
 
-final class StdoutDisplayListRenderer: ViewRendererBase {
+private protocol StdoutOutputFormatter {
+    func format(_ list: DisplayList, version: DisplayList.Version) -> String
+}
+
+private struct StdoutDisplayListFormatter: StdoutOutputFormatter {
+    let surface: CGSize
+
+    func format(_ list: DisplayList, version: DisplayList.Version) -> String {
+        list.stdoutDescription(surface: surface, version: version)
+    }
+}
+
+private struct StdoutTerminalFormatter: StdoutOutputFormatter {
+    let surface: CGSize
+    let terminalSize: _RendererConfiguration.StdoutOptions.TerminalSize
+    let colorMode: _RendererConfiguration.StdoutOptions.ColorMode
+
+    func format(_ list: DisplayList, version: DisplayList.Version) -> String {
+        list.stdoutTerminalDescription(
+            surface: surface,
+            version: version,
+            terminalSize: terminalSize,
+            colorMode: colorMode
+        )
+    }
+}
+
+private extension _RendererConfiguration.StdoutOptions {
+    var outputFormatter: any StdoutOutputFormatter {
+        switch viewMode {
+        case .displayList:
+            StdoutDisplayListFormatter(surface: surface)
+        case .terminal:
+            StdoutTerminalFormatter(
+                surface: surface,
+                terminalSize: terminalSize ?? StdoutTerminalSupport.terminalSize(),
+                colorMode: colorMode
+            )
+        }
+    }
+}
+
+// MARK: - StdoutRenderer
+
+final class StdoutRenderer: ViewRendererBase {
     let platform: DisplayList.ViewUpdater.Platform
     weak var host: (any ViewRendererHost)?
     var options: _RendererConfiguration.StdoutOptions
@@ -681,22 +725,7 @@ final class StdoutDisplayListRenderer: ViewRendererBase {
         }
         hasRendered = true
         seed = nextSeed
-        let description: String
-        switch options.viewMode {
-        case .displayList:
-            description = list.stdoutDescription(
-                surface: options.surface,
-                version: version
-            )
-        case .terminal:
-            description = list.stdoutTerminalDescription(
-                surface: options.surface,
-                version: version,
-                terminalSize: options.terminalSize ?? StdoutTerminalSupport.terminalSize(),
-                colorMode: options.colorMode
-            )
-        }
-        print(description)
+        print(options.outputFormatter.format(list, version: version))
         if let host, let observer = host.as(ViewGraphRenderObserver.self) {
             observer.didRender()
         }

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListStdoutRenderer.swift
@@ -7,6 +7,11 @@
 package import Foundation
 package import OpenCoreGraphicsShims
 import OpenSwiftUI_SPI
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 // MARK: - DisplayList + stdout rendering
 
@@ -27,6 +32,32 @@ extension DisplayList {
         return lines.joined(separator: "\n")
     }
 
+    package func stdoutTerminalDescription(
+        surface: CGSize,
+        version: DisplayList.Version,
+        terminalSize: _RendererConfiguration.StdoutOptions.TerminalSize,
+        colorMode: _RendererConfiguration.StdoutOptions.ColorMode
+    ) -> String {
+        let resolvedColorMode = StdoutTerminalSupport.resolvedColorMode(
+            colorMode,
+            environment: ProcessInfo.processInfo.environment,
+            isTerminal: StdoutTerminalSupport.stdoutIsTerminal
+        )
+        var canvas = StdoutTerminalCanvas(
+            surface: surface,
+            terminalSize: terminalSize
+        )
+        canvas.draw(stdoutRenderCommands())
+        return [
+            "OpenSwiftUI backend: stdout",
+            "surface: \(stdoutFormat(surface.width))x\(stdoutFormat(surface.height))",
+            "display-list-version: \(version.value)",
+            "terminal: \(canvas.columns)x\(canvas.rows) color:\(resolvedColorMode.stdoutDescription)",
+            "rendered:",
+            canvas.description(colorMode: resolvedColorMode),
+        ].joined(separator: "\n")
+    }
+
     private func stdoutRenderCommands() -> [StdoutRenderCommand] {
         var visitor = StdoutRenderCommandVisitor()
         visitor.append(list: self)
@@ -36,12 +67,36 @@ extension DisplayList {
 
 private enum StdoutRenderCommand {
     case fill(frame: CGRect, color: Color.Resolved)
+    case text(
+        frame: CGRect,
+        runs: [StdoutTextRun],
+        alignment: TextAlignment,
+        layoutDirection: LayoutDirection
+    )
 
     var description: String {
         switch self {
         case let .fill(frame, color):
             "fill x:\(stdoutFormat(frame.minX)) y:\(stdoutFormat(frame.minY)) w:\(stdoutFormat(frame.width)) h:\(stdoutFormat(frame.height)) \(color.description)"
+        case let .text(frame, runs, _, _):
+            "text x:\(stdoutFormat(frame.minX)) y:\(stdoutFormat(frame.minY)) w:\(stdoutFormat(frame.width)) h:\(stdoutFormat(frame.height)) \(runs.map(\.description).joined(separator: " "))"
         }
+    }
+}
+
+private struct StdoutTextRun {
+    var string: String
+    var color: Color.Resolved?
+
+    var description: String {
+        let colorDescription = color?.description ?? "default"
+        return "\(colorDescription):\(String(reflecting: string))"
+    }
+
+    func multiplyingOpacity(by opacity: Float) -> StdoutTextRun {
+        var copy = self
+        copy.color = color?.multiplyingOpacity(by: opacity)
+        return copy
     }
 }
 
@@ -95,6 +150,18 @@ private struct StdoutRenderCommandVisitor {
             if let color = paint.stdoutResolvedColor {
                 commands.append(.fill(frame: frame, color: color.multiplyingOpacity(by: opacity)))
             }
+        case let .text(text, _):
+            #if os(macOS)
+            let runs = text.stdoutTextRuns.map { $0.multiplyingOpacity(by: opacity) }
+            commands.append(.text(
+                frame: frame,
+                runs: runs,
+                alignment: text.text.layoutProperties.multilineTextAlignment,
+                layoutDirection: text.text.layoutProperties.layoutDirection
+            ))
+            #else
+            break
+            #endif
         case let .flattened(list, offset, _):
             append(
                 list: list,
@@ -141,9 +208,440 @@ private extension AnyResolvedPaint {
     }
 }
 
+#if os(macOS)
+private extension StyledTextContentView {
+    var stdoutTextRuns: [StdoutTextRun] {
+        guard let storage = text.storage, storage.length > 0 else {
+            return []
+        }
+        var runs: [StdoutTextRun] = []
+        storage.enumerateAttributes(
+            in: NSRange(location: 0, length: storage.length)
+        ) { attributes, range, _ in
+            let string = storage.attributedSubstring(from: range).string
+            let color = attributes[.kitForegroundColor].flatMap(stdoutResolvedColor)
+            if let lastIndex = runs.indices.last, runs[lastIndex].color == color {
+                runs[lastIndex].string += string
+            } else {
+                runs.append(StdoutTextRun(string: string, color: color))
+            }
+        }
+        return runs
+    }
+}
+
+private func stdoutResolvedColor(_ value: Any) -> Color.Resolved? {
+    if let color = value as? Color.Resolved {
+        return color
+    }
+    return Color.Resolved(platformColor: value as AnyObject)
+}
+#endif
+
 private func stdoutFormat(_ value: CGFloat) -> String {
     let number = Double(value)
     return String(format: "%.1f", number == -0.0 ? 0.0 : number)
+}
+
+// MARK: - Terminal support [TBA]
+
+package enum StdoutTerminalSupport {
+    package static var stdoutIsTerminal: Bool {
+        #if canImport(Darwin) || canImport(Glibc)
+        isatty(STDOUT_FILENO) == 1
+        #else
+        false
+        #endif
+    }
+
+    package static func resolvedColorMode(
+        _ requestedMode: _RendererConfiguration.StdoutOptions.ColorMode,
+        environment: [String: String],
+        isTerminal: Bool
+    ) -> _RendererConfiguration.StdoutOptions.ColorMode {
+        guard requestedMode == .automatic else {
+            return requestedMode
+        }
+        guard isTerminal,
+              environment["NO_COLOR", default: ""].isEmpty,
+              environment["TERM"]?.lowercased() != "dumb" else {
+            return .monochrome
+        }
+        let colorTerminal = environment["COLORTERM", default: ""].lowercased()
+        let terminal = environment["TERM", default: ""].lowercased()
+        if colorTerminal == "truecolor" || colorTerminal == "24bit" ||
+            terminal.contains("truecolor") || terminal.contains("direct") {
+            return .trueColor
+        }
+        if terminal.contains("256color") {
+            return .ansi256
+        }
+        return terminal.isEmpty ? .monochrome : .ansi16
+    }
+
+    package static func terminalSize(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> _RendererConfiguration.StdoutOptions.TerminalSize {
+        #if canImport(Darwin) || canImport(Glibc)
+        var windowSize = winsize()
+        if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &windowSize) == 0,
+           windowSize.ws_col > 0,
+           windowSize.ws_row > 0 {
+            return .init(
+                columns: Int(windowSize.ws_col),
+                rows: Int(windowSize.ws_row)
+            )
+        }
+        #endif
+        let columns = environment["COLUMNS"].flatMap(Int.init).flatMap { $0 > 0 ? $0 : nil } ?? 80
+        let rows = environment["LINES"].flatMap(Int.init).flatMap { $0 > 0 ? $0 : nil } ?? 24
+        return .init(columns: columns, rows: rows)
+    }
+}
+
+private extension _RendererConfiguration.StdoutOptions.ColorMode {
+    var stdoutDescription: String {
+        switch self {
+        case .automatic: "automatic"
+        case .monochrome: "monochrome"
+        case .ansi16: "ansi16"
+        case .ansi256: "ansi256"
+        case .trueColor: "trueColor"
+        }
+    }
+}
+
+private struct StdoutTerminalCanvas {
+    private struct Cell {
+        var character: Character?
+        var foreground: Color.Resolved?
+        var background: Color.Resolved?
+    }
+
+    let surface: CGSize
+    let columns: Int
+    let rows: Int
+    private var cells: [Cell]
+
+    init(
+        surface: CGSize,
+        terminalSize: _RendererConfiguration.StdoutOptions.TerminalSize
+    ) {
+        self.surface = surface
+        columns = max(1, terminalSize.columns)
+        rows = max(1, terminalSize.rows)
+        cells = Array(
+            repeating: Cell(),
+            count: max(1, terminalSize.columns) * max(1, terminalSize.rows)
+        )
+    }
+
+    mutating func draw(_ commands: [StdoutRenderCommand]) {
+        for command in commands {
+            switch command {
+            case let .fill(frame, color):
+                fill(frame: frame, color: color)
+            case let .text(frame, runs, alignment, layoutDirection):
+                drawText(
+                    frame: frame,
+                    runs: runs,
+                    alignment: alignment,
+                    layoutDirection: layoutDirection
+                )
+            }
+        }
+    }
+
+    func description(
+        colorMode: _RendererConfiguration.StdoutOptions.ColorMode
+    ) -> String {
+        (0..<rows).map { row in
+            var result = ""
+            var activeForeground: Color.Resolved?
+            var activeBackground: Color.Resolved?
+            for column in 0..<columns {
+                let cell = cells[index(column: column, row: row)]
+                if colorMode != .monochrome,
+                   cell.foreground != activeForeground || cell.background != activeBackground {
+                    result += stdoutANSISequence(
+                        foreground: cell.foreground,
+                        background: cell.background,
+                        colorMode: colorMode
+                    )
+                    activeForeground = cell.foreground
+                    activeBackground = cell.background
+                }
+                if let character = cell.character {
+                    result.append(character)
+                } else if colorMode == .monochrome, cell.background != nil {
+                    result.append("█")
+                } else {
+                    result.append(" ")
+                }
+            }
+            if colorMode != .monochrome,
+               activeForeground != nil || activeBackground != nil {
+                result += "\u{001B}[0m"
+            }
+            return result
+        }.joined(separator: "\n")
+    }
+
+    private mutating func fill(frame: CGRect, color: Color.Resolved) {
+        guard !frame.isEmpty else {
+            return
+        }
+        let columnRange = cellRange(
+            from: frame.minX,
+            to: frame.maxX,
+            surfaceLength: surface.width,
+            cellCount: columns
+        )
+        let rowRange = cellRange(
+            from: frame.minY,
+            to: frame.maxY,
+            surfaceLength: surface.height,
+            cellCount: rows
+        )
+        for row in rowRange {
+            for column in columnRange {
+                let index = index(column: column, row: row)
+                cells[index].character = nil
+                cells[index].foreground = nil
+                cells[index].background = color
+            }
+        }
+    }
+
+    private struct TextCell {
+        var character: Character
+        var foreground: Color.Resolved?
+    }
+
+    private mutating func drawText(
+        frame: CGRect,
+        runs: [StdoutTextRun],
+        alignment: TextAlignment,
+        layoutDirection: LayoutDirection
+    ) {
+        let lines = textLines(runs: runs)
+        let measuredColumns = lines.map(\.count).max() ?? 0
+        guard measuredColumns > 0 else {
+            return
+        }
+        // The display-list frame was measured using the resolved proportional font.
+        // Preserve its center while replacing its size with terminal-cell metrics.
+        let centerColumn = cellOffset(
+            frame.midX,
+            surfaceLength: surface.width,
+            cellCount: columns
+        )
+        let centerRow = cellOffset(
+            frame.midY,
+            surfaceLength: surface.height,
+            cellCount: rows
+        )
+        let initialColumn = centerColumn - measuredColumns / 2
+        let initialRow = centerRow - lines.count / 2
+
+        for (lineOffset, line) in lines.enumerated() {
+            let row = initialRow + lineOffset
+            guard row >= 0, row < rows else {
+                continue
+            }
+            let columnOffset = textAlignmentOffset(
+                availableWidth: measuredColumns,
+                lineWidth: line.count,
+                alignment: alignment,
+                layoutDirection: layoutDirection
+            )
+            var column = initialColumn + columnOffset
+            for textCell in line {
+                guard column >= 0, column < columns else {
+                    column += 1
+                    continue
+                }
+                let index = index(column: column, row: row)
+                cells[index].character = textCell.character
+                cells[index].foreground = textCell.foreground
+                column += 1
+            }
+        }
+    }
+
+    private func textLines(runs: [StdoutTextRun]) -> [[TextCell]] {
+        var lines: [[TextCell]] = [[]]
+        for run in runs {
+            for character in run.string {
+                if character == "\n" {
+                    lines.append([])
+                    continue
+                }
+                lines[lines.index(before: lines.endIndex)].append(
+                    TextCell(character: character, foreground: run.color)
+                )
+            }
+        }
+        return lines
+    }
+
+    private func textAlignmentOffset(
+        availableWidth: Int,
+        lineWidth: Int,
+        alignment: TextAlignment,
+        layoutDirection: LayoutDirection
+    ) -> Int {
+        let remainingWidth = availableWidth - lineWidth
+        switch alignment {
+        case .leading:
+            return layoutDirection == .leftToRight ? 0 : remainingWidth
+        case .center:
+            return remainingWidth / 2
+        case .trailing:
+            return layoutDirection == .leftToRight ? remainingWidth : 0
+        }
+    }
+
+    private func index(column: Int, row: Int) -> Int {
+        row * columns + column
+    }
+
+    private func cellOffset(
+        _ position: CGFloat,
+        surfaceLength: CGFloat,
+        cellCount: Int
+    ) -> Int {
+        guard surfaceLength > 0 else {
+            return 0
+        }
+        return Int(floor(position / surfaceLength * CGFloat(cellCount)))
+    }
+
+    private func cellRange(
+        from start: CGFloat,
+        to end: CGFloat,
+        surfaceLength: CGFloat,
+        cellCount: Int
+    ) -> Range<Int> {
+        guard surfaceLength > 0 else {
+            return 0..<0
+        }
+        let lowerBound = max(
+            0,
+            min(cellCount, Int(ceil(start / surfaceLength * CGFloat(cellCount) - 0.5)))
+        )
+        let upperBound = max(
+            lowerBound,
+            min(cellCount, Int(ceil(end / surfaceLength * CGFloat(cellCount) - 0.5)))
+        )
+        return lowerBound..<upperBound
+    }
+}
+
+private func stdoutANSISequence(
+    foreground: Color.Resolved?,
+    background: Color.Resolved?,
+    colorMode: _RendererConfiguration.StdoutOptions.ColorMode
+) -> String {
+    var parameters = ["0"]
+    if let foreground {
+        parameters.append(contentsOf: stdoutANSIColorParameters(
+            foreground,
+            isBackground: false,
+            colorMode: colorMode
+        ))
+    }
+    if let background {
+        parameters.append(contentsOf: stdoutANSIColorParameters(
+            background,
+            isBackground: true,
+            colorMode: colorMode
+        ))
+    }
+    return "\u{001B}[\(parameters.joined(separator: ";"))m"
+}
+
+private func stdoutANSIColorParameters(
+    _ color: Color.Resolved,
+    isBackground: Bool,
+    colorMode: _RendererConfiguration.StdoutOptions.ColorMode
+) -> [String] {
+    let components = color.stdoutRGBComponents
+    switch colorMode {
+    case .ansi16:
+        let index = stdoutNearestANSI16Color(to: components)
+        let base = isBackground ? 40 : 30
+        let code = index < 8 ? base + index : base + 60 + index - 8
+        return [String(code)]
+    case .ansi256:
+        return [isBackground ? "48" : "38", "5", String(stdoutANSI256Color(for: components))]
+    case .trueColor:
+        return [
+            isBackground ? "48" : "38",
+            "2",
+            String(components.red),
+            String(components.green),
+            String(components.blue),
+        ]
+    case .automatic, .monochrome:
+        return []
+    }
+}
+
+private extension Color.Resolved {
+    var stdoutRGBComponents: (red: Int, green: Int, blue: Int) {
+        func component(_ value: Float) -> Int {
+            Int((value.clamp(min: 0, max: 1) * 255).rounded())
+        }
+        return (component(red), component(green), component(blue))
+    }
+}
+
+private func stdoutNearestANSI16Color(
+    to color: (red: Int, green: Int, blue: Int)
+) -> Int {
+    let palette = [
+        (0, 0, 0), (128, 0, 0), (0, 128, 0), (128, 128, 0),
+        (0, 0, 128), (128, 0, 128), (0, 128, 128), (192, 192, 192),
+        (128, 128, 128), (255, 0, 0), (0, 255, 0), (255, 255, 0),
+        (0, 0, 255), (255, 0, 255), (0, 255, 255), (255, 255, 255),
+    ]
+    return palette.enumerated().min { lhs, rhs in
+        stdoutColorDistance(lhs.element, color) < stdoutColorDistance(rhs.element, color)
+    }?.offset ?? 0
+}
+
+private func stdoutANSI256Color(
+    for color: (red: Int, green: Int, blue: Int)
+) -> Int {
+    let levels = [0, 95, 135, 175, 215, 255]
+    func nearestLevel(to component: Int) -> Int {
+        levels.enumerated().min {
+            abs($0.element - component) < abs($1.element - component)
+        }?.offset ?? 0
+    }
+    let red = nearestLevel(to: color.red)
+    let green = nearestLevel(to: color.green)
+    let blue = nearestLevel(to: color.blue)
+    let cubeColor = (levels[red], levels[green], levels[blue])
+    let cubeIndex = 16 + 36 * red + 6 * green + blue
+    let average = (color.red + color.green + color.blue) / 3
+    let gray = max(0, min(23, Int(round((Double(average) - 8) / 10))))
+    let grayValue = 8 + gray * 10
+    let grayColor = (grayValue, grayValue, grayValue)
+    return stdoutColorDistance(grayColor, color) < stdoutColorDistance(cubeColor, color)
+        ? 232 + gray
+        : cubeIndex
+}
+
+private func stdoutColorDistance(
+    _ lhs: (Int, Int, Int),
+    _ rhs: (red: Int, green: Int, blue: Int)
+) -> Int {
+    let red = lhs.0 - rhs.red
+    let green = lhs.1 - rhs.green
+    let blue = lhs.2 - rhs.blue
+    return red * red + green * green + blue * blue
 }
 
 // MARK: - StdoutDisplayListRenderer
@@ -183,7 +681,22 @@ final class StdoutDisplayListRenderer: ViewRendererBase {
         }
         hasRendered = true
         seed = nextSeed
-        print(list.stdoutDescription(surface: options.surface, version: version))
+        let description: String
+        switch options.viewMode {
+        case .displayList:
+            description = list.stdoutDescription(
+                surface: options.surface,
+                version: version
+            )
+        case .terminal:
+            description = list.stdoutTerminalDescription(
+                surface: options.surface,
+                version: version,
+                terminalSize: options.terminalSize ?? StdoutTerminalSupport.terminalSize(),
+                colorMode: options.colorMode
+            )
+        }
+        print(description)
         if let host, let observer = host.as(ViewGraphRenderObserver.self) {
             observer.didRender()
         }

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
@@ -123,7 +123,7 @@ extension DisplayList {
                 /* OpenSwiftUI Addition Begin */
                 #if !OPENSWIFTUI_SWIFTUI_RENDERER
                 case let .stdout(options):
-                    let stdoutRenderer = renderer as! StdoutDisplayListRenderer
+                    let stdoutRenderer = renderer as! StdoutRenderer
                     stdoutRenderer.options = options
                     stdoutRenderer.host = host
                 #endif
@@ -147,7 +147,7 @@ extension DisplayList {
                 /* OpenSwiftUI Addition Begin */
                 #if !OPENSWIFTUI_SWIFTUI_RENDERER
                 case let .stdout(options):
-                    renderer = StdoutDisplayListRenderer(
+                    renderer = StdoutRenderer(
                         platform: platform,
                         host: host,
                         options: options

--- a/Sources/OpenSwiftUICore/Render/RendererConfiguration.swift
+++ b/Sources/OpenSwiftUICore/Render/RendererConfiguration.swift
@@ -70,8 +70,61 @@ public struct _RendererConfiguration {
     /// Options for the `stdout` renderer.
     @_spi(StdoutRenderer)
     public struct StdoutOptions {
+        /// The representation written by the stdout renderer.
+        public enum ViewMode: Equatable {
+            /// Writes the display list as a sequence of textual render commands.
+            case displayList
+
+            /// Renders the display list into a terminal-cell canvas.
+            case terminal
+        }
+
+        /// The terminal color capability used by terminal view mode.
+        public enum ColorMode: Equatable {
+            /// Detects color support from standard output and the process
+            /// environment.
+            case automatic
+
+            /// Does not emit ANSI color escape sequences.
+            case monochrome
+
+            /// Emits colors from the 16-color ANSI palette.
+            case ansi16
+
+            /// Emits colors from the 256-color ANSI palette.
+            case ansi256
+
+            /// Emits 24-bit ANSI colors.
+            case trueColor
+        }
+
+        /// The dimensions of a terminal-cell canvas.
+        public struct TerminalSize {
+            /// The number of columns in the canvas.
+            public var columns: Int
+
+            /// The number of rows in the canvas.
+            public var rows: Int
+
+            public init(columns: Int, rows: Int) {
+                self.columns = columns
+                self.rows = rows
+            }
+        }
+
         /// The surface size reported by the stdout renderer.
         public var surface: CGSize = defaultSurfaceSize
+
+        /// The representation written by the stdout renderer.
+        public var viewMode: ViewMode = .displayList
+
+        /// The color capability used by terminal view mode.
+        public var colorMode: ColorMode = .automatic
+
+        /// An optional terminal size override. When `nil`, the renderer reads
+        /// the size from standard output and falls back to 80 columns by 24
+        /// rows.
+        public var terminalSize: TerminalSize?
 
         // TODO: Get from host platform API
         private static let defaultSurfaceSize = CGSize(width: 640.0, height: 480.0)

--- a/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListStdoutRendererTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListStdoutRendererTests.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import OpenCoreGraphicsShims
-import OpenSwiftUICore
+@_spi(Private) @_spi(StdoutRenderer) import OpenSwiftUICore
 import Testing
 
 struct DisplayListStdoutRendererTests {
@@ -66,6 +66,138 @@ struct DisplayListStdoutRendererTests {
         rendered:
           - fill x:5.0 y:6.0 w:70.0 h:80.0 #00FF00FF
         """)
+    }
+
+    #if os(macOS)
+    @Test
+    func textContentDescription() {
+        let storage = NSMutableAttributedString(string: "Hello")
+        storage.addAttribute(
+            NSAttributedString.Key("NSColor"),
+            value: Color.Resolved.green.kitColor,
+            range: NSRange(location: 0, length: storage.length)
+        )
+        let text = StyledTextContentView(
+            text: ResolvedStyledText.styledText(
+                storage: storage,
+                layoutProperties: TextLayoutProperties()
+            )
+        )
+        let item = item(
+            .content(.init(
+                .text(text, CGSize(width: 30.0, height: 10.0)),
+                seed: .init(decodedValue: 4)
+            )),
+            frame: CGRect(x: 7.0, y: 8.0, width: 30.0, height: 10.0)
+        )
+
+        #expect(DisplayList(item).stdoutDescription(
+            surface: CGSize(width: 80.0, height: 24.0),
+            version: .init(decodedValue: 9)
+        ) == """
+        OpenSwiftUI backend: stdout
+        surface: 80.0x24.0
+        display-list-version: 9
+        rendered:
+          - text x:7.0 y:8.0 w:30.0 h:10.0 #00FF00FF:"Hello"
+        """)
+    }
+
+    @Test
+    func terminalDescriptionRendersColorAndText() {
+        let fill = item(
+            .content(.init(
+                .color(.red),
+                seed: .init(decodedValue: 1)
+            )),
+            frame: CGRect(x: 0.0, y: 0.0, width: 2.0, height: 2.0)
+        )
+        let text = StyledTextContentView(
+            text: ResolvedStyledText.styledText(
+                storage: NSAttributedString(string: "A"),
+                layoutProperties: TextLayoutProperties()
+            )
+        )
+        let textItem = item(
+            .content(.init(
+                .text(text, CGSize(width: 1.0, height: 1.0)),
+                seed: .init(decodedValue: 2)
+            )),
+            frame: CGRect(x: 2.0, y: 0.0, width: 1.0, height: 1.0),
+            identity: .init(decodedValue: 2)
+        )
+
+        let description = DisplayList([fill, textItem]).stdoutTerminalDescription(
+            surface: CGSize(width: 4.0, height: 2.0),
+            version: .init(decodedValue: 10),
+            terminalSize: .init(columns: 4, rows: 2),
+            colorMode: .trueColor
+        )
+
+        #expect(description.contains("terminal: 4x2 color:trueColor"))
+        #expect(description.contains("\u{001B}[0;48;2;255;0;0m  \u{001B}[0mA "))
+    }
+
+    @Test
+    func terminalDescriptionRemeasuresCenteredTextInCells() throws {
+        let string = "OpenSwiftUI stdout renderer"
+        let text = StyledTextContentView(
+            text: ResolvedStyledText.styledText(
+                storage: NSAttributedString(string: string),
+                layoutProperties: TextLayoutProperties()
+            )
+        )
+        let textItem = item(
+            .content(.init(
+                .text(text, CGSize(width: 174.0, height: 16.0)),
+                seed: .init(decodedValue: 1)
+            )),
+            frame: CGRect(x: 233.0, y: 0.0, width: 174.0, height: 16.0)
+        )
+
+        let description = DisplayList(textItem).stdoutTerminalDescription(
+            surface: CGSize(width: 640.0, height: 480.0),
+            version: .init(decodedValue: 5),
+            terminalSize: .init(columns: 48, rows: 16),
+            colorMode: .monochrome
+        )
+        let rendered = try #require(description.components(separatedBy: "rendered:\n").last)
+        let firstLine = try #require(rendered.split(separator: "\n", omittingEmptySubsequences: false).first)
+        let expected = Substring(
+            String(repeating: " ", count: 11) + string + String(repeating: " ", count: 10)
+        )
+
+        #expect(firstLine == expected)
+    }
+    #endif
+
+    @Test(arguments: [
+        (false, ["TERM": "xterm-256color"], _RendererConfiguration.StdoutOptions.ColorMode.monochrome),
+        (true, ["NO_COLOR": "1", "TERM": "xterm-256color"], .monochrome),
+        (true, ["COLORTERM": "truecolor", "TERM": "xterm-256color"], .trueColor),
+        (true, ["TERM": "xterm-256color"], .ansi256),
+        (true, ["TERM": "xterm"], .ansi16),
+        (true, ["TERM": "dumb"], .monochrome),
+    ])
+    func automaticTerminalColorDetection(
+        isTerminal: Bool,
+        environment: [String: String],
+        expected: _RendererConfiguration.StdoutOptions.ColorMode
+    ) {
+        #expect(StdoutTerminalSupport.resolvedColorMode(
+            .automatic,
+            environment: environment,
+            isTerminal: isTerminal
+        ) == expected)
+    }
+
+    @Test
+    func explicitTerminalColorModeOverridesDetection() {
+        #expect(StdoutTerminalSupport.resolvedColorMode(
+            .trueColor,
+            environment: ["NO_COLOR": "1", "TERM": "dumb"],
+            isTerminal: false
+        ) == .trueColor)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add a terminal-cell view mode alongside the existing display-list stdout output
- render solid colors and macOS text content with terminal-aware placement and ANSI color output
- detect terminal dimensions and color capabilities, with explicit configuration overrides
- update the stdout example, documentation, and focused renderer coverage

## Motivation

The stdout renderer previously exposed only textual display-list commands. A terminal view provides a compact visual representation that is useful for local renderer development and diagnostics while preserving the existing display-list mode.

## Validation

- Focused stdout renderer suite passes (10 tests)
- The macOS stdout example renders a centered text label and color regions in a 48 by 16 terminal canvas
- Diff whitespace checks pass