### PR TITLE
Fix ProgressViewUITests failure on macOS

### DIFF
--- a/Example/Shared/View/Text/TextExample.swift
+++ b/Example/Shared/View/Text/TextExample.swift
@@ -22,12 +22,21 @@ struct TextForegroundExample: View {
 struct TextFormatStyleExample: View {
     @State private var myDate = Date(timeIntervalSince1970: 1_767_225_600)
 
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
     var body: some View {
         VStack {
             Text(myDate, format: Date.FormatStyle(date: .numeric, time: .omitted))
             Text(myDate, format: Date.FormatStyle(date: .complete, time: .complete))
             Text(myDate, format: Date.FormatStyle().hour(.defaultDigitsNoAMPM).minute())
         }
+        .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+        .environment(\.calendar, calendar)
+        .environment(\.timeZone, calendar.timeZone)
     }
 }
 

--- a/Sources/COpenSwiftUI/Shims/AppKit/NSView_Private.h
+++ b/Sources/COpenSwiftUI/Shims/AppKit/NSView_Private.h
@@ -20,6 +20,14 @@
 - (void)_updateLayerGeometryFromView;
 - (void)_updateLayerShadowFromView;
 - (void)_updateLayerShadowColorFromView;
+
+- (void)measureMin:(CGSize * _Nonnull)min
+               max:(CGSize * _Nonnull)max
+             ideal:(CGSize * _Nonnull)ideal;
+- (void)measureMin:(CGSize * _Nonnull)min
+               max:(CGSize * _Nonnull)max
+             ideal:(CGSize * _Nonnull)ideal
+stretchingPriority:(float)stretchingPriority;
 @end
 
 #endif /* __has_include(<AppKit/AppKit.h>) */

--- a/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewHost.swift
+++ b/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewHost.swift
@@ -126,9 +126,80 @@ where Content: PlatformViewRepresentable {
         let height = dimension(value: intrinsicContentSize.height, axis: .vertical)
         return .init(width: width, height: height)
         #elseif os(macOS)
-        let selector = Selector(("measureMin:max:ideal:stretchingPriority:"))
-        // TODO
-        return .init()
+        func validateDimension(
+            min: CGFloat,
+            ideal: CGFloat,
+            max: CGFloat
+        ) -> _LayoutTraits.Dimension {
+            let infinity = CGFloat.infinity
+            var min = min == .greatestFiniteMagnitude ? infinity : min
+            var ideal = ideal == .greatestFiniteMagnitude ? infinity : ideal
+            var max = max == .greatestFiniteMagnitude ? infinity : max
+            if !(0 <= min && min < infinity) {
+                Log.externalWarning(
+                    String(
+                        format: "%@ has a minimum length (%lf) that doesn't satisfy 0 <= min < .infinity.",
+                        self,
+                        min
+                    )
+                )
+                min = .zero
+            }
+            if !(min <= max) {
+                Log.externalWarning(
+                    String(
+                        format: "%@ has an maximum length (%lf) that doesn't satisfy min (%lf) <= max (%lf).",
+                        self,
+                        max,
+                        min,
+                        max
+                    )
+                )
+                max = min
+            }
+            if !(ideal.isFinite && min <= ideal && ideal <= max) {
+                Log.externalWarning(
+                    String(
+                        format: "%@ has an ideal length (%lf) that doesn't satisfy min (%lf) <= ideal <= max (%lf) < .infinity.",
+                        self,
+                        ideal,
+                        min,
+                        max
+                    )
+                )
+                ideal = min
+            }
+            return .init(min: min, ideal: ideal, max: max)
+        }
+
+        var min = CGSize.zero
+        var max = CGSize.zero
+        var ideal = CGSize.zero
+        let options = Content.layoutOptions(representedViewProvider)
+        let prioritySelector = #selector(
+            NSView.measureMin(_:max:ideal:stretchingPriority:)
+        )
+        if options.contains(._1), responds(to: prioritySelector) {
+            measureMin(
+                &min,
+                max: &max,
+                ideal: &ideal,
+                stretchingPriority: 500
+            )
+        } else {
+            measureMin(&min, max: &max, ideal: &ideal)
+        }
+        let width = validateDimension(
+            min: min.width,
+            ideal: ideal.width,
+            max: max.width
+        )
+        let height = validateDimension(
+            min: min.height,
+            ideal: ideal.height,
+            max: max.height
+        )
+        return .init(width: width, height: height)
         #endif
     }
 

--- a/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewRepresentableLayoutOptions.swift
+++ b/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewRepresentableLayoutOptions.swift
@@ -11,6 +11,8 @@
 public struct _PlatformViewRepresentableLayoutOptions: OptionSet {
     public let rawValue: Int
 
+    static var _1: _PlatformViewRepresentableLayoutOptions { .init(rawValue: 1 << 1) }
+
     @_spi(Private)
     @available(OpenSwiftUI_v5_0, *)
     public static let propagatesSafeArea: _PlatformViewRepresentableLayoutOptions = .init(rawValue: 1 << 2)

--- a/Sources/OpenSwiftUI/View/Control/ProgressView/LinearProgressViewStyle.swift
+++ b/Sources/OpenSwiftUI/View/Control/ProgressView/LinearProgressViewStyle.swift
@@ -6,6 +6,7 @@
 //  Status: Complete
 //  ID: 6399EAC5515CA9566698FD9D51220283 (SwiftUI)
 
+import Foundation
 public import OpenSwiftUICore
 
 // MARK: - ProgressViewStyle + Linear
@@ -48,7 +49,14 @@ public struct LinearProgressViewStyle: ProgressViewStyle {
     }
 
     public func makeBody(configuration: Configuration) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        #if os(macOS)
+        let spacing: CGFloat = 0
+        let currentValueLabelFont: Font = .subheadline
+        #else
+        let spacing: CGFloat = 4
+        let currentValueLabelFont: Font = .caption
+        #endif
+        VStack(alignment: .leading, spacing: spacing) {
             if !isLinkedOnOrAfter(.v5) || labelsVisibility != .hidden {
                 configuration.label
             }
@@ -56,7 +64,7 @@ public struct LinearProgressViewStyle: ProgressViewStyle {
             if !isLinkedOnOrAfter(.v5) || labelsVisibility != .hidden {
                 configuration.currentValueLabel
                     .defaultForegroundColor(.secondary)
-                    .font(.caption)
+                    .font(currentValueLabelFont)
                     .monospacedDigit()
             }
         }


### PR DESCRIPTION
## Summary

- Measure AppKit platform views using intrinsic layout constraints for representables.
- Match linear progress spacing and current-value typography on macOS while preserving iOS behavior.