### PR TITLE
Add previews for shared examples

### DIFF
--- a/.github/actions/uitests/action.yml
+++ b/.github/actions/uitests/action.yml
@@ -42,8 +42,9 @@ runs:
         xcode-version: ${{ inputs.xcode-version }}
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
       with:
+        version: 2026.8.14
         install: false
         cache: false
 

--- a/Example/OpenSwiftUIUITests/Integration/Hosting/CAHostingLayerUITests.swift
+++ b/Example/OpenSwiftUIUITests/Integration/Hosting/CAHostingLayerUITests.swift
@@ -14,10 +14,8 @@ struct CAHostingLayerUITests {
     #endif
     @Test
     func basicLayer() {
-        let example = CAHostingLayerExample(content: Color.red, size: defaultSize)
-        let vc = example.makeViewController()
-        openSwiftUIControllerAssertSnapshot(
-            of: vc,
+        openSwiftUIAssertSnapshot(
+            of: CAHostingLayerExample(content: Color.red),
             as: .image(drawHierarchyInKeyWindow: false, size: defaultSize)
         )
     }

--- a/Example/Shared/Animation/Animation/AnimationCompleteExample.swift
+++ b/Example/Shared/Animation/Animation/AnimationCompleteExample.swift
@@ -54,3 +54,7 @@ struct AnimationCompleteExample: View {
         }
     }
 }
+
+#Preview {
+    AnimationCompleteExample()
+}

--- a/Example/Shared/Animation/Animation/ColorAnimationExample.swift
+++ b/Example/Shared/Animation/Animation/ColorAnimationExample.swift
@@ -23,3 +23,7 @@ struct ColorAnimationExample: View {
         }
     }
 }
+
+#Preview {
+    ColorAnimationExample()
+}

--- a/Example/Shared/Animation/Animation/ElasticEaseInEaseOutAnimationExample.swift
+++ b/Example/Shared/Animation/Animation/ElasticEaseInEaseOutAnimationExample.swift
@@ -51,3 +51,7 @@ struct ElasticEaseInEaseOutAnimationExample: View {
         .padding()
     }
 }
+
+#Preview {
+    ElasticEaseInEaseOutAnimationExample()
+}

--- a/Example/Shared/Animation/Animation/RepeatAnimationExample.swift
+++ b/Example/Shared/Animation/Animation/RepeatAnimationExample.swift
@@ -47,3 +47,7 @@ struct RepeatAnimationExample: View {
         }
     }
 }
+
+#Preview {
+    RepeatAnimationExample()
+}

--- a/Example/Shared/Animation/Animation/SpringAnimationExample.swift
+++ b/Example/Shared/Animation/Animation/SpringAnimationExample.swift
@@ -24,3 +24,7 @@ struct SpringAnimationExample: View {
         }
     }
 }
+
+#Preview {
+    SpringAnimationExample()
+}

--- a/Example/Shared/Animation/Transaction/TransactionExample.swift
+++ b/Example/Shared/Animation/Transaction/TransactionExample.swift
@@ -62,3 +62,7 @@ struct TransactionExample: View {
         }
     }
 }
+
+#Preview {
+    TransactionExample()
+}

--- a/Example/Shared/Data/ObservationExample.swift
+++ b/Example/Shared/Data/ObservationExample.swift
@@ -36,3 +36,7 @@ struct ObservationExample: View {
         }
     }
 }
+
+#Preview {
+    ObservationExample()
+}

--- a/Example/Shared/Event/Gesture/SpatialTapGestureExample.swift
+++ b/Example/Shared/Event/Gesture/SpatialTapGestureExample.swift
@@ -25,3 +25,7 @@ struct SpatialTapGestureExample: View {
             .gesture(tap)
     }
 }
+
+#Preview {
+    SpatialTapGestureExample()
+}

--- a/Example/Shared/Event/Gesture/TapGestureExample.swift
+++ b/Example/Shared/Event/Gesture/TapGestureExample.swift
@@ -23,3 +23,7 @@ struct TapGestureExample: View {
             }
     }
 }
+
+#Preview {
+    TapGestureExample()
+}

--- a/Example/Shared/Graphics/Color/NamedColorExample.swift
+++ b/Example/Shared/Graphics/Color/NamedColorExample.swift
@@ -27,3 +27,7 @@ struct NamedColorExample: View {
         }
     }
 }
