### PR TITLE
Implement ViewThatFits layout selection

### DIFF
--- a/Example/OpenSwiftUIUITests/Layout/ViewThatFitsUITests.swift
+++ b/Example/OpenSwiftUIUITests/Layout/ViewThatFitsUITests.swift
@@ -1,0 +1,16 @@
+//
+//  ViewThatFitsUITests.swift
+//  OpenSwiftUIUITests
+
+import SnapshotTesting
+import Testing
+@testable import TestingHost
+
+@MainActor
+@Suite(.snapshots(record: .never, diffTool: diffTool))
+struct ViewThatFitsUITests {
+    @Test
+    func uploadProgressAlternatives() {
+        openSwiftUIAssertSnapshot(of: ViewThatFitsExample())
+    }
+}

--- a/Example/Shared/Layout/ViewThatFitsExample.swift
+++ b/Example/Shared/Layout/ViewThatFitsExample.swift
@@ -1,0 +1,44 @@
+//
+//  ViewThatFitsExample.swift
+//  Shared
+
+import Foundation
+#if OPENSWIFTUI
+import OpenSwiftUI
+#else
+import SwiftUI
+#endif
+
+struct UploadProgressView: View {
+    var uploadProgress: Double
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack {
+                Text("\(uploadProgress.formatted(.percent))")
+                ProgressView(value: uploadProgress)
+                    .frame(width: 100)
+            }
+            ProgressView(value: uploadProgress)
+                .frame(width: 100)
+            Text("\(uploadProgress.formatted(.percent))")
+        }
+    }
+}
+
+struct ViewThatFitsExample: View {
+    var body: some View {
+        VStack {
+            UploadProgressView(uploadProgress: 0.75)
+                .frame(maxWidth: 200)
+            UploadProgressView(uploadProgress: 0.75)
+                .frame(maxWidth: 100)
+            UploadProgressView(uploadProgress: 0.75)
+                .frame(maxWidth: 50)
+        }
+    }
+}
+
+#Preview {
+    ViewThatFitsExample()
+}

--- a/Sources/OpenSwiftUI/Layout/ViewThatFits.swift
+++ b/Sources/OpenSwiftUI/Layout/ViewThatFits.swift
@@ -2,11 +2,15 @@
 //  ViewThatFits.swift
 //  OpenSwiftUI
 //
-//  Audited for 6.0.87
-//  Status: Blocked by Layout Computer
+//  Audited for 6.5.4
+//  Status: Complete
 //  ID: F613AABF2A2A0496B46514894D5116C3 (SwiftUI)
 
-public import OpenSwiftUICore
+@_spi(ForOpenSwiftUIOnly) public import OpenSwiftUICore
+import OpenAttributeGraphShims
+import OpenCoreGraphicsShims
+
+// MARK: - ViewThatFits
 
 /// A view that adapts to the available space by providing the first
 /// child view that fits.
@@ -62,6 +66,7 @@ public import OpenSwiftUICore
 /// the available horizontal space. The first line shows the text, 75%, and a
 /// three-quarters-full progress bar. The second line shows only the progress
 /// view. The third line shows only the text.](ViewThatFits-1)
+@available(OpenSwiftUI_v4_0, *)
 @frozen
 public struct ViewThatFits<Content>: View, UnaryView, PrimitiveView where Content: View {
     @usableFromInline
@@ -92,11 +97,11 @@ public struct ViewThatFits<Content>: View, UnaryView, PrimitiveView where Conten
             inputs: inputs
         )
     }
-
-    public typealias Body = Never
 }
 @available(*, unavailable)
 extension ViewThatFits: Sendable {}
