### PR TITLE
Work around Tuist resource accessor header injection

### DIFF
--- a/Example/Tuist/Patches/OpenSwiftUI_SPI-resource-bundle-accessor.patch
+++ b/Example/Tuist/Patches/OpenSwiftUI_SPI-resource-bundle-accessor.patch
@@ -1,0 +1,12 @@
+--- a/Derived/Sources/TuistBundle+OpenSwiftUI_SPI.h
++++ b/Derived/Sources/TuistBundle+OpenSwiftUI_SPI.h
+@@ -1 +1,3 @@
++#if __OBJC__
++
+ #import <Foundation/Foundation.h>
+@@ -13 +15,3 @@
+ #endif
+\ No newline at end of file
++
++#endif
+\ No newline at end of file

--- a/Example/setup.sh
+++ b/Example/setup.sh
@@ -46,3 +46,10 @@ fi
 run_mise install
 run_mise exec -- tuist install
 run_mise exec -- tuist generate --no-open
+
+# Tuist currently injects Objective-C resource accessor headers into every
+# C-family source through GCC_PREFIX_HEADER. Keep the generated header inert
+# for plain C sources until Tuist scopes the injection to Objective-C sources.
+# https://github.com/tuist/tuist/issues/12559
+patch -d "$SCRIPT_DIR/.." -p1 < \
+  "$SCRIPT_DIR/Tuist/Patches/OpenSwiftUI_SPI-resource-bundle-accessor.patch"


### PR DESCRIPTION
## Summary

- Guard the generated resource accessor header so plain C translation units do not parse Objective-C Foundation declarations.
- Apply the workaround automatically after generating the Example workspace.