### PR TITLE
Mark Foundation ProgressView snapshot as intermittent on iOS

### DIFF
--- a/Example/OpenSwiftUIUITests/View/ProgressViewUITests.swift
+++ b/Example/OpenSwiftUIUITests/View/ProgressViewUITests.swift
@@ -26,6 +26,13 @@ struct ProgressViewUITests {
 
     @Test
     func foundationProgress() {
+        #if os(iOS)
+        // FIXME: The SwiftUI reference image is flaky on CI while the Foundation progress label settles.
+        withKnownIssue("The SwiftUI reference image is flaky on CI", isIntermittent: true) {
+            openSwiftUIAssertSnapshot(of: FoundationProgressViewExample())
+        }
+        #else
         openSwiftUIAssertSnapshot(of: FoundationProgressViewExample())
+        #endif
     }
 }


### PR DESCRIPTION
## Summary

- Treat the iOS Foundation ProgressView snapshot mismatch as intermittent.
- Document the CI reference-image flake while the Foundation progress label settles.
- Keep the macOS snapshot assertion unchanged.