### PR TITLE
Update OpenCombine integration to 0.16.0

### DIFF
--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -17,9 +17,11 @@ configureOpenSwiftUIEnvironment(provider: PackageContextEnvironmentProvider())
 let exampleServerConfiguration = OpenSwiftUIExampleServerConfiguration.resolve()
 let enableLookInsideServer = exampleServerConfiguration.enableLookInsideServer
 let enableLookInServer = exampleServerConfiguration.enableLookInServer
+let openCombineCondition = envBoolValue("OPENCOMBINE")
 #else
 let enableLookInsideServer = Context.environment["OPENSWIFTUI_EXAMPLE_LOOKINSIDE_SERVER"] == "1"
 let enableLookInServer = Context.environment["OPENSWIFTUI_EXAMPLE_LOOKIN_SERVER"] == "1"
+let openCombineCondition = Context.environment["OPENSWIFTUI_OPENCOMBINE"] == "1"
 #endif
 
 var dependencies: [PackageDescription.Package.Dependency] = [
@@ -34,6 +36,12 @@ var dependencies: [PackageDescription.Package.Dependency] = [
     .package(url: "https://github.com/OpenSwiftUIProject/SymbolLocator.git", from: "0.2.0"),
     .package(url: "https://github.com/OpenSwiftUIProject/swift-snapshot-testing.git", exact: "1.19.3"),
 ]
+
+if openCombineCondition {
+    dependencies.append(
+        .package(url: "https://github.com/OpenSwiftUIProject/OpenCombine.git", from: "0.16.0")
+    )
+}
 
 if enableLookInsideServer {
     dependencies.append(.package(url: "https://github.com/LookInsideApp/LookInside-Release.git", from: "0.2.2"))

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fdcca3afece30410c054d1dbaa77cb74480dc14180740ca42acde3decedfb888",
+  "originHash" : "3482eb6440e1059ead3596c30808f817c4758ff588afaca85b25a988276317ae",
   "pins" : [
     {
       "identity" : "darwinprivateframeworks",

--- a/Package.swift
+++ b/Package.swift
@@ -936,7 +936,7 @@ if useLocalDeps {
 
 if openCombineCondition {
     package.dependencies.append(
-        .package(url: "https://github.com/OpenSwiftUIProject/OpenCombine.git", from: "0.15.0")
+        .package(url: "https://github.com/OpenSwiftUIProject/OpenCombine.git", from: "0.16.0")
     )
     cOpenSwiftUITarget.addOpenCombineCSettings()
     openSwiftUICoreTarget.addOpenCombineSettings()

--- a/Sources/OpenSwiftUI/Export.swift
+++ b/Sources/OpenSwiftUI/Export.swift
@@ -15,3 +15,9 @@ package typealias UniqueID = OpenSwiftUICore.UniqueID
 #if canImport(CoreGraphics)
 @_exported import CoreGraphics
 #endif
+
+#if canImport(OpenCombine)
+public import OpenCombine
+public typealias Published = OpenCombine.Published
+public typealias ObservableObject = OpenCombine.ObservableObject
+#endif

--- a/Sources/OpenSwiftUI/View/Control/ProgressView/ProgressView+Foundation.swift
+++ b/Sources/OpenSwiftUI/View/Control/ProgressView/ProgressView+Foundation.swift
@@ -36,7 +36,8 @@ extension Foundation.Progress {
         )
     }
 
-    #if !OPENSWIFTUI_OPENCOMBINE
+    #if canImport(ObjectiveC)
+    // OpenCombine also support this API on Darwin since 0.16.0
     fileprivate typealias UIStatePublisher = Publishers.Map<
         Publishers.CombineLatest4<
             NSObject.KeyValueObservingPublisher<Foundation.Progress, Int64>,
@@ -70,12 +71,11 @@ extension Foundation.Progress {
         }
     }
     #else
-    // TODO: Implement NSObject.KeyValueObservingPublisher in OpenCombine
     fileprivate typealias UIStatePublisher = AnyPublisher<UIState, Never>
 
     fileprivate var uiStatePublisher: UIStatePublisher {
-        // [AI] OpenCombineFoundation does not provide KVO publishers. Sample
-        // Progress while the graph-owned subscription is active instead.
+        // Sample Progress while the graph-owned subscription is active on
+        // platforms without Objective-C KVO support.
         Foundation.Timer.publish(
             every: 1.0 / 30.0,
             on: .main,


### PR DESCRIPTION
## Summary

- Update the optional OpenCombine dependency to 0.16.0.
- Add OpenCombine to the Tuist package configuration when enabled.
- Export the OpenCombine Published and ObservableObject compatibility aliases.
- Use KVO-backed Progress observation on Objective-C platforms while retaining the polling fallback elsewhere.