### PR TITLE
Stabilize UI tests on Xcode 26.6

### DIFF
--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -201,7 +201,7 @@ runs:
           fi
 
           existing_status="$(gh run view "$existing_run" --repo "$GITHUB_REPOSITORY" --json status --jq .status 2>/dev/null || true)"
-          if [[ "$existing_status" == "completed" ]]; then
+          if [[ "$existing_status" == "completed" ]] && [[ "$(cat "$lockfile" 2>/dev/null || true)" == "$existing_lock" ]]; then
             echo "::notice::Removing stale snapshot reference lock from completed run $existing_run."
             rm -f "$lockfile"
           fi
@@ -211,20 +211,30 @@ runs:
           ( set -o noclobber; printf '%s\n' "$lock_owner" > "$lockfile" ) 2>/dev/null
         }
 
-        lock_acquired=false
-        remove_completed_run_lock
-        if acquire_lock; then
-          lock_acquired=true
-        else
+        # Baseline images are shared by every configuration for a platform, so
+        # parallel matrix jobs must wait for the current recorder to finish.
+        lock_wait_timeout_seconds=1800
+        lock_poll_interval_seconds=10
+        lock_wait_started=$SECONDS
+        next_lock_notice_at=0
+        while true; do
           remove_completed_run_lock
           if acquire_lock; then
-            lock_acquired=true
+            break
           fi
-        fi
-        if [[ "$lock_acquired" != "true" ]]; then
-          echo "::error::Snapshot reference images are locked by $(cat "$lockfile" 2>/dev/null || echo "another UI test run")."
-          exit 1
-        fi
+
+          lock_wait_elapsed=$((SECONDS - lock_wait_started))
+          existing_lock="$(cat "$lockfile" 2>/dev/null || echo "another UI test run")"
+          if (( lock_wait_elapsed >= lock_wait_timeout_seconds )); then
+            echo "::error::Timed out after ${lock_wait_timeout_seconds}s waiting for snapshot reference images locked by $existing_lock."
+            exit 1
+          fi
+          if (( lock_wait_elapsed >= next_lock_notice_at )); then
+            echo "::notice::Snapshot reference images are locked by $existing_lock; retrying every ${lock_poll_interval_seconds}s for up to ${lock_wait_timeout_seconds}s."
+            next_lock_notice_at=$((lock_wait_elapsed + 60))
+          fi
+          sleep "$lock_poll_interval_seconds"
+        done
         trap remove_current_lock EXIT INT TERM
 
         set -o pipefail

--- a/Example/OpenSwiftUIUITests/View/LabeledContent/LabelsHiddenModifierUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/LabeledContent/LabelsHiddenModifierUITests.swift
@@ -6,7 +6,10 @@ import Testing
 import SnapshotTesting
 
 @MainActor
