### PR TITLE
Add multi-module versioned documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -58,15 +58,18 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .docs/cache/versioned-docc
-          key: versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved') }}-${{ github.sha }}
+          key: versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved', 'Scripts/extract-documentation-symbol-graphs.sh') }}-${{ github.sha }}
           restore-keys: |
-            versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved') }}-
+            versioned-docc-${{ runner.os }}-${{ hashFiles('.vdc.json', 'Package.resolved', 'Scripts/extract-documentation-symbol-graphs.sh') }}-
             versioned-docc-${{ runner.os }}-
       - uses: oras-project/setup-oras@v1
       - name: Log in to GitHub Container Registry
         run: echo "${{ github.token }}" | oras login ghcr.io --username "${{ github.actor }}" --password-stdin
+      - name: Extract additional module symbol graphs
+        run: Scripts/extract-documentation-symbol-graphs.sh
+        shell: bash
       - name: Build versioned DocC site
-        uses: DocCLab/VersionedDocC@0.0.14
+        uses: DocCLab/VersionedDocC@0.1.2
         with:
           config: .vdc.json
           publish-oci-cache: true
@@ -79,7 +82,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: .docs/build/versioned-site/OpenSwiftUI
+          path: .docs/build/versioned-site
 
   deploy:
     name: Deploy DocC site

