### PR TITLE
Fix inherited platform view state propagation

### DIFF
--- a/Example/OpenSwiftUIUITests/Integration/Representable/PlatformViewRepresentableUITests.swift
+++ b/Example/OpenSwiftUIUITests/Integration/Representable/PlatformViewRepresentableUITests.swift
@@ -45,4 +45,49 @@ struct PlatformViewRepresentableUITests {
         }
         openSwiftUIAssertSnapshot(of: ContentView())
     }
+
+    @Test
+    func clippedAncestorPreservesPlatformViewPosition() {
+        struct ColorView: PlatformViewRepresentable {
+            #if os(iOS) || os(visionOS)
+            func makeUIView(context: Context) -> some UIView {
+                let view = UIView()
+                view.backgroundColor = .green
+                return view
+            }
+
+            func updateUIView(_ uiView: UIViewType, context: Context) {}
+            #elseif os(macOS)
+            func makeNSView(context: Context) -> some NSView {
+                let view = NSView()
+                view.wantsLayer = true
+                view.layer?.backgroundColor = NSColor.green.cgColor
+                return view
+            }
+
+            func updateNSView(_ nsView: NSViewType, context: Context) {}
+            #endif
+        }
+
+        struct ContentView: View {
+            var body: some View {
+                VStack(spacing: 12) {
+                    Color.red
+                        .frame(width: 40, height: 40)
+                    ColorView()
+                        .frame(width: 100, height: 16)
+                }
+                .padding(8)
+                .background(Color.yellow)
+                .clipped()
+                .frame(
+                    width: defaultSize.width,
+                    height: defaultSize.height,
+                    alignment: .bottom
+                )
+            }
+        }
+
+        openSwiftUIAssertSnapshot(of: ContentView())
+    }
 }

--- a/Example/Shared/Layout/Stack/JindoKit/JindoKitExample.swift
+++ b/Example/Shared/Layout/Stack/JindoKit/JindoKitExample.swift
@@ -62,10 +62,8 @@ struct JindoKitExample: View {
                         Spacer()
                         Text("68%")
                     }
-
-                    Capsule()
-                        .fill(Color.mint)
-                        .frame(width: 180, height: 6)
+                    ProgressView(value: 0.68)
+                        .tint(Color.mint)
                 }
             }
         } compactLeading: {

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewUpdater.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewUpdater.swift
@@ -286,26 +286,24 @@ extension DisplayList {
                 return
             }
             if requirements.contains(.inheritedView) {
-                var result = withUnsafePointer(to: state) { statePtr in
-                    viewCache.update(
+                var result = viewCache.update(
+                    item: item,
+                    state: parentState,
+                    tag: .inherited,
+                    in: container.id
+                ) { [platform] _, item, state in
+                    platform.makeInheritedViewInfo(
                         item: item,
-                        state: statePtr,
-                        tag: .inherited,
-                        in: container.id
-                    ) { [platform] _, item, state in
-                        platform.makeInheritedViewInfo(
-                            item: item,
-                            size: item.size,
-                            state: state
-                        )
-                    } updateView: { [platform] info, _, item, state in
-                        platform.updateInheritedViewInfo(
-                            &info,
-                            item: item,
-                            size: item.size,
-                            state: state
-                        )
-                    }
+                        size: item.size,
+                        state: state
+                    )
+                } updateView: { [platform] info, _, item, state in
+                    platform.updateInheritedViewInfo(
+                        &info,
+                        item: item,
+                        size: item.size,
+                        state: state
+                    )
                 }
                 isValid = isValid && result.isValid
                 container.platform.addSubview(
@@ -385,26 +383,22 @@ extension DisplayList {
                 return nil
             }
             if oldRequirements.contains(.inheritedView) {
-                let result = withUnsafePointer(to: oldState) { oldStatePtr in
-                    withUnsafePointer(to: newState) { newStatePtr in
-                        viewCache.updateAsync(
-                            oldItem: oldItem,
-                            oldState: oldStatePtr,
-                            newItem: newItem,
-                            newState: newStatePtr,
-                            tag: .inherited
-                        ) { [platform] layer, _, oldItem, oldState, newItem, newState in
-                            platform.updateInheritedLayerAsync(
-                                layer: &layer,
-                                oldItem: oldItem,
-                                oldSize: oldItem.size,
-                                oldState: oldState,
-                                newItem: newItem,
-                                newSize: newItem.size,
-                                newState: newState
-                            )
-                        }
-                    }
+                let result = viewCache.updateAsync(
+                    oldItem: oldItem,
+                    oldState: oldParentState,
+                    newItem: newItem,
+                    newState: newParentState,
+                    tag: .inherited
+                ) { [platform] layer, _, oldItem, oldState, newItem, newState in
+                    platform.updateInheritedLayerAsync(
+                        layer: &layer,
+                        oldItem: oldItem,
+                        oldSize: oldItem.size,
+                        oldState: oldState,
+                        newItem: newItem,
+                        newSize: newItem.size,
+                        newState: newState
+                    )
                 }
                 guard var result else {
                     return nil


### PR DESCRIPTION
## Summary

Preserve the incoming parent state when materializing inherited views. The merged local state may reset inherited transforms and clips for child content, so passing it to the inherited wrapper could position platform-backed views incorrectly.

Apply the same state separation to synchronous and asynchronous updates, exercise the behavior with `ProgressView` in the JindoKit example, and add cross-platform snapshot coverage for a platform view inside a clipped ancestor.

Validated against SwiftUI reference snapshots on iOS 18.5 Simulator and macOS.