-@Suite(.snapshots(record: .never, diffTool: diffTool))
+@Suite(
+    .disabled(if: attributeGraphVendor == .compute, "Temporarily disabled for Compute snapshot stack overflow. See https://github.com/jcmosc/Compute/issues/47"),
+    .snapshots(record: .never, diffTool: diffTool)
+)
 struct LabelsHiddenModifierUITests {
     @Test
     func toggleLabelsHidden() {

--- a/Example/OpenSwiftUIUITests/View/ToggleUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/ToggleUITests.swift
@@ -6,7 +6,10 @@ import Testing
 import SnapshotTesting
 
 @MainActor
-@Suite(.snapshots(record: .never, diffTool: diffTool))
+@Suite(
+    .disabled(if: attributeGraphVendor == .compute, "Temporarily disabled for Compute snapshot stack overflow. See https://github.com/jcmosc/Compute/issues/47"),
+    .snapshots(record: .never, diffTool: diffTool)
+)
 struct ToggleUITests {
     @Test
     func onAndOffWithDefaultStyle() {

--- a/Example/Tuist/Package.resolved
+++ b/Example/Tuist/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "ce85840ac666117ca10d2b5ccdece485060cdc99f62ed49e9b2bd3ba19c6bc46",
+  "originHash" : "f29d8609b7396a490f6044267bdd2085f2d5ce3aab2aed2de7c0283190c895f4",
   "pins" : [
     {
       "identity" : "compute",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/compute",
+      "location" : "https://github.com/OpenSwiftUIProject/Compute",
       "state" : {
         "revision" : "a8387801fb54836919bec824f99049b28245d0b3",
         "version" : "0.4.1-bugfix.2"
@@ -13,7 +13,7 @@
     {
       "identity" : "equatable",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/equatable",
+      "location" : "https://github.com/OpenSwiftUIProject/equatable",
       "state" : {
         "branch" : "main",
         "revision" : "c50e4f72fdd163a43738dfd4d92bf62c2531f367"
@@ -22,16 +22,16 @@
     {
       "identity" : "opencoregraphics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/opencoregraphics",
+      "location" : "https://github.com/OpenSwiftUIProject/OpenCoreGraphics",
       "state" : {
         "branch" : "main",
-        "revision" : "050239bd42b19a4c8b1ef3936bfb9f3589ecfc46"
+        "revision" : "df5ab4c4dcd0afc8fde978f6a0ad5228bb8aee17"
       }
     },
     {
       "identity" : "openobservation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openswiftuiproject/openobservation",
+      "location" : "https://github.com/OpenSwiftUIProject/OpenObservation",
       "state" : {
         "branch" : "main",
         "revision" : "51c52f318eb3278b1eaa8b724f50d1af9f9f8bae"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "54f62c02c08bb245c5bfdba8f1ac6d7d89e69bd5b95823f2a578e50dfb9b7a38",
+  "originHash" : "435827a6efe6141ae139278a93f96e55cbb704ace4e1f8f2bc212e14886f660a",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -222,8 +222,10 @@ var sharedSwiftSettings: [SwiftSetting] = [
     .define("OPENSWIFTUI_RELEASE_\(releaseVersion)"),
     .unsafeFlags(["-Xfrontend", "-experimental-spi-only-imports"]),
     // Swift 6.3.3 crashes while indexing AppKit with the private framework shims.
-    // FIXME: Tuist duplicates shared Swift settings when generating an
-    // SDK-conditioned OTHER_SWIFT_FLAGS entry, so keep this unconditional.
+    // Tuist used to duplicate unconditional settings into SDK-conditioned OTHER_SWIFT_FLAGS:
+    // https://github.com/tuist/tuist/issues/12377
+    // Fixed by https://github.com/tuist/tuist/pull/12411 in Tuist 4.206.0-canary.16.
+    // FIXME: Keep this unconditional until the project's Tuist version includes that fix.
     .unsafeFlags(["-index-ignore-system-modules"]),
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -222,8 +222,9 @@ var sharedSwiftSettings: [SwiftSetting] = [
     .define("OPENSWIFTUI_RELEASE_\(releaseVersion)"),
     .unsafeFlags(["-Xfrontend", "-experimental-spi-only-imports"]),
     // Swift 6.3.3 crashes while indexing AppKit with the private framework shims.
-    // Keep source indexing enabled while skipping imported system modules.
-    .unsafeFlags(["-index-ignore-system-modules"], .when(platforms: [.macOS])),
+    // FIXME: Tuist duplicates shared Swift settings when generating an
+    // SDK-conditioned OTHER_SWIFT_FLAGS entry, so keep this unconditional.
+    .unsafeFlags(["-index-ignore-system-modules"]),
 ]
 
 if releaseVersion >= 2021 {


### PR DESCRIPTION
## Summary

- Keep `-index-ignore-system-modules` unconditional so Tuist-generated projects do not duplicate shared Swift settings and availability macros.
- Skip the Compute snapshot suites that stack overflow when executed as part of the full UI test plan.
- Wait for the shared snapshot reference lock instead of letting later matrix jobs exit before running their UI tests.
- Refresh package resolutions after the dependency alignment.

## Details

Tuist issue https://github.com/tuist/tuist/issues/12377 causes SDK-conditioned `OTHER_SWIFT_FLAGS` to inherit and repeat the shared flags. The upstream fix is https://github.com/tuist/tuist/pull/12411; the setting remains unconditional until the project uses a Tuist version containing that fix.

The affected Compute snapshot suites recurse through view aliases until TestingHost exhausts its stack. They are disabled only for the Compute attribute graph vendor and remain enabled for other configurations. The shared reference-image recorder now polls its lock every 10 seconds for up to 30 minutes and removes a completed run lock only when its contents still match the inspected owner.

## Validation

- Availability macros occur once in generated iOS and macOS compiler commands.
- The local Compute UI test plan completes without TestingHost crashes after the targeted skips.
- Lock contenders wait for the active recorder rather than skipping their UI test execution.