+
+#Preview {
+    NamedColorExample()
+}

--- a/Example/Shared/Integration/Hosting/CAHostingLayerExample.swift
+++ b/Example/Shared/Integration/Hosting/CAHostingLayerExample.swift
@@ -24,42 +24,105 @@ import AppKit
 import UIKit
 #endif
 
-@MainActor
-struct CAHostingLayerExample<Content: View> {
-    var content: Content
-    var size: CGSize
+#if !OPENSWIFTUI
+@available(iOS 18.0, macOS 15.0, *)
+#endif
+final class CAHostingLayerExampleView: PlatformView {
+    private let hostingLayer: CALayer
 
-    #if !OPENSWIFTUI
-    @available(iOS 18.0, macOS 15.0, *)
-    #endif
-    func makeViewController() -> PlatformViewController {
-        let layer = CAHostingLayer(rootView: content)
-        layer.anchorPoint = .zero
-        layer.bounds = CGRect(origin: .zero, size: size)
-        #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-        let view = NSView(frame: CGRect(origin: .zero, size: size))
-        view.wantsLayer = true
-        view.layer?.addSublayer(layer)
-        let vc = NSViewController()
-        vc.view = view
-        #elseif canImport(UIKit)
-        let view = UIView(frame: CGRect(origin: .zero, size: size))
-        view.layer.addSublayer(layer)
-        let vc = UIViewController()
-        vc.view = view
+    init(content: some View) {
+        let hostingLayer = CAHostingLayer(rootView: content)
+        self.hostingLayer = hostingLayer
+
+        super.init(frame: .zero)
+
+        hostingLayer.anchorPoint = .zero
+        #if canImport(UIKit)
+        layer.addSublayer(hostingLayer)
+        #elseif canImport(AppKit)
+        wantsLayer = true
+        layer!.addSublayer(hostingLayer)
         #endif
-        return vc
+        updateHostingLayer()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    #if canImport(UIKit)
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateHostingLayer()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateHostingLayer()
+    }
+    #elseif canImport(AppKit)
+    override func layout() {
+        super.layout()
+        updateHostingLayer()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        updateHostingLayer()
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        updateHostingLayer()
+    }
+    #endif
+
+    private func updateHostingLayer() {
+        #if canImport(UIKit)
+        let contentsScale = window?.screen.scale
+            ?? traitCollection.displayScale
+        #elseif canImport(AppKit)
+        let contentsScale = window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 1.0
+        #endif
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        hostingLayer.frame = bounds
+        if hostingLayer.contentsScale != contentsScale {
+            hostingLayer.contentsScale = contentsScale
+            hostingLayer.setNeedsLayout()
+        }
+        CATransaction.commit()
     }
 }
 
-#Preview("CAHostingLayerExample") {
-    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-    let size = CGSize(width: 500, height: 300)
-    #elseif canImport(UIKit)
-    let size = UIScreen.main.bounds.size
+#Preview("CAHostingLayerExampleView") {
+    CAHostingLayerExampleView(content: ContentView())
+}
+
+#if !OPENSWIFTUI
+@available(iOS 18.0, macOS 15.0, *)
+#endif
+struct CAHostingLayerExample<Content: View>: PlatformViewRepresentable {
+    let content: Content
+
+    #if canImport(UIKit)
+    func makeUIView(context: Context) -> CAHostingLayerExampleView {
+        CAHostingLayerExampleView(content: content)
+    }
+
+    func updateUIView(_ uiView: CAHostingLayerExampleView, context: Context) {}
+    #elseif canImport(AppKit)
+    func makeNSView(context: Context) -> CAHostingLayerExampleView {
+        CAHostingLayerExampleView(content: content)
+    }
+
+    func updateNSView(_ nsView: CAHostingLayerExampleView, context: Context) {}
     #endif
-    return CAHostingLayerExample(
-        content: ContentView(),
-        size: size
-    ).makeViewController()
+}
+
+#Preview("CAHostingLayerExample") {
+    CAHostingLayerExample(content: ContentView())
 }

