### PR TITLE
Add system format style UI coverage

### DIFF
--- a/Example/OpenSwiftUIUITests/View/Text/TextUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/Text/TextUITests.swift
@@ -19,6 +19,14 @@ struct TextUITests {
         openSwiftUIAssertSnapshot(of: TextFormatStyleExample())
     }
 
+    @Test
+    func systemFormatStyleExample() {
+        openSwiftUIAssertSnapshot(
+            of: TextSystemFormatStyleExample(),
+            size: CGSize(width: 320, height: 260)
+        )
+    }
+
     @Test("Verify text background height is normal")
     func textHeight() {
         openSwiftUIAssertSnapshot(of: TextBackgroundHeightExample())

--- a/Example/Shared/View/Text/TextExample.swift
+++ b/Example/Shared/View/Text/TextExample.swift
@@ -31,6 +31,89 @@ struct TextFormatStyleExample: View {
     }
 }
 
+struct TextSystemFormatStyleExample: View {
+    private let start = Date(timeIntervalSinceReferenceDate: 1_000_000)
+    private let showsHoursVariants = [true, false]
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    var body: some View {
+        let end = start.addingTimeInterval(7_200)
+        let futureStart = Date(timeIntervalSince1970: 4_102_444_800)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 16) {
+                ForEach(showsHoursVariants, id: \.self) { showsHours in
+                    Text(
+                        start.addingTimeInterval(3_665),
+                        format: SystemFormatStyle.Timer.timer(
+                            countingUpIn: start..<end,
+                            showsHours: showsHours,
+                            maxPrecision: .seconds(1)
+                        )
+                    )
+                }
+            }
+            HStack(spacing: 16) {
+                ForEach(showsHoursVariants, id: \.self) { showsHours in
+                    Text(
+                        start.addingTimeInterval(65),
+                        format: SystemFormatStyle.Timer.timer(
+                            countingDownIn: start..<end,
+                            showsHours: showsHours,
+                            maxPrecision: .seconds(1)
+                        )
+                    )
+                }
+            }
+            HStack(spacing: 16) {
+                ForEach(showsHoursVariants, id: \.self) { showsHours in
+                    Text(
+                        start.addingTimeInterval(3_665),
+                        format: SystemFormatStyle.Stopwatch.stopwatch(
+                            startingAt: start,
+                            showsHours: showsHours,
+                            maxPrecision: .seconds(1)
+                        )
+                    )
+                }
+            }
+            Text(
+                start.addingTimeInterval(90),
+                format: SystemFormatStyle.DateOffset.offset(
+                    to: start,
+                    allowedFields: [.minute, .second],
+                    maxFieldCount: 2,
+                    sign: .always(includingZero: false)
+                )
+            )
+            Text(
+                start.addingTimeInterval(90 * 60),
+                format: SystemFormatStyle.DateReference.reference(
+                    to: start,
+                    allowedFields: [.day, .hour, .minute],
+                    maxFieldCount: 2,
+                    thresholdField: .day
+                )
+            )
+            Text(
+                futureStart.addingTimeInterval(65),
+                format: SystemFormatStyle.Stopwatch.stopwatch(
+                    startingAt: futureStart,
+                    maxPrecision: .seconds(1)
+                )
+            )
+        }
+        .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+        .environment(\.calendar, calendar)
+        .environment(\.timeZone, calendar.timeZone)
+        .padding()
+    }
+}
+
 struct TextBackgroundHeightExample: View {
     var body: some View {
         Text("Hello, world!")

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+AttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+AttributedString.swift
@@ -597,6 +597,29 @@ extension AttributedString {
 }
 
 extension NSAttributedString {
+    // OpenSwiftUI Addition:
+    // Foundation's unscoped bridge explicitly loads the system SwiftUI
+    // attribute scope, but does not discover OpenSwiftUI's scope. Route this
+    // source-compatible initializer through the explicit OpenSwiftUI bridge so
+    // attributes such as OpenSwiftUI.FontModifiers are preserved.
+    //
+    // Pseudo code in the current Foundation implementation
+    //
+    //    guard let handle = dlopen(
+    //        "/System/Library/Frameworks/SwiftUI.framework/SwiftUI",
+    //        RTLD_NOLOAD
+    //    ),
+    //    let symbol = dlsym(
+    //        handle,
+    //        "$s10Foundation15AttributeScopesO7SwiftUIE0D12UIAttributesVN"
+    //    ) else {
+    //        return nil
+    //    }
+    @inline(__always)
+    package convenience init(_ attributedString: AttributedString) {
+        self.init(openSwiftUIAttributedString: attributedString)
+    }
+
     convenience init(openSwiftUIAttributedString attributedString: AttributedString) {
         #if canImport(Darwin)
         let transformedAttributedString = CoreGlue2.shared.transformingEquivalentAttributes(attributedString)

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+AttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+AttributedString.swift
@@ -597,6 +597,7 @@ extension AttributedString {
 }
 
 extension NSAttributedString {
+    #if canImport(Darwin)
     // OpenSwiftUI Addition:
     // Foundation's unscoped bridge explicitly loads the system SwiftUI
     // attribute scope, but does not discover OpenSwiftUI's scope. Route this
@@ -619,6 +620,7 @@ extension NSAttributedString {
     package convenience init(_ attributedString: AttributedString) {
         self.init(openSwiftUIAttributedString: attributedString)
     }
+    #endif
 
     convenience init(openSwiftUIAttributedString attributedString: AttributedString) {
         #if canImport(Darwin)

--- a/Sources/OpenSwiftUICore/View/Text/FormatStyle/SystemFormatStyle+Timer.swift
+++ b/Sources/OpenSwiftUICore/View/Text/FormatStyle/SystemFormatStyle+Timer.swift
@@ -643,39 +643,43 @@ extension SystemFormatStyle.Timer: FormatStyle {
         let pattern: Duration.TimeFormatStyle.Pattern
         let applicableRange: ClosedRange<Duration>?
         let showsSubseconds: Bool
-        if shouldShowHoursMinutesSeconds {
-            let fractionalDigits = maximumFieldCount > 3
-                ? smallestUnit.fractionalDigits
-                : 0
-            let padHourToLength = countingMode == .stopwatch && !forceNoPadding
-                ? (sizeVariant <= .compact ? 2 : 1)
-                : 1
-            pattern = .hourMinuteSecond(
-                padHourToLength: padHourToLength,
-                fractionalSecondsLength: fractionalDigits,
-                roundFractionalSeconds: rounding
-            )
-            applicableRange = nil
-            showsSubseconds = fractionalDigits > 0
-        } else if shouldShowHoursMinutes {
-            if !inputDoesNotRoundToHour,
-               input < .seconds(3600)
-            {
-                pattern = .hourMinute(
-                    padHourToLength: 1,
-                    roundSeconds: rounding
-                )
-                applicableRange =
-                    (Duration.seconds(3600) - subHourRoundingIncrement)...Duration.seconds(3600)
-            } else {
-                pattern = .hourMinute(
-                    padHourToLength: 1,
-                    roundSeconds: .towardZero
+        if showsHours && !inputDoesNotRoundToHour {
+            if shouldShowHoursMinutesSeconds {
+                let fractionalDigits = maximumFieldCount > 3
+                    ? smallestUnit.fractionalDigits
+                    : 0
+                let padHourToLength = countingMode == .stopwatch && !forceNoPadding
+                    ? (sizeVariant <= .compact ? 2 : 1)
+                    : 1
+                pattern = .hourMinuteSecond(
+                    padHourToLength: padHourToLength,
+                    fractionalSecondsLength: fractionalDigits,
+                    roundFractionalSeconds: rounding
                 )
                 applicableRange = nil
+                showsSubseconds = fractionalDigits > 0
+            } else if shouldShowHoursMinutes {
+                if !inputDoesNotRoundToHour,
+                   input < .seconds(3600)
+                {
+                    pattern = .hourMinute(
+                        padHourToLength: 1,
+                        roundSeconds: rounding
+                    )
+                    applicableRange =
+                        (Duration.seconds(3600) - subHourRoundingIncrement)...Duration.seconds(3600)
+                } else {
+                    pattern = .hourMinute(
+                        padHourToLength: 1,
+                        roundSeconds: .towardZero
+                    )
+                    applicableRange = nil
+                }
+                showsSubseconds = false
+            } else {
+                return nil
             }
-            showsSubseconds = false
-        } else if !(Duration.seconds(1) < subHourRoundingIncrement) {
+        } else if !(Duration.seconds(3600) < subHourRoundingIncrement) {
             let fractionalDigits = maximumFieldCount > 3
                 ? smallestUnit.fractionalDigits
                 : 0

--- a/Sources/OpenSwiftUICore/View/Text/FormatStyle/SystemFormatStyle+Timer.swift
+++ b/Sources/OpenSwiftUICore/View/Text/FormatStyle/SystemFormatStyle+Timer.swift
@@ -1166,7 +1166,7 @@ extension SystemFormatStyle.Timer: InterfaceIdiomDependentFormatStyle {
         _ idiom: AnyInterfaceIdiom
     ) -> SystemFormatStyle.Timer {
         var style = self
-        style.forceNoPadding = !idiom.accepts(ComplicationInterfaceIdiom.self)
+        style.redactUsingDashes = !idiom.accepts(ComplicationInterfaceIdiom.self)
         return style
     }
 }

--- a/Tests/OpenSwiftUICoreTests/View/Text/FormatStyle/SystemFormatStyleTimerTests.swift
+++ b/Tests/OpenSwiftUICoreTests/View/Text/FormatStyle/SystemFormatStyleTimerTests.swift
@@ -73,12 +73,12 @@ struct SystemFormatStyleTimerTests {
         )
         .locale(locale)
 
-        #expect(plainText(countup.format(start.addingTimeInterval(-1))) == "0:00:00")
-        #expect(plainText(countup.format(start.addingTimeInterval(65))) == "0:01:05")
-        #expect(plainText(countup.format(end.addingTimeInterval(1))) == "0:01:40")
-        #expect(plainText(countdown.format(start.addingTimeInterval(-1))) == "0:01:40")
-        #expect(plainText(countdown.format(start.addingTimeInterval(65))) == "0:00:35")
-        #expect(plainText(countdown.format(end.addingTimeInterval(1))) == "0:00:00")
+        #expect(plainText(countup.format(start.addingTimeInterval(-1))) == "0:00")
+        #expect(plainText(countup.format(start.addingTimeInterval(65))) == "1:05")
+        #expect(plainText(countup.format(end.addingTimeInterval(1))) == "1:40")
+        #expect(plainText(countdown.format(start.addingTimeInterval(-1))) == "1:40")
+        #expect(plainText(countdown.format(start.addingTimeInterval(65))) == "0:35")
+        #expect(plainText(countdown.format(end.addingTimeInterval(1))) == "0:00")
     }
 
     @Test
@@ -89,8 +89,8 @@ struct SystemFormatStyleTimerTests {
         )
         .locale(locale)
 
-        #expect(plainText(stopwatch.format(start.addingTimeInterval(-1))) == "00:00:0000")
-        #expect(plainText(stopwatch.format(start.addingTimeInterval(1.25))) == "00:00:0125")
+        #expect(plainText(stopwatch.format(start.addingTimeInterval(-1))) == "00:0000")
+        #expect(plainText(stopwatch.format(start.addingTimeInterval(1.25))) == "00:0125")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add deterministic rendered coverage for timer, stopwatch, date offset, and date reference format styles.
- Correct timer pattern selection and interface idiom handling exposed by the expanded coverage.
- Preserve OpenSwiftUI attributed-string attributes when bridging formatted text through NSAttributedString.