### PR TITLE
Fix clipped shape rendering with the SwiftUI renderer

### DIFF
--- a/Example/OpenSwiftUIUITests/Render/RendererEffect/ClipEffectUITests.swift
+++ b/Example/OpenSwiftUIUITests/Render/RendererEffect/ClipEffectUITests.swift
@@ -8,7 +8,6 @@ import SnapshotTesting
 @MainActor
 @Suite(.snapshots(record: .never, diffTool: diffTool))
 struct ClipEffectUITests {
-    // FIXME: Investigate the diff. precision should be 1.0
 
     @Test
     func clipShapeCircle() {
@@ -19,7 +18,7 @@ struct ClipEffectUITests {
                     .clipShape(Circle())
             }
         }
-        openSwiftUIAssertSnapshot(of: ContentView(), precision: 0.99)
+        openSwiftUIAssertSnapshot(of: ContentView())
     }
 
     @Test
@@ -31,7 +30,7 @@ struct ClipEffectUITests {
                     .clipShape(RoundedRectangle(cornerRadius: 15))
             }
         }
-        openSwiftUIAssertSnapshot(of: ContentView(), precision: 0.99)
+        openSwiftUIAssertSnapshot(of: ContentView())
     }
 
     @Test
@@ -43,7 +42,7 @@ struct ClipEffectUITests {
                     .clipShape(Capsule())
             }
         }
-        openSwiftUIAssertSnapshot(of: ContentView(), precision: 0.99)
+        openSwiftUIAssertSnapshot(of: ContentView())
     }
 
     @Test
@@ -70,7 +69,6 @@ struct ClipEffectUITests {
                     .clipShape(Ellipse())
             }
         }
-        openSwiftUIAssertSnapshot(of: ContentView(), precision: 0.99)
+        openSwiftUIAssertSnapshot(of: ContentView())
     }
 }
-

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
@@ -9,6 +9,11 @@
 import OpenSwiftUI_SPI
 package import Foundation
 
+#if OPENSWIFTUI_SWIFTUI_RENDERER
+@_silgen_name("_OpenSwiftUI_LinkSwiftUIRendererInterposers")
+private func linkSwiftUIRendererInterposers()
+#endif
+
 protocol ViewRendererBase: AnyObject {
     var platform: DisplayList.ViewUpdater.Platform { get }
 
@@ -173,6 +178,7 @@ extension DisplayList {
 
             // validateSwiftUIRendererABI
             #if OPENSWIFTUI_SWIFTUI_RENDERER
+            linkSwiftUIRendererInterposers()
             let message = "Unsupported SwiftUI Renderer ABI version. Supported runtime ranges: iOS/tvOS [18.5, 26.0), macOS [15.5, 26.0), watchOS [11.5, 26.0)."
             guard #available(iOS 18.5, macOS 15.5, tvOS 18.5, watchOS 11.5, *) else {
                 // Stop if below SwiftUI 6.5.4 version

--- a/Sources/OpenSwiftUI_SPI/Util/Interpose.c
+++ b/Sources/OpenSwiftUI_SPI/Util/Interpose.c
@@ -23,6 +23,11 @@ static bool my_kdebug_is_enabled(uint32_t debugid) {
 #include <os/log.h>
 #include <CoreFoundation/CoreFoundation.h>
 
+// OpenSwiftUI_SPI is linked as a static framework by generated projects. Keep
+// an explicit reference to this translation unit so the linker extracts the
+// interpose registrations from the archive.
+void _OpenSwiftUI_LinkSwiftUIRendererInterposers(void) {}
+
 static os_log_t interpose_log(void) {
     static dispatch_once_t onceToken;
     static os_log_t log = NULL;


### PR DESCRIPTION
## Summary

Generated projects package `OpenSwiftUI_SPI` as a static framework, allowing the linker to omit the translation unit containing the SwiftUI renderer interpose registrations.

Add an explicit link anchor so those registrations are included when using the SwiftUI renderer. This restores the expected color handling for clipped shapes and allows `ClipEffectUITests` to use exact snapshot comparisons.