--- a/Example/Shared/Integration/Representable/ColorRepresentableExample.swift
+++ b/Example/Shared/Integration/Representable/ColorRepresentableExample.swift
@@ -58,3 +58,11 @@ struct ColorViewControllerRepresentableExample: PlatformViewControllerRepresenta
     func updateNSViewController(_ nsViewController: NSViewControllerType, context: Context) {}
     #endif
 }
+
+#Preview("ColorViewRepresentableExample") {
+    ColorViewRepresentableExample()
+}
+
+#Preview("ColorViewControllerRepresentableExample") {
+    ColorViewControllerRepresentableExample()
+}

--- a/Example/Shared/Layout/CustomLayout/MyViewThatFitsExample.swift
+++ b/Example/Shared/Layout/CustomLayout/MyViewThatFitsExample.swift
@@ -24,3 +24,7 @@ struct MyViewThatFitsExample: View {
         .id(showRed)
     }
 }
+
+#Preview {
+    MyViewThatFitsExample()
+}

--- a/Example/Shared/Layout/Dynamic/DynamicLayoutViewExample.swift
+++ b/Example/Shared/Layout/Dynamic/DynamicLayoutViewExample.swift
@@ -20,3 +20,7 @@ struct DynamicLayoutViewExample: View {
         }
     }
 }
+
+#Preview {
+    DynamicLayoutViewExample()
+}

--- a/Example/Shared/Layout/Geometry/GeometryActionModifierExample.swift
+++ b/Example/Shared/Layout/Geometry/GeometryActionModifierExample.swift
@@ -29,3 +29,7 @@ struct GeometryActionModifierExample: View {
         .padding()
     }
 }
+
+#Preview {
+    GeometryActionModifierExample()
+}

--- a/Example/Shared/Layout/Geometry/GeometryReaderExample.swift
+++ b/Example/Shared/Layout/Geometry/GeometryReaderExample.swift
@@ -23,3 +23,7 @@ struct GeometryReaderExample: View {
         }
     }
 }
+
+#Preview {
+    GeometryReaderExample()
+}

--- a/Example/Shared/Layout/Modifier/InsetViewModifierExample.swift
+++ b/Example/Shared/Layout/Modifier/InsetViewModifierExample.swift
@@ -25,3 +25,7 @@ struct InsetViewModifierExample: View {
             }
     }
 }
+
+#Preview {
+    InsetViewModifierExample()
+}

--- a/Example/Shared/Layout/Stack/JindoKit/JindoKitExample.swift
+++ b/Example/Shared/Layout/Stack/JindoKit/JindoKitExample.swift
@@ -83,4 +83,8 @@ struct JindoKitExample: View {
     }
 }
 
+#Preview {
+    JindoKitExample()
+}
+
 #endif

--- a/Example/Shared/Render/Async/AsyncRendererExample.swift
+++ b/Example/Shared/Render/Async/AsyncRendererExample.swift
@@ -57,3 +57,11 @@ struct AsyncRendererTransitionExample: View {
         }
     }
 }
+
+#Preview("AsyncRendererExample") {
+    AsyncRendererExample()
+}
+
+#Preview("AsyncRendererTransitionExample") {
+    AsyncRendererTransitionExample()
+}

--- a/Example/Shared/Render/GeometryEffect/GeometryEffectExample.swift
+++ b/Example/Shared/Render/GeometryEffect/GeometryEffectExample.swift
@@ -67,3 +67,19 @@ struct Rotation3DEffectExample: View {
             )
     }
 }
+
+#Preview("GeometryEffectExample") {
+    GeometryEffectExample()
+}
+
+#Preview("OffsetEffectExample") {
+    OffsetEffectExample()
+}
+
+#Preview("RotationEffectExample") {
+    RotationEffectExample()
+}
+
+#Preview("Rotation3DEffectExample") {
+    Rotation3DEffectExample()
+}

--- a/Example/Shared/Render/GeometryEffect/MatchedGeometryEffectExample.swift
+++ b/Example/Shared/Render/GeometryEffect/MatchedGeometryEffectExample.swift
@@ -95,3 +95,15 @@ struct MatchedGeometryEffectClipShapeModifierExample: View {
 //        .border(Color.gray, width: 3)
     }
 }