+
+// MARK: - _SizeFittingRoot
 
 @frozen
 public struct _SizeFittingRoot: _VariadicView.UnaryViewRoot {
@@ -107,21 +112,291 @@ public struct _SizeFittingRoot: _VariadicView.UnaryViewRoot {
     init(axes: Axis.Set) { self.axes = axes }
 
     nonisolated public static func _makeView(root: _GraphValue<Self>, inputs: _ViewInputs, body: (_Graph, _ViewInputs) -> _ViewListOutputs) -> _ViewOutputs {
-        _openSwiftUIUnimplementedFailure()
+        let list = body(_Graph(), inputs)
+            .makeAttribute(inputs: _ViewListInputs(inputs.base))
+        var childInputs = inputs
+        childInputs.requestsLayoutComputer = false
+        childInputs.preferences.remove(WidgetAuxiliaryViewMetadata.Key.self)
+        var outputs = childInputs.makeIndirectOutputs()
+        let state = SizeFittingState(
+            root: root.value,
+            list: list,
+            inputs: childInputs,
+            outputs: outputs
+        )
+        let mux = Attribute(SizeFittingMux(state: state))
+        outputs.setIndirectDependency(mux.identifier)
+        if inputs.requestsLayoutComputer {
+            outputs.layoutComputer = Attribute(SizeFittingLayoutComputer(state: state))
+        }
+        if let representation = inputs.requestedViewThatFitsRepresentation,
+           representation.shouldMakeRepresentation(inputs: inputs) {
+            representation.makeRepresentation(inputs: inputs, state: state, outputs: &outputs)
+        }
+        return outputs
     }
 
-    public typealias Body = Never
+    fileprivate func size(_ size: CGSize, fits proposal: _ProposedSize) -> Bool {
+        (!axes.contains(.horizontal) || size.width <= (proposal.width ?? .infinity)) &&
+            (!axes.contains(.vertical) || size.height <= (proposal.height ?? .infinity))
+    }
 }
 
-// WIP
+// MARK: - SizeFittingState
+
 final package class SizeFittingState {
+    @Attribute var root: _SizeFittingRoot
+    @Attribute var list: any ViewList
+    let inputs: _ViewInputs
+    let outputs: _ViewOutputs
+    let parentSubgraph: Subgraph
+    var children: [ViewList.ID.Canonical: Child]
+    var seed: UInt32
 
+    init(
+        root: Attribute<_SizeFittingRoot>,
+        list: Attribute<any ViewList>,
+        inputs: _ViewInputs,
+        outputs: _ViewOutputs
+    ) {
+        _root = root
+        _list = list
+        self.inputs = inputs
+        self.outputs = outputs
+        parentSubgraph = Subgraph.current!
+        children = [:]
+        seed = 0
+    }
+
+    package func applyChildren(
+        selectLast: Bool,
+        to body: (_ViewOutputs, Bool) -> Bool
+    ) {
+        seed.unsafeIncrement()
+        let list = list
+        let count = list.count
+        var start = 0
+        var order = 0
+        var selectedOrder: Int?
+
+        list.applySublists(from: &start, list: $list) { sublist in
+            let lastOrder = count &- 1
+            for index in 0 ..< sublist.count {
+                let id = sublist.id.elementID(at: index).canonicalID
+                if let child = children[id] {
+                    if child.isInserted || selectedOrder == nil {
+                        precondition(child.seed != seed, "child view IDs must be unique: \(id)")
+                        var newChild = child
+                        newChild.seed = seed
+                        newChild.order = UInt32(truncatingIfNeeded: order)
+                        children[id] = newChild
+                        if selectedOrder == nil,
+                           body(newChild.outputs, order == lastOrder) {
+                            selectedOrder = order
+                        }
+                    }
+                } else if selectedOrder == nil {
+                    let subgraph = Subgraph(graph: parentSubgraph.graph)
+                    let child = subgraph.apply {
+                        var inputs = inputs
+                        inputs.copyCaches()
+                        let outputs = sublist.elements.makeOneElement(at: index, inputs: inputs) { inputs, makeElement in
+                            makeElement(inputs)
+                        } ?? _ViewOutputs()
+                        return Child(
+                            subgraph: subgraph,
+                            release: sublist.elements.retain(),
+                            outputs: outputs,
+                            seed: seed,
+                            order: order
+                        )
+                    }
+                    children[id] = child
+                    if selectedOrder == nil,
+                       body(child.outputs, order == lastOrder) {
+                        selectedOrder = order
+                    }
+                }
+                if order == lastOrder {
+                    return false
+                }
+                order &+= 1
+            }
+            return true
+        }
+
+        children = children.filter { _, child in
+            guard child.seed != seed else {
+                return true
+            }
+            child.subgraph.willInvalidate(isInserted: child.isInserted)
+            child.subgraph.invalidate()
+            return false
+        }
+
+        guard let selectedOrder, selectLast else {
+            return
+        }
+        children.forEach { id, value in
+            var child = value
+            let shouldInsert = Int(child.order) == selectedOrder
+            if shouldInsert != child.isInserted {
+                child.isInserted = shouldInsert
+                if shouldInsert {
+                    parentSubgraph.addChild(child.subgraph)
+                    child.subgraph.didReinsert()
+                    outputs.attachIndirectOutputs(to: child.outputs)
+                } else {
+                    child.subgraph.willRemove()
+                    parentSubgraph.removeChild(child.subgraph)
+                }
+            }
+            children[id] = child
+        }
+    }
+
+    package func invalidate() {
+        for child in children.values {
+            child.subgraph.willInvalidate(isInserted: child.isInserted)
+            child.subgraph.invalidate()
+        }
+    }
+
+    struct Child {
+        var subgraph: Subgraph
+        var release: ViewList.Elements.Release?
+        var outputs: _ViewOutputs
+        var seed: UInt32
+        var order: UInt32
+        var isInserted: Bool
+
+        @inline(__always)
+        init(
+            subgraph: Subgraph,
+            release: ViewList.Elements.Release?,
+            outputs: _ViewOutputs,
+            seed: UInt32,
+            order: Int
+        ) {
+            self.subgraph = subgraph
+            self.release = release
+            self.outputs = outputs
+            self.seed = seed
+            self.order = UInt32(truncatingIfNeeded: order)
+            isInserted = false
+        }
+    }
 }
 
-// Blocked by LayoutComputer
-private struct SizeFittingLayoutComputer {
-    struct Engine {}
+// MARK: - SizeFittingMux
+
+private struct SizeFittingMux: StatefulRule, ObservedAttribute, AsyncAttribute {
+    let state: SizeFittingState
+
+    typealias Value = Void
+
+    mutating func updateValue() {
+        let proposal = state.inputs.size.value.proposal
+        state.applyChildren(selectLast: true) { outputs, isLast in
+            let computer = outputs.layoutComputer?.value ?? .defaultValue
+            let axes = state.root.axes
+            var fittingProposal = proposal
+            if axes.contains(.horizontal) {
+                fittingProposal.width = nil
+            }
+            if axes.contains(.vertical) {
+                fittingProposal.height = nil
+            }
+            let size = computer.sizeThatFits(fittingProposal)
+            return isLast || state.root.size(size, fits: proposal)
+        }
+    }
+
+    mutating func destroy() {
+        state.invalidate()
+    }
 }
+
+// MARK: - SizeFittingLayoutComputer
+
+private struct SizeFittingLayoutComputer: StatefulRule, AsyncAttribute {
+    let state: SizeFittingState
+
+    typealias Value = LayoutComputer
+
+    mutating func updateValue() {
+        update(to: Engine(root: state.root, ctx: context, state: state))
+    }
+
+    private struct Engine: LayoutEngine {
+        var root: _SizeFittingRoot
+        let ctx: RuleContext<LayoutComputer>
+        let state: SizeFittingState
+        var sizeCache: ViewSizeCache = .init()
+
+        mutating func spacing() -> Spacing {
+            var result = Spacing.zero
+            ctx.update {
+                state.applyChildren(selectLast: false) { outputs, _ in
+                    let computer = outputs.layoutComputer?.value ?? .defaultValue
+                    result = computer.spacing()
+                    return true
+                }
+            }
+            return result
+        }
+
+        mutating func sizeThatFits(_ proposedSize: _ProposedSize) -> CGSize {
+            let root = root
+            let ctx = ctx
+            let state = state
+            return sizeCache.get(proposedSize) {
+                var result = CGSize.zero
+                ctx.update {
+                    state.applyChildren(selectLast: false) { outputs, _ in
+                        let computer = outputs.layoutComputer?.value ?? .defaultValue
+                        var fittingProposal = proposedSize
+                        if root.axes.contains(.horizontal) {
+                            fittingProposal.width = nil
+                        }
+                        if root.axes.contains(.vertical) {
+                            fittingProposal.height = nil
+                        }
+                        let fittingSize = computer.sizeThatFits(fittingProposal)
+                        result = computer.sizeThatFits(proposedSize)
+                        return root.size(fittingSize, fits: proposedSize)
+                    }
+                }
+                return result
+            }
+        }
+
+        mutating func explicitAlignment(_ key: AlignmentKey, at viewSize: ViewSize) -> CGFloat? {
+            var result: CGFloat?
+            ctx.update {
+                state.applyChildren(selectLast: false) { outputs, isLast in
+                    let computer = outputs.layoutComputer?.value ?? .defaultValue
+                    var fittingProposal = viewSize.proposal
+                    if root.axes.contains(.horizontal) {
+                        fittingProposal.width = nil
+                    }
+                    if root.axes.contains(.vertical) {
+                        fittingProposal.height = nil
+                    }
+                    let fittingSize = computer.sizeThatFits(fittingProposal)
+                    guard isLast || root.size(fittingSize, fits: viewSize.proposal) else {
+                        return false
+                    }
+                    result = computer.explicitAlignment(key, at: viewSize)
+                    return true
+                }
+            }
+            return result
+        }
+    }
+}
+
+// MARK: - PlatformViewThatFitsRepresentable
 
 package protocol PlatformViewThatFitsRepresentable {
     static func shouldMakeRepresentation(inputs: _ViewInputs) -> Bool
@@ -138,7 +413,7 @@ extension _ViewInputs {
 
 extension _GraphInputs {
     private struct ViewThatFitsRepresentationKey: GraphInput {
-        static var defaultValue: (any PlatformViewThatFitsRepresentable.Type)?
+        static var defaultValue: (any PlatformViewThatFitsRepresentable.Type)? { nil }
     }
 
     package var requestedViewThatFitsRepresentation: (any PlatformViewThatFitsRepresentable.Type)? {

--- a/Tests/OpenSwiftUITests/View/ViewThatFitsTests.swift
+++ b/Tests/OpenSwiftUITests/View/ViewThatFitsTests.swift
@@ -1,0 +1,49 @@
+//
+//  ViewThatFitsTests.swift
+//  OpenSwiftUITests
+
+import Foundation
+import OpenAttributeGraphShims
+@testable import OpenSwiftUI
+import Testing
+
+@MainActor
+struct ViewThatFitsTests {
+    @Test
+    func initialization() {
+        let defaultView = ViewThatFits { EmptyView() }
+        #expect(defaultView._tree.root.axes == [.horizontal, .vertical])
+
+        let horizontalView = ViewThatFits(in: .horizontal) { EmptyView() }
+        #expect(horizontalView._tree.root.axes == .horizontal)
+    }
+
+    @Test(.disabled(if: attributeGraphVendor == .oag))
+    func selectsFirstChildThatFits() {
+        struct ContentView: View {
+            var body: some View {
+                ViewThatFits {
+                    Color.red.frame(width: 200, height: 200)
+                    Color.blue.frame(width: 100, height: 100)
+                }
+            }
+        }
+
+        let graph = ViewGraph(
+            rootViewType: ContentView.self,
+            requestedOutputs: [.layout, .displayList]
+        )
+        graph.instantiateOutputs()
+        graph.setRootView(ContentView())
+
+        graph.setProposedSize(CGSize(width: 150, height: 150))
+        let (fallbackDisplayList, _) = graph.displayList()
+        #expect(fallbackDisplayList.items.count == 1)
+        #expect(fallbackDisplayList.items.first?.frame.size == CGSize(width: 100, height: 100))
+
+        graph.setProposedSize(CGSize(width: 250, height: 250))
+        let (preferredDisplayList, _) = graph.displayList()
+        #expect(preferredDisplayList.items.count == 1)
+        #expect(preferredDisplayList.items.first?.frame.size == CGSize(width: 200, height: 200))
+    }
+}


### PR DESCRIPTION
## Summary

- Implement ViewThatFits child management, fit selection, layout-computer behavior, and platform representation hooks.
- Add a shared upload-progress example with snapshot coverage for adaptive alternatives.
- Add initialization and child-selection tests, including fallback to the final child.