### PR TITLE
Implement foreground layer renderer effects

### DIFF
--- a/Sources/OpenSwiftUI/View/Control/ProgressView/ArchivableProgressView.swift
+++ b/Sources/OpenSwiftUI/View/Control/ProgressView/ArchivableProgressView.swift
@@ -76,7 +76,7 @@ struct ArchivableCircularProgressView: View {
                 )
                 .frame(height: min(proxy.size.width, proxy.size.height) * 0.5)
                 .labelStyle(.iconOnly)
-                .modifier(_ForegroundLayerViewModifier())
+                .foregroundLayer()
                 .multilineTextAlignment(.center)
             }
         }
@@ -195,9 +195,6 @@ struct LinearCapsuleGauge: View {
         EmptyView()
     }
 }
-
-// FIXME
-typealias _ForegroundLayerViewModifier = EmptyModifier
 
 extension View {
     func labelStyle(_ style: LabelStyle) -> some View {

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListTransforms.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListTransforms.swift
@@ -9,9 +9,12 @@
 package import OpenAttributeGraphShims
 
 extension DisplayList {
-//    package mutating func insertLayerFilters(matrices: [_ForegroundLayerLevel : _ColorMatrix], version: DisplayList.Version, premultiplied: Bool) {
-//
-//    }
+    package mutating func insertLayerFilters(
+        matrices: [_ForegroundLayerLevel: _ColorMatrix],
+        version: DisplayList.Version,
+        premultiplied: Bool
+    ) {
+    }
 
     package mutating func applyViewGraphTransform(time: Attribute<Time>, version: DisplayList.Version) {
         // TODO

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListTransforms.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListTransforms.swift
@@ -2,11 +2,12 @@
 //  DisplayListTransforms.swift
 //  OpenSwiftUICore
 //
-//  Audited for 6.0.87
-//  Status: WIP
+//  Audited for 6.5.4
+//  Status: Complete (TBA)
 //  ID: 8C82E31DBCFF23E23B8937F47207F4D1 (SwiftUICore)
 
 package import OpenAttributeGraphShims
+package import OpenCoreGraphicsShims
 
 extension DisplayList {
     package mutating func insertLayerFilters(
@@ -14,9 +15,315 @@ extension DisplayList {
         version: DisplayList.Version,
         premultiplied: Bool
     ) {
+        var transform = ForegroundTransform(
+            matrices: matrices,
+            version: version,
+            premultiplied: premultiplied
+        )
+        transform.apply(to: &self)
     }
 
-    package mutating func applyViewGraphTransform(time: Attribute<Time>, version: DisplayList.Version) {
-        // TODO
+    package mutating func applyViewGraphTransform(
+        time: Attribute<Time>,
+        version: DisplayList.Version
+    ) {
+        var transform = ViewGraphTransform(
+            time: time,
+            version: version
+        )
+        transform.apply(to: &self)
+    }
+}
+
+// MARK: - ForegroundTransform [TBA]
+
+private struct ForegroundTransform {
+    var matrices: [_ForegroundLayerLevel: _ColorMatrix]
+    let properties: DisplayList.Properties
+    let version: DisplayList.Version
+    let premultiplied: Bool
+    var level: _ForegroundLayerLevel = .none
+
+    init(
+        matrices: [_ForegroundLayerLevel: _ColorMatrix],
+        version: DisplayList.Version,
+        premultiplied: Bool
+    ) {
+        self.matrices = matrices
+        self.version = version
+        self.premultiplied = premultiplied
+        properties = matrices.keys.reduce(into: []) { properties, level in
+            properties.formUnion(level.properties)
+        }
+    }
+
+    mutating func apply(to displayList: inout DisplayList) {
+        var result = NewList(version: version)
+
+        for var item in displayList.items {
+            let itemProperties = item.properties.intersection(properties)
+            if level != .none || itemProperties.isEmpty {
+                result.append(item, level: level, transform: self)
+            } else if let fallbackLevel = transform(
+                &item,
+                properties: itemProperties
+            ) {
+                result.append(item, level: fallbackLevel, transform: self)
+            } else {
+                result.flushPendingItems(transform: self)
+                result.append(item)
+            }
+        }
+        result.flushPendingItems(transform: self)
+        displayList = DisplayList(result.items)
+    }
+
+    private mutating func transform(
+        _ item: inout DisplayList.Item,
+        properties itemProperties: DisplayList.Properties
+    ) -> _ForegroundLayerLevel? {
+        switch item.value {
+        case .empty:
+            break
+        case var .content(content):
+            guard case let .flattened(nestedDisplayList, origin, options) = content.value else {
+                break
+            }
+            var transformedDisplayList = nestedDisplayList
+            apply(to: &transformedDisplayList)
+            content.value = .flattened(transformedDisplayList, origin, options)
+            item.value = .content(content)
+        case let .effect(effect, displayList):
+            var transformedDisplayList = displayList
+            switch effect {
+            case let .properties(effectProperties):
+                let childLevel = _ForegroundLayerLevel(
+                    effectProperties.intersection(properties)
+                )
+                let rawLevel = childLevel.properties.rawValue
+                if rawLevel & (rawLevel &- 1) == 0 {
+                    var transform = self
+                    transform.level = childLevel
+                    transform.apply(to: &transformedDisplayList)
+                } else {
+                    apply(to: &transformedDisplayList)
+                }
+                item.value = .effect(effect, transformedDisplayList)
+            case let .filter(filter):
+                guard let filterMatrix = _ColorMatrix(
+                    filter,
+                    premultiplied: premultiplied
+                ) else {
+                    return fallbackLevel(for: itemProperties)
+                }
+                var transform = self
+                for (level, matrix) in transform.matrices {
+                    transform.matrices[level] = matrix * filterMatrix
+                }
+                transform.apply(to: &transformedDisplayList)
+                item.value = .effect(.identity, transformedDisplayList)
+            default:
+                apply(to: &transformedDisplayList)
+                item.value = .effect(effect, transformedDisplayList)
+            }
+        case let .states(states):
+            var states = states
+            for index in states.indices {
+                apply(to: &states[index].1)
+            }
+            item.value = .states(states)
+        }
+        return nil
+    }
+
+    private func fallbackLevel(
+        for properties: DisplayList.Properties
+    ) -> _ForegroundLayerLevel {
+        if properties.contains(.foregroundLayer) {
+            .primary
+        } else if properties.contains(.secondaryForegroundLayer) {
+            .secondary
+        } else if properties.contains(.tertiaryForegroundLayer) {
+            .tertiary
+        } else if properties.contains(.quaternaryForegroundLayer) {
+            .quaternary
+        } else {
+            .none
+        }
+    }
+
+    // MARK: - ViewGraphTransform.NewList
+
+    private struct NewList {
+        var items: [DisplayList.Item] = []
+        var pendingItems: [DisplayList.Item] = []
+        var pendingLevel: _ForegroundLayerLevel = .none
+        var pendingFrame: CGRect = .null
+        var pendingVersion: DisplayList.Version
+
+        init(version: DisplayList.Version) {
+            pendingVersion = version
+        }
+
+        mutating func append(_ item: DisplayList.Item) {
+            items.append(item)
+        }
+
+        mutating func append(
+            _ item: DisplayList.Item,
+            level: _ForegroundLayerLevel,
+            transform: ForegroundTransform
+        ) {
+            if !pendingItems.isEmpty, pendingLevel != level {
+                flushPendingItems(transform: transform)
+            }
+            pendingLevel = level
+            pendingItems.append(item)
+            pendingFrame = pendingFrame.union(item.frame)
+            pendingVersion.combine(with: item.version)
+        }
+
+        mutating func flushPendingItems(transform: ForegroundTransform) {
+            guard !pendingItems.isEmpty else {
+                return
+            }
+            defer {
+                pendingItems = []
+                pendingFrame = .null
+                pendingVersion = transform.version
+            }
+
+            guard let matrix = transform.matrices[pendingLevel], !matrix.isIdentity else {
+                items.append(contentsOf: pendingItems)
+                return
+            }
+
+            let frame = pendingFrame
+            let origin = frame.origin
+            for index in pendingItems.indices {
+                pendingItems[index].frame.origin.x -= origin.x
+                pendingItems[index].frame.origin.y -= origin.y
+            }
+            let filter = GraphicsFilter.colorMatrix(
+                matrix,
+                premultiplied: transform.premultiplied
+            )
+            let content = DisplayList(
+                DisplayList.Item(
+                    .effect(.compositingGroup, DisplayList(pendingItems)),
+                    frame: frame,
+                    identity: .none,
+                    version: pendingVersion
+                )
+            )
+            items.append(
+                DisplayList.Item(
+                    .effect(.filter(filter), content),
+                    frame: CGRect(origin: .zero, size: frame.size),
+                    identity: .none,
+                    version: pendingVersion
+                )
+            )
+        }
+    }
+}
+
+// MARK: - ViewGraphTransform
+
+private struct ViewGraphTransform {
+    let time: Attribute<Time>
+    let version: DisplayList.Version
+    var states: [(StrongHash, DisplayList.Version)] = []
+
+    private func needsTransform(_ features: DisplayList.Features) -> Bool {
+        !features.isDisjoint(with: [.interpolatorRoots, .stateEffects]) ||
+            (features.contains(.states) && !states.isEmpty)
+    }
+
+    @discardableResult
+    mutating func apply(to displayList: inout DisplayList) -> DisplayList.Version {
+        guard needsTransform(displayList.features) else {
+            return .init()
+        }
+        var transformedVersion = DisplayList.Version()
+        displayList.transform { item in
+            switch item.value {
+            case .empty:
+                break
+            case var .content(content):
+                guard case let .flattened(nestedList, origin, options) = content.value else {
+                    break
+                }
+                // NOTE: We can't use guard apply != .init() here
+                guard needsTransform(nestedList.features) else { break }
+                var list = nestedList
+                let version = apply(to: &list)
+                item.version.combine(with: version)
+                content.value = .flattened(list, origin, options)
+                content.seed = item.version.seed
+                item.value = .content(content)
+                transformedVersion.combine(with: version)
+            case let .effect(originalEffect, nestedList):
+                let version: DisplayList.Version
+                let list: DisplayList
+                let effect: DisplayList.Effect
+                switch originalEffect {
+                case let .mask(mask, options):
+                    var n = nestedList
+                    var v = apply(to: &n)
+                    var mask = mask
+                    v.combine(with: apply(to: &mask))
+                    version = v
+                    list = n
+                    effect = .mask(mask, options)
+                case let .state(hash):
+                    states.append((hash, item.version))
+                    var n = nestedList
+                    version = apply(to: &n)
+                    states.removeLast()
+                    list = n
+                    effect = .identity
+                case let .interpolatorRoot(group, contentOrigin, contentOffset):
+                    var n = nestedList
+                    var v = apply(to: &n)
+                    if group.rewriteDisplayList(
+                        &n,
+                        time: time,
+                        contentOrigin: contentOrigin,
+                        contentOffset: contentOffset,
+                        version: self.version
+                    ) {
+                        v = self.version
+                    }
+                    version = v
+                    list = n
+                    effect = .identity
+                default:
+                    var n = nestedList
+                    version = apply(to: &n)
+                    list = n
+                    effect = originalEffect
+                }
+                item.value = .effect(effect, list)
+                item.version.combine(with: version)
+                transformedVersion.combine(with: version)
+            case let .states(values):
+                guard let state = states.popLast() else {
+                    break
+                }
+                if let value = values.first(where: { $0.0 == state.0 }) {
+                    var list = value.1
+                    let version = apply(to: &list)
+                    item.version.combine(with: version)
+                    item.value = .effect(.identity, list)
+                } else {
+                    item.value = .empty
+                }
+                item.version.combine(with: state.1)
+                transformedVersion.combine(with: item.version)
+                states.append(state)
+            }
+        }
+        return transformedVersion
     }
 }

--- a/Sources/OpenSwiftUICore/Render/RendererEffect/ForegroundLayerEffect.swift
+++ b/Sources/OpenSwiftUICore/Render/RendererEffect/ForegroundLayerEffect.swift
@@ -1,0 +1,291 @@
+//
+//  ForegroundLayerEffect.swift
+//  OpenSwiftUICore
+//
+//  Audited for 6.5.4
+//  Status: Complete
+//  ID: BCBFDABE28FEE061FC04EF9B5F079DC4 (SwiftUICore)
+
+package import Foundation
+import OpenAttributeGraphShims
+
+// MARK: - _ForegroundLayerViewModifier
+
+@available(OpenSwiftUI_v2_0, *)
+@frozen
+@MainActor
+@preconcurrency
+public struct _ForegroundLayerViewModifier: RendererEffect {
+    @inlinable
+    public init() {}
+
+    package func effectValue(size: CGSize) -> DisplayList.Effect {
+        .properties(.foregroundLayer)
+    }
+}
+
+extension View {
+    @inline(__always)
+    package func foregroundLayer() -> some View {
+        modifier(_ForegroundLayerViewModifier())
+    }
+}
+
+// MARK: - _ForegroundLayerColorMatrixEffect
+
+@available(OpenSwiftUI_v2_0, *)
+@frozen
+public struct _ForegroundLayerColorMatrixEffect: MultiViewModifier, PrimitiveViewModifier {
+    public var foreground: _ColorMatrix
+
+    public var background: _ColorMatrix
+
+    @inlinable
+    public init(
+        foreground: _ColorMatrix = .init(),
+        background: _ColorMatrix = .init()
+    ) {
+        (self.foreground, self.background) = (foreground, background)
+    }
+
+    private var levelEffect: _ForegroundLayerLevelColorMatrixEffect {
+        _ForegroundLayerLevelColorMatrixEffect(
+            [.none: background, .primary: foreground]
+        )
+    }
+
+    nonisolated public static func _makeView(
+        modifier: _GraphValue<Self>,
+        inputs: _ViewInputs,
+        body: @escaping (_Graph, _ViewInputs) -> _ViewOutputs
+    ) -> _ViewOutputs {
+        _ForegroundLayerLevelColorMatrixEffect._makeView(
+            modifier: modifier[\.levelEffect],
+            inputs: inputs,
+            body: body
+        )
+    }
+}
+
+extension View {
+    @inline(__always)
+    package func foregroundLayerColorMatrix(
+        foreground: _ColorMatrix,
+        background: _ColorMatrix
+    ) -> some View {
+        modifier(
+            _ForegroundLayerColorMatrixEffect(
+                foreground: foreground,
+                background: background
+            )
+        )
+    }
+}
+
+// MARK: - _ForegroundLayerLevel
+
+@_spi(Private)
+@available(OpenSwiftUI_v6_0, *)
+public struct _ForegroundLayerLevel: Equatable, Hashable, Sendable {
+    package var properties: DisplayList.Properties
+
+    package init(_ properties: DisplayList.Properties) {
+        self.properties = properties.intersection(Self.all.properties)
+    }
+
+    private init(unchecked properties: DisplayList.Properties) {
+        self.properties = properties
+    }
+
+    public static let none = _ForegroundLayerLevel([])
+
+    public static let primary = _ForegroundLayerLevel(.foregroundLayer)
+
+    public static let secondary = _ForegroundLayerLevel(.secondaryForegroundLayer)
+
+    public static let tertiary = _ForegroundLayerLevel(.tertiaryForegroundLayer)
+
+    public static let quaternary = _ForegroundLayerLevel(.quaternaryForegroundLayer)
+
+    private static let all = _ForegroundLayerLevel(
+        unchecked: [
+            .foregroundLayer,
+            .secondaryForegroundLayer,
+            .tertiaryForegroundLayer,
+            .quaternaryForegroundLayer,
+        ]
+    )
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(properties.rawValue)
+    }
+
+    public static func == (a: _ForegroundLayerLevel, b: _ForegroundLayerLevel) -> Bool {
+        a.properties.rawValue == b.properties.rawValue
+    }
+}
+
+// MARK: - _ForegroundLayerLevelViewModifier
+
+@_spi(Private)
+@available(OpenSwiftUI_v6_0, *)
+@MainActor
+@preconcurrency
+public struct _ForegroundLayerLevelViewModifier: RendererEffect {
+    private var level: _ForegroundLayerLevel
+
+    public init(level: _ForegroundLayerLevel) {
+        self.level = level
+    }
+
+    package func effectValue(size: CGSize) -> DisplayList.Effect {
+        .properties(level.properties)
+    }
+}
+
+@_spi(Private)
+@available(*, unavailable)
+extension _ForegroundLayerLevelViewModifier: Sendable {}
+
+extension View {
+    @inline(__always)
+    package func foregroundLayerLevel(_ level: _ForegroundLayerLevel) -> some View {
+        modifier(_ForegroundLayerLevelViewModifier(level: level))
+    }
+}
+
+// MARK: - _ForegroundLayerLevelColorMatrixEffect
+
+@_spi(Private)
+@available(OpenSwiftUI_v6_0, *)
+@MainActor
+@preconcurrency
+public struct _ForegroundLayerLevelColorMatrixEffect: MultiViewModifier, PrimitiveViewModifier {
+    @frozen
+    public struct Options: OptionSet {
+        public let rawValue: UInt32
+
+        public init(rawValue: UInt32) {
+            self.rawValue = rawValue
+        }
+
+        public static let premultiplied = Options(rawValue: 1 << 0)
+    }
+
+    fileprivate var matrices: [_ForegroundLayerLevel: _ColorMatrix]
+
+    fileprivate var options: Options
+
+    public init(
+        _ matrices: [_ForegroundLayerLevel: _ColorMatrix],
+        options: Options = .init()
+    ) {
+        self.matrices = matrices
+        self.options = options
+    }
+
+    public init(
+        level: _ForegroundLayerLevel,
+        foreground: _ColorMatrix = .init(),
+        background: _ColorMatrix = .init()
+    ) {
+        self.init(level: level, foreground: foreground, background: background, options: [])
+    }
+
+    public init(
+        level: _ForegroundLayerLevel,
+        foreground: _ColorMatrix = .init(),
+        background: _ColorMatrix = .init(),
+        options: Options
+    ) {
+        var matrices: [_ForegroundLayerLevel: _ColorMatrix] = [.none: background]
+        if level != .none {
+            matrices[level] = foreground
+        }
+        self.init(matrices, options: options)
+    }
+
+    nonisolated public static func _makeView(
+        modifier: _GraphValue<Self>,
+        inputs: _ViewInputs,
+        body: @escaping (_Graph, _ViewInputs) -> _ViewOutputs
+    ) -> _ViewOutputs {
+        var outputs = body(_Graph(), inputs)
+        if let displayList = outputs.displayList {
+            outputs.displayList = Attribute(
+                ForegroundLayerDisplayList(
+                    effect: modifier.value,
+                    content: .init(displayList),
+                    effectVersion: .init()
+                )
+            )
+        }
+        return outputs
+    }
+}
+
+@_spi(Private)
+@available(*, unavailable)
+extension _ForegroundLayerLevelColorMatrixEffect: Sendable {}
+
+extension View {
+    @inline(__always)
+    package func foregroundLayerLevelColorMatrix(
+        _ matrices: [_ForegroundLayerLevel: _ColorMatrix],
+        options: _ForegroundLayerLevelColorMatrixEffect.Options = .init()
+    ) -> some View {
+        modifier(
+            _ForegroundLayerLevelColorMatrixEffect(
+                matrices,
+                options: options
+            )
+        )
+    }
+
+    @inline(__always)
+    package func foregroundLayerLevelColorMatrix(
+        level: _ForegroundLayerLevel,
+        foreground: _ColorMatrix = .init(),
+        background: _ColorMatrix = .init(),
+        options: _ForegroundLayerLevelColorMatrixEffect.Options = .init()
+    ) -> some View {
+        modifier(
+            _ForegroundLayerLevelColorMatrixEffect(
+                level: level,
+                foreground: foreground,
+                background: background,
+                options: options
+            )
+        )
+    }
+}
+
+// MARK: - ForegroundLayerDisplayList
+
+@available(OpenSwiftUI_v6_0, *)
+private struct ForegroundLayerDisplayList: StatefulRule, AsyncAttribute {
+    typealias Value = DisplayList
+
+    @Attribute var effect: _ForegroundLayerLevelColorMatrixEffect
+
+    @OptionalAttribute var content: DisplayList?
+
+    var effectVersion: DisplayList.Version
+
+    mutating func updateValue() {
+        guard var content else {
+            value = DisplayList()
+            return
+        }
+        let (effect, effectChanged) = $effect.changedValue()
+        if effectChanged {
+            effectVersion = DisplayList.Version(forUpdate: ())
+        }
+        content.insertLayerFilters(
+            matrices: effect.matrices,
+            version: effectVersion,
+            premultiplied: effect.options.contains(.premultiplied)
+        )
+        value = content
+    }
+}

--- a/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListTransformsTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Render/DisplayList/DisplayListTransformsTests.swift
@@ -1,0 +1,207 @@
+//
+//  DisplayListTransformsTests.swift
+//  OpenSwiftUICoreTests
+//
+//  Author: Codex 5.6 Sol
+
+import Foundation
+import OpenAttributeGraphShims
+@_spi(ForOpenSwiftUIOnly) @testable import OpenSwiftUICore
+import Testing
+
+@MainActor
+@Suite
+struct DisplayListTransformsTests {
+    @Test
+    func stateSelectsMatchingDisplayList() {
+        let firstHash = StrongHash(of: 1)
+        let secondHash = StrongHash(of: 2)
+        let first = DisplayList(contentItem(identity: 1, version: 3))
+        let second = DisplayList(contentItem(identity: 2, version: 4))
+        let states = DisplayList(item(
+            .states([(firstHash, first), (secondHash, second)]),
+            version: 5
+        ))
+        var displayList = DisplayList(item(
+            .effect(.state(secondHash), states),
+            version: 17
+        ))
+
+        displayList.applyViewGraphTransform(
+            time: Attribute(identifier: .nil),
+            version: .init(decodedValue: 100)
+        )
+
+        guard case let .effect(.identity, transformedStates) = displayList.items[0].value,
+              case let .effect(.identity, selected) = transformedStates.items[0].value
+        else {
+            Issue.record("Expected the matching state to replace the state table")
+            return
+        }
+        #expect(selected.items.count == 1)
+        #expect(selected.items[0].identity == .init(decodedValue: 2))
+        #expect(transformedStates.items[0].version.value == 17)
+        #expect(displayList.items[0].version.value == 17)
+        #expect(displayList.features.isEmpty)
+    }
+
+    @Test
+    func stateWithoutMatchBecomesEmpty() {
+        let selectedHash = StrongHash(of: 1)
+        let states = DisplayList(item(
+            .states([(StrongHash(of: 2), DisplayList(contentItem(identity: 2, version: 4)))]),
+            version: 5
+        ))
+        var displayList = DisplayList(item(
+            .effect(.state(selectedHash), states),
+            version: 17
+        ))
+
+        displayList.applyViewGraphTransform(
+            time: Attribute(identifier: .nil),
+            version: .init(decodedValue: 100)
+        )
+
+        guard case let .effect(.identity, transformedStates) = displayList.items[0].value,
+              case .empty = transformedStates.items[0].value
+        else {
+            Issue.record("Expected an unmatched state to become empty")
+            return
+        }
+        #expect(transformedStates.items[0].version.value == 17)
+        #expect(displayList.items[0].version.value == 17)
+        #expect(displayList.features.isEmpty)
+    }
+
+    @Test
+    func flattenedContentUsesCombinedItemVersionAsSeed() {
+        let hash = StrongHash(of: 1)
+        let states = DisplayList(item(
+            .states([(hash, DisplayList(contentItem(identity: 1, version: 3)))]),
+            version: 5
+        ))
+        let state = DisplayList(item(.effect(.state(hash), states), version: 17))
+        var displayList = DisplayList(item(
+            .content(.init(
+                .flattened(state, CGPoint(x: 2, y: 3), .init()),
+                seed: .init(decodedValue: 123)
+            )),
+            version: 23
+        ))
+
+        displayList.applyViewGraphTransform(
+            time: Attribute(identifier: .nil),
+            version: .init(decodedValue: 100)
+        )
+
+        guard case let .content(content) = displayList.items[0].value,
+              case let .flattened(transformed, origin, _) = content.value,
+              case .effect(.identity, _) = transformed.items[0].value
+        else {
+            Issue.record("Expected flattened content to be transformed recursively")
+            return
+        }
+        #expect(origin == CGPoint(x: 2, y: 3))
+        #expect(content.seed == DisplayList.Seed(.init(decodedValue: 23)))
+        #expect(displayList.items[0].version.value == 23)
+    }
+
+    @Test
+    func flattenedContentWithoutTransformFeaturesIsUnchanged() {
+        let nested = DisplayList(contentItem(identity: 1, version: 3))
+        let flattened = item(
+            .content(.init(
+                .flattened(nested, CGPoint(x: 2, y: 3), .init()),
+                seed: .init(decodedValue: 123)
+            )),
+            version: 9
+        )
+        let stateEffect = item(
+            .effect(.state(StrongHash(of: 1)), DisplayList()),
+            version: 17
+        )
+        var displayList = DisplayList([flattened, stateEffect])
+
+        displayList.applyViewGraphTransform(
+            time: Attribute(identifier: .nil),
+            version: .init(decodedValue: 100)
+        )
+
+        guard case let .content(content) = displayList.items[0].value,
+              case let .flattened(transformed, origin, _) = content.value
+        else {
+            Issue.record("Expected flattened content to remain flattened")
+            return
+        }
+        #expect(origin == CGPoint(x: 2, y: 3))
+        #expect(content.seed == .init(decodedValue: 123))
+        #expect(transformed.items[0].identity == .init(decodedValue: 1))
+        #expect(displayList.items[0].version.value == 9)
+    }
+
+    @Test
+    func interpolatorRootBecomesIdentity() {
+        let child = DisplayList(contentItem(identity: 1, version: 3))
+        var displayList = DisplayList(item(
+            .effect(
+                .interpolatorRoot(
+                    DisplayList.InterpolatorGroup(),
+                    contentOrigin: CGPoint(x: 2, y: 3),
+                    contentOffset: CGSize(width: 4, height: 5)
+                ),
+                child
+            ),
+            version: 17
+        ))
+
+        displayList.applyViewGraphTransform(
+            time: Attribute(identifier: .nil),
+            version: .init(decodedValue: 100)
+        )
+
+        guard case let .effect(.identity, transformed) = displayList.items[0].value else {
+            Issue.record("Expected the interpolator root to become identity")
+            return
+        }
+        #expect(transformed.items[0].identity == .init(decodedValue: 1))
+        #expect(displayList.items[0].version.value == 17)
+        #expect(displayList.features.isEmpty)
+    }
+
+    @Test
+    func unrelatedDisplayListIsUnchanged() {
+        var displayList = DisplayList(contentItem(identity: 1, version: 3))
+        let original = displayList
+
+        displayList.applyViewGraphTransform(
+            time: Attribute(identifier: .nil),
+            version: .init(decodedValue: 100)
+        )
+
+        #expect(displayList == original)
+    }
+
+    private func item(
+        _ value: DisplayList.Item.Value,
+        version: Int
+    ) -> DisplayList.Item {
+        DisplayList.Item(
+            value,
+            frame: .zero,
+            identity: .none,
+            version: .init(decodedValue: version)
+        )
+    }
+
+    private func contentItem(identity: UInt32, version: Int) -> DisplayList.Item {
+        DisplayList.Item(
+            .content(.init(
+                .color(.init(red: 1, green: 0, blue: 0, opacity: 1)),
+                seed: .init(decodedValue: UInt16(version))
+            )),
+            frame: .zero,
+            identity: .init(decodedValue: identity),
+            version: .init(decodedValue: version)
+        )
+    }
+}

--- a/Tests/OpenSwiftUICoreTests/Render/RendererEffect/ForegroundLayerEffectTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Render/RendererEffect/ForegroundLayerEffectTests.swift
@@ -1,0 +1,291 @@
+//
+//  ForegroundLayerEffectTests.swift
+//  OpenSwiftUICoreTests
+//
+//  Author: Codex 5.6 Sol
+
+import Foundation
+@_spi(Private) import OpenSwiftUICore
+import Testing
+
+@MainActor
+@Suite
+struct ForegroundLayerEffectTests {
+    @Test
+    func viewModifierEffect() {
+        let modifier = _ForegroundLayerViewModifier()
+
+        guard case let .properties(properties) = modifier.effectValue(size: .zero) else {
+            Issue.record("Expected a properties effect")
+            return
+        }
+        #expect(properties == .foregroundLayer)
+    }
+
+    @Test
+    func levelProperties() {
+        #expect(_ForegroundLayerLevel.none.properties.rawValue == 0x00)
+        #expect(_ForegroundLayerLevel.primary.properties.rawValue == 0x01)
+        #expect(_ForegroundLayerLevel.secondary.properties.rawValue == 0x10)
+        #expect(_ForegroundLayerLevel.tertiary.properties.rawValue == 0x20)
+        #expect(_ForegroundLayerLevel.quaternary.properties.rawValue == 0x40)
+
+        let custom = _ForegroundLayerLevel([
+            .secondaryForegroundLayer,
+            .tertiaryForegroundLayer,
+            .privacySensitive,
+        ])
+        #expect(custom.properties == [.secondaryForegroundLayer, .tertiaryForegroundLayer])
+    }
+
+    @Test
+    func levelViewModifierEffect() {
+        let level: _ForegroundLayerLevel = .init([
+            .secondaryForegroundLayer,
+            .tertiaryForegroundLayer,
+        ])
+        let modifier = _ForegroundLayerLevelViewModifier(level: level)
+
+        guard case let .properties(properties) = modifier.effectValue(size: .zero) else {
+            Issue.record("Expected a properties effect")
+            return
+        }
+        #expect(properties == [.secondaryForegroundLayer, .tertiaryForegroundLayer])
+    }
+
+    @Test
+    func colorMatrixEffectInitialization() {
+        var foreground = _ColorMatrix()
+        foreground.m11 = 0.25
+        var background = _ColorMatrix()
+        background.m22 = 0.5
+
+        let effect = _ForegroundLayerColorMatrixEffect(
+            foreground: foreground,
+            background: background
+        )
+
+        #expect(effect.foreground == foreground)
+        #expect(effect.background == background)
+    }
+
+    @Test
+    func insertsAndGroupsLayerFilters() {
+        var backgroundMatrix = _ColorMatrix()
+        backgroundMatrix.m11 = 0.25
+        var foregroundMatrix = _ColorMatrix()
+        foregroundMatrix.m22 = 0.5
+        let foregroundFrame = CGRect(x: 20, y: 0, width: 20, height: 10)
+        let foregroundLayer = DisplayList.Item(
+            .effect(
+                .properties(.foregroundLayer),
+                DisplayList([
+                    item(frame: CGRect(x: 20, y: 0, width: 10, height: 10), version: 12),
+                    item(frame: CGRect(x: 30, y: 0, width: 10, height: 10), version: 13),
+                ])
+            ),
+            frame: foregroundFrame,
+            identity: .none,
+            version: .init(decodedValue: 13)
+        )
+        var displayList = DisplayList([
+            item(frame: CGRect(x: 0, y: 0, width: 10, height: 10), version: 11),
+            foregroundLayer,
+        ])
+
+        displayList.insertLayerFilters(
+            matrices: [.none: backgroundMatrix, .primary: foregroundMatrix],
+            version: .init(decodedValue: 10),
+            premultiplied: true
+        )
+
+        #expect(displayList.items.count == 2)
+        assertFilter(
+            displayList.items[0],
+            matrix: backgroundMatrix,
+            premultiplied: true,
+            frame: CGRect(x: 0, y: 0, width: 10, height: 10),
+            version: 11,
+            childOrigins: [.zero]
+        )
+        assertLayerFilter(
+            displayList.items[1],
+            properties: .foregroundLayer,
+            matrix: foregroundMatrix,
+            premultiplied: true,
+            frame: foregroundFrame,
+            version: 13,
+            childOrigins: [.zero, CGPoint(x: 10, y: 0)]
+        )
+    }
+
+    @Test
+    func identityMatrixLeavesItemsUnwrapped() {
+        let original = [
+            item(frame: CGRect(x: 2, y: 3, width: 4, height: 5), version: 11),
+            item(frame: CGRect(x: 8, y: 9, width: 4, height: 5), version: 12),
+        ]
+        var displayList = DisplayList(original)
+
+        displayList.insertLayerFilters(
+            matrices: [.none: _ColorMatrix()],
+            version: .init(decodedValue: 10),
+            premultiplied: false
+        )
+
+        #expect(displayList.items == original)
+    }
+
+    @Test
+    func recursivelySplitsMixedLayerContent() {
+        var primaryMatrix = _ColorMatrix()
+        primaryMatrix.m11 = 0.25
+        var secondaryMatrix = _ColorMatrix()
+        secondaryMatrix.m22 = 0.5
+        let child = DisplayList([
+            layerItem(
+                .foregroundLayer,
+                frame: CGRect(x: 0, y: 0, width: 10, height: 10),
+                version: 11
+            ),
+            layerItem(
+                .secondaryForegroundLayer,
+                frame: CGRect(x: 10, y: 0, width: 10, height: 10),
+                version: 12
+            ),
+        ])
+        var displayList = DisplayList(
+            DisplayList.Item(
+                .effect(.opacity(0.5), child),
+                frame: CGRect(x: 0, y: 0, width: 20, height: 10),
+                identity: .none,
+                version: .init(decodedValue: 12)
+            )
+        )
+
+        displayList.insertLayerFilters(
+            matrices: [.primary: primaryMatrix, .secondary: secondaryMatrix],
+            version: .init(decodedValue: 10),
+            premultiplied: false
+        )
+
+        #expect(displayList.items.count == 1)
+        guard case let .effect(.opacity(opacity), transformedChild) = displayList.items[0].value else {
+            Issue.record("Expected the outer opacity effect to be preserved")
+            return
+        }
+        #expect(opacity == 0.5)
+        #expect(transformedChild.items.count == 2)
+        assertLayerFilter(
+            transformedChild.items[0],
+            properties: .foregroundLayer,
+            matrix: primaryMatrix,
+            premultiplied: false,
+            frame: CGRect(x: 0, y: 0, width: 10, height: 10),
+            version: 11,
+            childOrigins: [.zero]
+        )
+        assertLayerFilter(
+            transformedChild.items[1],
+            properties: .secondaryForegroundLayer,
+            matrix: secondaryMatrix,
+            premultiplied: false,
+            frame: CGRect(x: 10, y: 0, width: 10, height: 10),
+            version: 12,
+            childOrigins: [.zero]
+        )
+    }
+
+    private func item(frame: CGRect, version: Int) -> DisplayList.Item {
+        DisplayList.Item(
+            .content(.init(
+                .color(.init(red: 1, green: 1, blue: 1, opacity: 1)),
+                seed: .init(decodedValue: UInt16(version))
+            )),
+            frame: frame,
+            identity: .none,
+            version: .init(decodedValue: version)
+        )
+    }
+
+    private func layerItem(
+        _ properties: DisplayList.Properties,
+        frame: CGRect,
+        version: Int
+    ) -> DisplayList.Item {
+        DisplayList.Item(
+            .effect(.properties(properties), DisplayList(item(frame: frame, version: version))),
+            frame: frame,
+            identity: .none,
+            version: .init(decodedValue: version)
+        )
+    }
+
+    private func assertFilter(
+        _ item: DisplayList.Item,
+        matrix: _ColorMatrix,
+        premultiplied: Bool,
+        frame: CGRect,
+        version: Int,
+        childOrigins: [CGPoint],
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        #expect(
+            item.frame == CGRect(origin: .zero, size: frame.size),
+            sourceLocation: sourceLocation
+        )
+        #expect(item.version.value == version, sourceLocation: sourceLocation)
+        guard case let .effect(.filter(filter), content) = item.value,
+              case let .colorMatrix(actualMatrix, actualPremultiplied) = filter
+        else {
+            Issue.record("Expected a color matrix filter", sourceLocation: sourceLocation)
+            return
+        }
+        #expect(actualMatrix == matrix, sourceLocation: sourceLocation)
+        #expect(actualPremultiplied == premultiplied, sourceLocation: sourceLocation)
+        guard content.items.count == 1 else {
+            Issue.record("Expected one compositing group", sourceLocation: sourceLocation)
+            return
+        }
+        let group = content.items[0]
+        #expect(group.frame == frame, sourceLocation: sourceLocation)
+        #expect(group.version.value == version, sourceLocation: sourceLocation)
+        guard case let .effect(.compositingGroup, children) = group.value else {
+            Issue.record("Expected a compositing group", sourceLocation: sourceLocation)
+            return
+        }
+        #expect(children.items.map(\.frame.origin) == childOrigins, sourceLocation: sourceLocation)
+    }
+
+    private func assertLayerFilter(
+        _ item: DisplayList.Item,
+        properties: DisplayList.Properties,
+        matrix: _ColorMatrix,
+        premultiplied: Bool,
+        frame: CGRect,
+        version: Int,
+        childOrigins: [CGPoint],
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        #expect(item.frame == frame, sourceLocation: sourceLocation)
+        #expect(item.version.value == version, sourceLocation: sourceLocation)
+        guard case let .effect(.properties(actualProperties), content) = item.value else {
+            Issue.record("Expected a properties effect", sourceLocation: sourceLocation)
+            return
+        }
+        #expect(actualProperties == properties, sourceLocation: sourceLocation)
+        guard content.items.count == 1 else {
+            Issue.record("Expected one filtered item", sourceLocation: sourceLocation)
+            return
+        }
+        assertFilter(
+            content.items[0],
+            matrix: matrix,
+            premultiplied: premultiplied,
+            frame: frame,
+            version: version,
+            childOrigins: childOrigins,
+            sourceLocation: sourceLocation
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add foreground-layer renderer effect types, view modifiers, and API documentation.
- Implement foreground color-matrix insertion and view-graph display-list transformations.
- Add coverage for foreground-layer grouping and display-list transformation behavior.