+
+#Preview("MatchedGeometryEffectExample") {
+    MatchedGeometryEffectExample()
+}
+
+#Preview("MatchedGeometryEffectModifierExample") {
+    MatchedGeometryEffectModifierExample()
+}
+
+#Preview("MatchedGeometryEffectClipShapeModifierExample") {
+    MatchedGeometryEffectClipShapeModifierExample()
+}

--- a/Example/Shared/Render/RendererEffect/VariableBlurEffectExample.swift
+++ b/Example/Shared/Render/RendererEffect/VariableBlurEffectExample.swift
@@ -15,3 +15,7 @@ struct VariableBlurEffectExample: View {
             .variableBlur(maxRadius: 10, mask: Image(systemName: "plus"))
     }
 }
+
+#Preview {
+    VariableBlurEffectExample()
+}

--- a/Example/Shared/View/ConditionalContentExample.swift
+++ b/Example/Shared/View/ConditionalContentExample.swift
@@ -40,3 +40,7 @@ struct ConditionalContentExample: View {
         }
     }
 }
+
+#Preview {
+    ConditionalContentExample()
+}

--- a/Example/Shared/View/DynamicContentView/ForEachExample.swift
+++ b/Example/Shared/View/DynamicContentView/ForEachExample.swift
@@ -93,3 +93,15 @@ struct ForEachLazyContainerNonConstantCountView: View {
 //        }
     }
 }
+
+#Preview("ForEachExample") {
+    ForEachExample()
+}
+
+#Preview("ForEachOffsetExample") {
+    ForEachOffsetExample()
+}
+
+#Preview("ForEachKeyPathExample") {
+    ForEachKeyPathExample()
+}

--- a/Example/Shared/View/Image/AsyncImageExample.swift
+++ b/Example/Shared/View/Image/AsyncImageExample.swift
@@ -14,3 +14,7 @@ struct AsyncImageExample: View {
         AsyncImage(url: URL(string: "https://picsum.photos/200"))
     }
 }
+
+#Preview {
+    AsyncImageExample()
+}

--- a/Example/Shared/View/Image/ImageConversionsExample.swift
+++ b/Example/Shared/View/Image/ImageConversionsExample.swift
@@ -74,3 +74,11 @@ struct ImageConversionsSystemImageExample: View {
         }.foregroundStyle(.red)
     }
 }
+
+#Preview("ImageConversionsExample") {
+    ImageConversionsExample()
+}
+
+#Preview("ImageConversionsSystemImageExample") {
+    ImageConversionsSystemImageExample()
+}

--- a/Example/Shared/View/Image/NamedImageExample.swift
+++ b/Example/Shared/View/Image/NamedImageExample.swift
@@ -49,3 +49,19 @@ struct NamedImageRenderingModeTemplateExample: View {
         .frame(width: 200, height: 100)
     }
 }
+
+#Preview("NamedImageExample") {
+    NamedImageExample()
+}
+
+#Preview("NamedImageDecorativeExample") {
+    NamedImageDecorativeExample()
+}
+
+#Preview("NamedImageRenderingModeOriginalExample") {
+    NamedImageRenderingModeOriginalExample()
+}
+
+#Preview("NamedImageRenderingModeTemplateExample") {
+    NamedImageRenderingModeTemplateExample()
+}

--- a/Example/Shared/View/Image/SunsetSceneExample.swift
+++ b/Example/Shared/View/Image/SunsetSceneExample.swift
@@ -436,3 +436,7 @@ private struct BadgeView: View {
         }
     }
 }
+
+#Preview {
+    SunsetSceneExample()
+}

--- a/Example/Shared/View/Image/VariableImageExample.swift
+++ b/Example/Shared/View/Image/VariableImageExample.swift
@@ -42,3 +42,7 @@ struct VariableImageExample: View {
          }
      }
  }
+
+#Preview {
+    VariableImageExample()
+}

--- a/Example/Shared/View/NamespaceExample.swift
+++ b/Example/Shared/View/NamespaceExample.swift
@@ -27,3 +27,7 @@ struct NamespaceExample: View {
             .id(first)
     }
 }
+
+#Preview {
+    NamespaceExample()
+}

--- a/Example/Shared/View/ProgressViewExample.swift
+++ b/Example/Shared/View/ProgressViewExample.swift
@@ -77,3 +77,19 @@ struct FoundationProgressViewExample: View {
             .padding()
     }
 }