--- a/.vdc.json
+++ b/.vdc.json
@@ -1,14 +1,14 @@
 {
-  "$schema": "https://raw.githubusercontent.com/DocCLab/VersionedDocC/0.0.14/Schema/VersionedDocC.schema.json",
+  "$schema": "https://raw.githubusercontent.com/DocCLab/VersionedDocC/0.1.2/Schema/VersionedDocC.schema.json",
   "schemaVersion": 1,
   "projectName": "OpenSwiftUI",
   "moduleName": "OpenSwiftUI",
   "modulePath": "openswiftui",
   "targetName": "OpenSwiftUI",
   "catalogPath": "Sources/OpenSwiftUI/OpenSwiftUI.docc",
-  "hostingBasePath": "/OpenSwiftUI",
+  "hostingBasePath": "/",
   "defaultVersion": "main",
-  "outputPath": ".docs/build/versioned-site/OpenSwiftUI",
+  "outputPath": ".docs/build/versioned-site",
   "cachePath": ".docs/cache/versioned-docc",
   "releasePolicy": {
     "latest": 2,
@@ -20,7 +20,25 @@
   },
   "allowedModules": [
     "OpenSwiftUI",
-    "OpenSwiftUICore"
+    "OpenSwiftUICore",
+    "OpenAttributeGraph",
+    "OpenObservation"
+  ],
+  "additionalModules": [
+    {
+      "moduleName": "OpenAttributeGraph",
+      "symbolGraphPath": ".docs/external-symbol-graphs/{version}/OpenAttributeGraph-symbol-graphs",
+      "catalogPath": "Sources/OpenAttributeGraph/OpenAttributeGraph.docc",
+      "sourceRepository": "https://github.com/OpenSwiftUIProject/OpenAttributeGraph",
+      "sourceRoot": "../OpenAttributeGraph"
+    },
+    {
+      "moduleName": "OpenObservation",
+      "symbolGraphPath": ".docs/external-symbol-graphs/{version}/OpenObservation-symbol-graphs",
+      "catalogPath": "Sources/OpenObservation/OpenObservation.docc",
+      "sourceRepository": "https://github.com/OpenSwiftUIProject/OpenObservation",
+      "sourceRoot": "../OpenObservation"
+    }
   ],
   "symbolGraph": {
     "minimumAccessLevel": "public",

--- a/Docs/Documentation.md
+++ b/Docs/Documentation.md
@@ -4,11 +4,11 @@ OpenSwiftUI publishes versioned Swift-DocC documentation with
 [VersionedDocC](https://github.com/DocCLab/VersionedDocC).
 
 - Development documentation:
-  <https://openswiftuiproject.github.io/OpenSwiftUI/main/documentation/openswiftui/>
+  <https://docs.openswiftuiproject.org/main/documentation/openswiftui/>
 - API changes:
-  <https://openswiftuiproject.github.io/OpenSwiftUI/main/changes/>
+  <https://docs.openswiftuiproject.org/main/changes/>
 
-The legacy unversioned `/OpenSwiftUI/documentation/...` routes remain usable and
+The legacy unversioned `/documentation/...` routes remain usable and
 redirect in the browser to the matching `main` route.
 
 ## Version Policy
@@ -24,8 +24,8 @@ selector `main`, `0.20.1`, and `0.19.2`. A later `0.20.2` replaces `0.20.1`
 in the published site. A new `0.21.0` moves the window to `0.21.0` and
 `0.20.2` without requiring a configuration edit.
 
-Only the selected versions are assembled into GitHub Pages. Superseded release
-caches remain immutable and may still exist locally or in GHCR.
+Only the selected versions are assembled into the published site. Superseded
+release caches remain immutable and may still exist locally or in GHCR.
 
 ## CI Deployment
 
@@ -43,10 +43,12 @@ The workflow:
    `OpenSwiftUIProject/swift-docc-render-artifact@release/6.3-colorful`.
 4. Restores `.docs/cache/versioned-docc` from GitHub Actions cache.
 5. Authenticates ORAS with GHCR.
-6. Runs `DocCLab/VersionedDocC@0.0.12`, restoring immutable release
+6. Resolves the selected documentation versions and extracts matching symbol
+   graphs for every additional documentation module.
+7. Runs `DocCLab/VersionedDocC@0.1.2`, restoring immutable release
    artifacts from GHCR, building cache misses, publishing new release artifacts,
    and assembling the versioned site.
-7. Uploads `.docs/build/versioned-site/OpenSwiftUI` and deploys it with GitHub
+8. Uploads `.docs/build/versioned-site` and deploys it with GitHub
    Pages Actions.
 
 The repository's Pages source must be **GitHub Actions**. The `github-pages`
@@ -99,12 +101,14 @@ dependency repositories. Do not run it from a checkout containing unrelated
 dependency work.
 
 Open
-<http://127.0.0.1:8766/OpenSwiftUI/main/documentation/openswiftui/> or
-<http://127.0.0.1:8766/OpenSwiftUI/main/changes/>.
+<http://127.0.0.1:8766/main/documentation/openswiftui/> or
+<http://127.0.0.1:8766/main/changes/>.
 
 VersionedDocC preview serves the assembled multi-version static site; it is not
 `docc preview` and does not watch source files. Re-run the script after changing
-documentation source. Publishing an OCI cache remains an explicit CI operation.
+documentation source. Use `--rebuild` after changing public declarations in an
+additional module so its external symbol graphs are regenerated. Publishing an
+OCI cache remains an explicit CI operation.
 
 ## Release Preflight
 
@@ -135,7 +139,7 @@ swift package --disable-sandbox \
 Verify the assembled site:
 
 ```bash
-SITE_ROOT=.docs/build/versioned-site/OpenSwiftUI
+SITE_ROOT=.docs/build/versioned-site
 
 test -s "$SITE_ROOT/versions.json"
 test -s "$SITE_ROOT/main/index.html"
@@ -175,8 +179,20 @@ patch in the selector does not delete the previous patch artifact.
 
 ## Symbol Graph Policy
 
-The public site retains only `OpenSwiftUI` and `OpenSwiftUICore` symbols.
-Re-exported system and dependency modules are removed during assembly.
+The public site provides separate documentation pages for `OpenSwiftUI`,
+`OpenAttributeGraph`, and `OpenObservation`. APIs implemented by the
+`OpenSwiftUICore` source target retain the `OpenSwiftUI` symbol namespace and
+are documented under `OpenSwiftUI`, avoiding duplicate pages for the same
+precise symbol identifiers. The primary and additional modules all follow the
+same configured documentation version policy.
+
+`Scripts/extract-documentation-symbol-graphs.sh` builds and filters the
+additional module graphs before VersionedDocC converts them. For each selected
+OpenSwiftUI version, it reads that version's `Package.resolved`, checks out the
+exact OpenAttributeGraph and OpenObservation revisions, and records the
+revision alongside the graph cache. The modules use their own DocC catalogs
+and source repositories. Re-exported system and unrelated dependency modules
+are removed.
 
 VersionedDocC passes `-skip-protocol-implementations` through the Swift
 frontend. Protocol-extension APIs are represented once on their declaring
@@ -225,14 +241,15 @@ diagnose a suspected fingerprint or cache-validation problem.
 
 ### Documentation contains dependency symbols
 
-Confirm `.vdc.json` still lists only `OpenSwiftUI` and `OpenSwiftUICore` under
-`allowedModules`, then inspect the pruning summary in the VersionedDocC log.
+Confirm `.vdc.json` lists only `OpenSwiftUI`, its `OpenSwiftUICore` source
+target, and the two additional documented modules under `allowedModules`, then
+inspect the extraction and pruning summaries in the VersionedDocC log.
 
 ### CSS or JavaScript returns 404
 
-The publishing base path comes from `hostingBasePath: /OpenSwiftUI` in
-`.vdc.json`. Do not override the artifact root: Pages must upload
-`.docs/build/versioned-site/OpenSwiftUI`.
+The custom documentation domain is hosted at its root, so `.vdc.json` uses
+`hostingBasePath: /`. Do not override the artifact root: Pages must upload
+`.docs/build/versioned-site`.
 
 ### OCI restore or publish fails
 

--- a/Docs/Release.md
+++ b/Docs/Release.md
@@ -84,7 +84,7 @@ git show --no-patch "$RELEASE_VERSION"
 
 Do not push until every preflight check succeeds. If the candidate belongs to
 one of the two newest release series, confirm that it appears in
-`.docs/build/versioned-site/OpenSwiftUI/versions.json` and that the API Changes
+`.docs/build/versioned-site/versions.json` and that the API Changes
 page contains the expected adjacent comparison.
 
 ## Publish

--- a/Package.resolved
+++ b/Package.resolved
@@ -43,7 +43,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/OpenRenderBox",
       "state" : {
         "branch" : "main",
-        "revision" : "d6db14f180068c6813a936088e767c2ca99c308d"
+        "revision" : "ec856ea3d709de2624fe1324c0ef004a7f492394"
       }
     },
     {
@@ -71,15 +71,6 @@
       "state" : {
         "revision" : "546053c03f282df1a8270853da6692e1b078be09",
         "version" : "0.2.1"
-      }
-    },
-    {
-      "identity" : "versioneddocc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/DocCLab/VersionedDocC.git",
-      "state" : {
-        "revision" : "ef03d94f3d8a41de9c9b9273e144de1b34c0bd64",
-        "version" : "0.1.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "04350c5edb9dc1797c4fd35bff8a56c1a96895d49cedbb8278ab734d307c830d",
+  "originHash" : "54f62c02c08bb245c5bfdba8f1ac6d7d89e69bd5b95823f2a578e50dfb9b7a38",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",
@@ -71,6 +71,15 @@
       "state" : {
         "revision" : "546053c03f282df1a8270853da6692e1b078be09",
         "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "versioneddocc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DocCLab/VersionedDocC.git",
+      "state" : {
+        "revision" : "ef03d94f3d8a41de9c9b9273e144de1b34c0bd64",
+        "version" : "0.1.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -798,7 +798,7 @@ if versionedDocCPlugin {
     package.dependencies.append(
         .package(
             url: "https://github.com/DocCLab/VersionedDocC.git",
-            exact: "0.0.14"
+            exact: "0.1.2"
         )
     )
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And the API design and documentation is to stay as compatible with the original 
 
 Currently, this project is in early development.
 
-The full API [documentation](https://openswiftuiproject.github.io/OpenSwiftUI/main/documentation/openswiftui/) is hosted on GitHub Pages.
+The full API [documentation](https://docs.openswiftuiproject.org/main/documentation/openswiftui/) is available on the OpenSwiftUI documentation site.
 
 ## Notes
 

--- a/Scripts/extract-documentation-symbol-graphs.sh
+++ b/Scripts/extract-documentation-symbol-graphs.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the OpenSwiftUI open source project
+##
+## Copyright (c) 2026 the OpenSwiftUI project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_PATH="${VDC_CONFIG_PATH:-.vdc.json}"
+BUILD_ROOT="$REPO_ROOT/.docs/build/additional-symbol-graphs"
+RESOLVED_VERSIONS_PATH="${VDC_RESOLVED_VERSIONS_PATH:-$BUILD_ROOT/resolved-versions.json}"
+TEMPORARY_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openswiftui-docc-graphs.XXXXXX")"
+
+cleanup() {
+    rm -rf "$TEMPORARY_ROOT"
+}
+
+trap cleanup EXIT INT TERM
+
+command -v swift >/dev/null 2>&1 || {
+    echo "error: swift is required" >&2
+    exit 1
+}
+command -v xcrun >/dev/null 2>&1 || {
+    echo "error: xcrun is required" >&2
+    exit 1
+}
+command -v python3 >/dev/null 2>&1 || {
+    echo "error: python3 is required" >&2
+    exit 1
+}
+command -v git >/dev/null 2>&1 || {
+    echo "error: git is required" >&2
+    exit 1
+}
+
+: "${OPENSWIFTUI_WERROR:=0}"
+: "${OPENSWIFTUI_COMPATIBILITY_TEST:=0}"
+: "${OPENSWIFTUI_SWIFT_LOG:=0}"
+: "${OPENSWIFTUI_SWIFT_CRYPTO:=0}"
+: "${OPENSWIFTUI_TARGET_RELEASE:=2024}"
+: "${OPENSWIFTUI_USE_LOCAL_DEPS:=1}"
+: "${OPENSWIFTUI_VERSIONED_DOCC_PLUGIN:=1}"
+: "${OPENSWIFTUI_LINK_TESTING:=0}"
+: "${OPENSWIFTUI_IGNORE_AVAILABILITY:=0}"
+: "${OPENSWIFTUI_LIBRARY_EVOLUTION:=0}"
+export OPENSWIFTUI_WERROR
+export OPENSWIFTUI_COMPATIBILITY_TEST
+export OPENSWIFTUI_SWIFT_LOG
+export OPENSWIFTUI_SWIFT_CRYPTO
+export OPENSWIFTUI_TARGET_RELEASE
+export OPENSWIFTUI_USE_LOCAL_DEPS
+export OPENSWIFTUI_VERSIONED_DOCC_PLUGIN
+export OPENSWIFTUI_LINK_TESTING
+export OPENSWIFTUI_IGNORE_AVAILABILITY
+export OPENSWIFTUI_LIBRARY_EVOLUTION
+export VDC_GENERATE_DOCS=1
+
+MACOS_SDK="$(xcrun --sdk macosx --show-sdk-path)"
+
+resolve_documentation_versions() {
+    local output_argument="${RESOLVED_VERSIONS_PATH#"$REPO_ROOT"/}"
+
+    if [[ -n "${VDC_RESOLVED_VERSIONS_PATH:-}" ]]; then
+        [[ -f "$RESOLVED_VERSIONS_PATH" ]] || {
+            echo "error: missing resolved versions file: $RESOLVED_VERSIONS_PATH" >&2
+            exit 1
+        }
+        return
+    fi
+    mkdir -p "$BUILD_ROOT"
+    swift package \
+        --disable-sandbox \
+        --allow-writing-to-package-directory \
+        --allow-network-connections all \
+        versioned-documentation \
+        resolve-versions \
+        --config "$CONFIG_PATH" \
+        --output "$output_argument"
+}
+
+resolved_dependency_revision() {
+    local resolved_path="$1"
+    local package_identity="$2"
+
+    python3 - "$resolved_path" "$package_identity" <<'PY'
+import json
+import pathlib
+import sys
+
+resolved_path = pathlib.Path(sys.argv[1])
+identity = sys.argv[2].casefold()
+with resolved_path.open(encoding="utf-8") as file:
+    pins = json.load(file).get("pins", [])
+for pin in pins:
+    if pin.get("identity", "").casefold() != identity:
+        continue
+    revision = pin.get("state", {}).get("revision")
+    if revision:
+        print(revision)
+        raise SystemExit(0)
+raise SystemExit(f"error: {resolved_path} has no revision for {identity}")
+PY
+}
+
+prepare_dependency_checkout() {
+    local canonical_path="$1"
+    local expected_revision="$2"
+    local documentation_version="$3"
+    local module_name="$4"
+    local checkout_path
+
+    if [[ ! -e "$canonical_path/.git" ]]; then
+        echo "error: missing dependency repository: $canonical_path" >&2
+        exit 1
+    fi
+    if ! git -C "$canonical_path" cat-file -e "${expected_revision}^{commit}" 2>/dev/null; then
+        echo "Fetching $module_name revision $expected_revision..."
+        git -C "$canonical_path" fetch origin "$expected_revision"
+    fi
+    if [[ "$(git -C "$canonical_path" rev-parse HEAD)" == "$expected_revision" ]]; then
+        PREPARED_DEPENDENCY_PATH="$canonical_path"
+        return
+    fi
+
+    checkout_path="$TEMPORARY_ROOT/$documentation_version/$module_name"
+    mkdir -p "$(dirname "$checkout_path")"
+    git clone --quiet --shared --no-checkout "$canonical_path" "$checkout_path"
+    git -C "$checkout_path" checkout --quiet --detach "$expected_revision"
+    if [[ -d "$canonical_path/Checkouts/swift" ]]; then
+        mkdir -p "$checkout_path/Checkouts/swift"
+        for swift_checkout_component in include stdlib; do
+            if [[ ! -e "$checkout_path/Checkouts/swift/$swift_checkout_component" ]]; then
+                ln -s \
+                    "$canonical_path/Checkouts/swift/$swift_checkout_component" \
+                    "$checkout_path/Checkouts/swift/$swift_checkout_component"
+            fi
+        done
+    fi
+    PREPARED_DEPENDENCY_PATH="$checkout_path"
+}
+
+extract_module() {
+    local documentation_version="$1"
+    local resolved_path="$2"
+    local module_name="$3"
+    local canonical_path="$4"
+    local target_name="$5"
+    local package_identity="$6"
+    local output_path="$REPO_ROOT/.docs/external-symbol-graphs/$documentation_version/${module_name}-symbol-graphs"
+    local scratch_path="$BUILD_ROOT/$documentation_version/$module_name"
+    local revision_path="$output_path/.source-revision"
+    local expected_revision
+    local package_path
+
+    expected_revision="$(resolved_dependency_revision "$resolved_path" "$package_identity")"
+
+    case "$output_path" in
+        "$REPO_ROOT"/.docs/external-symbol-graphs/*) ;;
+        *)
+            echo "error: refusing to clear unexpected path: $output_path" >&2
+            exit 1
+            ;;
+    esac
+
+    if [[ "${VDC_REBUILD_ADDITIONAL_SYMBOL_GRAPHS:-0}" != "1" ]] &&
+        [[ -f "$revision_path" ]] &&
+        [[ "$(<"$revision_path")" == "$expected_revision" ]] &&
+        python3 - "$output_path" "$module_name" <<'PY'
+import json
+import pathlib
+import sys
+
+graph_path = pathlib.Path(sys.argv[1])
+expected_module = sys.argv[2]
+paths = sorted(graph_path.glob("*.symbols.json"))
+if not paths:
+    raise SystemExit(1)
+for path in paths:
+    with path.open(encoding="utf-8") as file:
+        if json.load(file).get("module", {}).get("name") != expected_module:
+            raise SystemExit(1)
+PY
+    then
+        echo "Reusing $documentation_version $module_name symbol graphs at ${expected_revision:0:8}."
+        return
+    fi
+
+    prepare_dependency_checkout \
+        "$canonical_path" \
+        "$expected_revision" \
+        "$documentation_version" \
+        "$module_name"
+    package_path="$PREPARED_DEPENDENCY_PATH"
+
+    mkdir -p "$output_path"
+    find "$output_path" -mindepth 1 -delete
+    mkdir -p "$scratch_path"
+    find "$scratch_path" -mindepth 1 -delete
+
+    echo "Extracting $documentation_version $module_name symbol graphs at ${expected_revision:0:8}..."
+    OPENATTRIBUTEGRAPH_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH=0 \
+    OPENSWIFTUI_OPENATTRIBUTESHIMS_ATTRIBUTEGRAPH=0 \
+    OPENSWIFTUI_USE_LOCAL_DEPS=0 \
+    swift build \
+        --disable-sandbox \
+        --disable-index-store \
+        --package-path "$package_path" \
+        --scratch-path "$scratch_path" \
+        --target "$target_name" \
+        --triple arm64-apple-macosx \
+        --sdk "$MACOS_SDK" \
+        -Xswiftc -emit-symbol-graph \
+        -Xswiftc -emit-symbol-graph-dir \
+        -Xswiftc "$output_path" \
+        -Xswiftc -symbol-graph-minimum-access-level \
+        -Xswiftc public \
+        -Xswiftc -Xfrontend \
+        -Xswiftc -skip-protocol-implementations
+
+    python3 - "$output_path" "$module_name" <<'PY'
+import json
+import pathlib
+import sys
+
+graph_path = pathlib.Path(sys.argv[1])
+expected_module = sys.argv[2]
+retained = []
+
+for path in sorted(graph_path.glob("*.symbols.json")):
+    with path.open(encoding="utf-8") as file:
+        module_name = json.load(file).get("module", {}).get("name")
+    if module_name == expected_module:
+        retained.append(path.name)
+    else:
+        path.unlink()
+
+if not retained:
+    raise SystemExit(
+        f"error: no {expected_module} symbol graphs found in {graph_path}"
+    )
+
+print(f"Retained {len(retained)} {expected_module} symbol graph file(s).")
+PY
+    printf '%s\n' "$expected_revision" > "$revision_path"
+}
+
+cd "$REPO_ROOT"
+resolve_documentation_versions
+
+resolved_version_rows="$TEMPORARY_ROOT/resolved-versions.tsv"
+python3 - "$RESOLVED_VERSIONS_PATH" "$resolved_version_rows" <<'PY'
+import json
+import pathlib
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+with source_path.open(encoding="utf-8") as file:
+    versions = json.load(file)
+if not versions:
+    raise SystemExit("error: VersionedDocC resolved no documentation versions")
+output_path.write_text(
+    "".join(f'{version["name"]}\t{version["commit"]}\n' for version in versions),
+    encoding="utf-8",
+)
+PY
+
+while IFS=$'\t' read -r documentation_version documentation_commit; do
+    resolved_path="$TEMPORARY_ROOT/$documentation_version/Package.resolved"
+    mkdir -p "$(dirname "$resolved_path")"
+    git show "${documentation_commit}:Package.resolved" > "$resolved_path"
+
+    extract_module \
+        "$documentation_version" \
+        "$resolved_path" \
+        "OpenAttributeGraph" \
+        "$REPO_ROOT/../OpenAttributeGraph" \
+        "OpenAttributeGraph" \
+        "openattributegraph"
+
+    extract_module \
+        "$documentation_version" \
+        "$resolved_path" \
+        "OpenObservation" \
+        "$REPO_ROOT/../OpenObservation" \
+        "OpenObservation" \
+        "openobservation"
+done < "$resolved_version_rows"

--- a/Scripts/preview-documentation.sh
+++ b/Scripts/preview-documentation.sh
@@ -164,6 +164,17 @@ SWIFT_PLUGIN_ARGUMENTS=(
 )
 
 if [[ "$BUILD_SITE" == true ]]; then
+    if [[ "$ASSEMBLE_ONLY" == false ]]; then
+        if [[ "$REBUILD" == true ]]; then
+            VDC_CONFIG_PATH="$CONFIG_PATH" \
+                VDC_REBUILD_ADDITIONAL_SYMBOL_GRAPHS=1 \
+                "$SCRIPT_DIR/extract-documentation-symbol-graphs.sh"
+        else
+            VDC_CONFIG_PATH="$CONFIG_PATH" \
+                "$SCRIPT_DIR/extract-documentation-symbol-graphs.sh"
+        fi
+    fi
+
     BUILD_ARGUMENTS=(
         build
         --config "$CONFIG_PATH"


### PR DESCRIPTION
## Summary

- publish VersionedDocC output at the documentation domain root using VersionedDocC 0.1.2
- add OpenAttributeGraph and OpenObservation alongside OpenSwiftUI, with revision-aligned source and edit links
- generate additional-module symbol graphs for every selected OpenSwiftUI documentation version
- update the CI workflow, local preview tooling, and documentation for aggregate and module-scoped API changes

## Motivation

The documentation site is moving to `docs.openswiftuiproject.org` and should present OpenSwiftUI, OpenAttributeGraph, and OpenObservation as one versioned documentation set. Each additional module must follow the selected OpenSwiftUI revision so published declarations and source links remain consistent.

## Validation

Validated a full local VersionedDocC build for `main` and `0.20.1`, including all three module routes, aggregate and per-module API change pages, source/edit links, and SPA-aware API Changes navigation. The shell scripts pass syntax validation and the package resolves VersionedDocC 0.1.2.