### PR TITLE
Add pull request authoring guidance

### DIFF
--- a/.agents/skills/openswiftui-pr-authoring/SKILL.md
+++ b/.agents/skills/openswiftui-pr-authoring/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: openswiftui-pr-authoring
+description: Draft or review public OpenSwiftUI pull request titles and bodies. Use when proposing, creating, updating, or reviewing an OpenSwiftUI PR.
+---
+
+# OpenSwiftUI Pull Request Authoring
+
+- Write PR titles and bodies in English and scope them to the committed diff.
+- Use a concise sentence-case title that describes the outcome.
+- Use `## Summary` for the main body. Start the first word of every summary
+  bullet with a capital letter, and keep the bullets parallel and
+  outcome-focused.
+- Omit build commands, test invocations, contributor-workflow boilerplate,
+  remaining TODOs, and unrelated follow-up work.
+- Keep internal investigation methods out of public wording. Describe results
+  in terms of compatibility, behavior, validation, or implementation.
+- For stacked PRs, describe only the current layer. Add a `## Stack` section to
+  a dependent PR and identify its direct dependency as `Depends on #<number>`.
+- Drafting a PR does not authorize pushing branches or creating or updating a
+  PR. Obtain the required approval before changing remote state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@ swift test --enable-code-coverage
 swift test --list-tests
 ```
 
+## Test Authoring
+
+Follow `.agents/skills/openswiftui-test-authoring/SKILL.md`.
+
+## Pull Requests
+
+Follow `.agents/skills/openswiftui-pr-authoring/SKILL.md`.
+
 ## Dependencies Setup
 
 The project requires cloning additional repositories in the same parent directory:


### PR DESCRIPTION
## Summary

- Add repository guidance for writing concise, public-facing pull request titles and bodies.
- Link the test-authoring and pull-request-authoring skills from `AGENTS.md`.

## Stack

Depends on #1013.