+
+#Preview("ProgressViewExample") {
+    ProgressViewExample()
+}
+
+#Preview("IndeterminateProgressViewExample") {
+    IndeterminateProgressViewExample()
+}
+
+#Preview("DefaultDateProgressLabelExample") {
+    DefaultDateProgressLabelExample()
+}
+
+#Preview("FoundationProgressViewExample") {
+    FoundationProgressViewExample()
+}

--- a/Example/Shared/View/Text/LineLimitsExample.swift
+++ b/Example/Shared/View/Text/LineLimitsExample.swift
@@ -30,3 +30,11 @@ struct LineLimitReservesSpaceExample: View {
         }
     }
 }
+
+#Preview("LineLimitExample") {
+    LineLimitExample()
+}
+
+#Preview("LineLimitReservesSpaceExample") {
+    LineLimitReservesSpaceExample()
+}

--- a/Example/Shared/View/Text/TextExample.swift
+++ b/Example/Shared/View/Text/TextExample.swift
@@ -129,3 +129,19 @@ struct TextBackgroundHeightExample: View {
             .background(Color.red)
     }
 }
+
+#Preview("TextForegroundExample") {
+    TextForegroundExample()
+}
+
+#Preview("TextFormatStyleExample") {
+    TextFormatStyleExample()
+}
+
+#Preview("TextSystemFormatStyleExample") {
+    TextSystemFormatStyleExample()
+}
+
+#Preview("TextBackgroundHeightExample") {
+    TextBackgroundHeightExample()
+}

--- a/Example/Shared/View/Text/TextOrphanAndPushOutExample.swift
+++ b/Example/Shared/View/Text/TextOrphanAndPushOutExample.swift
@@ -32,3 +32,7 @@ struct TextOrphanAndPushOutExample: View {
         }
     }
 }
+
+#Preview {
+    TextOrphanAndPushOutExample()
+}

--- a/Example/Shared/View/ToggleExample.swift
+++ b/Example/Shared/View/ToggleExample.swift
@@ -22,3 +22,7 @@ struct ToggleExample: View {
         }
     }
 }
+
+#Preview {
+    ToggleExample()
+}

--- a/Example/Shared/ViewModifier/AppearanceActionModifierExample.swift
+++ b/Example/Shared/ViewModifier/AppearanceActionModifierExample.swift
@@ -25,3 +25,7 @@ struct AppearanceActionModifierExample: View {
             .id(first)
     }
 }
+
+#Preview {
+    AppearanceActionModifierExample()
+}

--- a/Example/Shared/ViewModifier/PreferenceActionModifierExample.swift
+++ b/Example/Shared/ViewModifier/PreferenceActionModifierExample.swift
@@ -25,3 +25,7 @@ struct PreferenceActionModifierExample: View {
             .onPreferenceChange(Key.self, perform: action)
     }
 }
+
+#Preview {
+    PreferenceActionModifierExample { _ in }
+}

--- a/Example/Shared/ViewModifier/ValueActionModifierExample.swift
+++ b/Example/Shared/ViewModifier/ValueActionModifierExample.swift
@@ -23,3 +23,7 @@ struct ValueActionModifierExample: View {
             }
     }
 }
+
+#Preview {
+    ValueActionModifierExample()
+}

--- a/Example/Tuist/Package.resolved
+++ b/Example/Tuist/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "f29d8609b7396a490f6044267bdd2085f2d5ce3aab2aed2de7c0283190c895f4",
+  "originHash" : "24f27c4fa462a56a8677d83e00650415b0dae1786d37f688f3e20df30f638e7c",
   "pins" : [
-    {
-      "identity" : "compute",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/OpenSwiftUIProject/Compute",
-      "state" : {
-        "revision" : "fcea97e940b65659e4ee8dd74fffacb332d1a103",
-        "version" : "0.5.2"
-      }
-    },
     {
       "identity" : "equatable",
       "kind" : "remoteSourceControl",


### PR DESCRIPTION
## Summary

- add Xcode previews to the existing shared example views, naming previews only when a file contains multiple variants
- update the `CAHostingLayer` example to use a platform representable that keeps layer bounds and display scale synchronized across UIKit and AppKit
- update the hosting-layer snapshot coverage and remove the stale Compute pin from the Example Tuist resolution