### PR TITLE
Add dependency bump issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bump-iag.yml
+++ b/.github/ISSUE_TEMPLATE/bump-iag.yml
@@ -1,0 +1,107 @@
+name: Bump IAG
+description: Track an upgrade of OpenSwiftUI's Compute-backed IAG integration.
+title: "Bump IAG to "
+labels:
+  - "type: maintenance"
+  - "area: graph"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        IAG refers to the Compute backend used by OpenSwiftUI's attribute graph shims. Use this form to keep its binary and source revisions, generated project, CI, and documentation in sync.
+
+  - type: input
+    id: current-binary-version
+    attributes:
+      label: Current binary version
+      description: The Compute binary version currently pinned in `mise.compute.toml`.
+      placeholder: "0.4.1"
+    validations:
+      required: true
+
+  - type: input
+    id: target-binary-version
+    attributes:
+      label: Target binary version
+      description: The proposed Compute binary version. Enter "Unchanged" if this pin does not move.
+      placeholder: "0.5.0"
+    validations:
+      required: true
+
+  - type: input
+    id: current-source-version
+    attributes:
+      label: Current source version
+      description: The Compute source tag or revision currently pinned in `mise.compute.toml`.
+      placeholder: "0.4.1-bugfix.2"
+    validations:
+      required: true
+
+  - type: input
+    id: target-source-version
+    attributes:
+      label: Target source version
+      description: The proposed Compute source tag or revision. Enter "Unchanged" if this pin does not move.
+      placeholder: "0.5.0"
+    validations:
+      required: true
+
+  - type: input
+    id: upstream-reference
+    attributes:
+      label: Upstream release or revision
+      description: Link the Compute release, tag, commit, or pull request being adopted.
+      placeholder: "https://github.com/OpenSwiftUIProject/Compute/releases/tag/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: resolved-issues
+    attributes:
+      label: Problems solved by the upgrade
+      description: Summarize fixes and compatibility changes, linking relevant Compute and OpenSwiftUI issues.
+      placeholder: |
+        - Fixes ...
+        - Includes OpenSwiftUIProject/Compute#...
+        - Unblocks OpenSwiftUIProject/OpenSwiftUI#...
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior-changes
+    attributes:
+      label: Behavior and compatibility changes
+      description: Note ABI, deployment target, Swift toolchain, snapshot, or graph behavior changes that need review.
+      placeholder: Describe the expected impact or write "None".
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: update-scope
+    attributes:
+      label: Update scope
+      options:
+        - label: Update the Compute binary and source versions in `mise.compute.toml`.
+        - label: Update the fallback revision in `Scripts/CI/compute_setup.sh`.
+        - label: Update Compute versions pinned directly by CI workflows.
+        - label: Regenerate `Example/Tuist/Package.resolved`.
+        - label: Update documentation that names the current Compute versions or known limitations.
+
+  - type: checkboxes
+    id: validation
+    attributes:
+      label: Validation
+      options:
+        - label: Resolve and generate the Example project with `Example/setup.sh --compute`.
+        - label: Build the affected Compute-backed OpenSwiftUI targets or XCFramework slices.
+        - label: Run the `swiftui-renderer-iag` UI test configuration on the affected platforms.
+        - label: Run the `openswiftui-renderer-iag` UI test configuration on the affected platforms.
+        - label: Review newly passing, failing, skipped, or expected-failure IAG snapshots.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add logs, benchmark results, snapshot comparisons, or rollout notes.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bump-tuist.yml
+++ b/.github/ISSUE_TEMPLATE/bump-tuist.yml
@@ -1,0 +1,88 @@
+name: Bump Tuist
+description: Track an upgrade of the Tuist CLI used to generate OpenSwiftUI projects.
+title: "Bump Tuist to "
+labels:
+  - "type: build"
+  - "area: tooling"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to track a Tuist upgrade, the upstream changes that motivate it, and validation of both OpenSwiftUI generation environments.
+
+  - type: input
+    id: current-version
+    attributes:
+      label: Current version
+      description: The Tuist version currently pinned by OpenSwiftUI.
+      placeholder: "4.203.4"
+    validations:
+      required: true
+
+  - type: input
+    id: target-version
+    attributes:
+      label: Target version
+      description: The Tuist version this issue proposes adopting.
+      placeholder: "4.206.0"
+    validations:
+      required: true
+
+  - type: input
+    id: upstream-reference
+    attributes:
+      label: Upstream release or pull request
+      description: Link the Tuist release, changelog, or pull request that contains the relevant changes.
+      placeholder: "https://github.com/tuist/tuist/releases/tag/4.206.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: resolved-issues
+    attributes:
+      label: Problems solved by the upgrade
+      description: Explain why the upgrade is needed and link the affected upstream and OpenSwiftUI issues.
+      placeholder: |
+        - Fixes ...
+        - Includes tuist/tuist#...
+        - Unblocks OpenSwiftUIProject/OpenSwiftUI#...
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility-notes
+    attributes:
+      label: Compatibility and migration notes
+      description: Summarize manifest changes, generated-project differences, deprecations, or workarounds that can be removed.
+      placeholder: Describe any required migration or write "None".
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: update-scope
+    attributes:
+      label: Update scope
+      options:
+        - label: Update the Tuist pin in `mise.toml`.
+        - label: Update the Tuist pin in `mise.compute.toml`.
+        - label: Review scripts, workflows, and documentation for version-specific behavior.
+        - label: Remove superseded workarounds when the minimum supported Tuist version allows it.
+
+  - type: checkboxes
+    id: validation
+    attributes:
+      label: Validation
+      options:
+        - label: Confirm `mise exec -- tuist version` reports the target version.
+        - label: Confirm `mise --env compute exec -- tuist version` reports the target version.
+        - label: Generate the default Example project with `Example/setup.sh`.
+        - label: Generate the Compute Example project with `Example/setup.sh --compute`.
+        - label: Build or test the generated projects affected by the upstream changes.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add logs, generated-project diffs, or other information useful during the upgrade.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- add a Tuist upgrade issue form that captures version changes, upstream fixes, migration notes, and default/Compute validation
- add an IAG upgrade issue form that tracks Compute binary and source pins, integration updates, and IAG UI test coverage
- apply the existing build, tooling, maintenance, and graph labels automatically