### PR TITLE
Update Dictionary.optimisticFilter for small dictionaries

### DIFF
--- a/Sources/OpenSwiftUICore/Util/StandardLibraryAdditions.swift
+++ b/Sources/OpenSwiftUICore/Util/StandardLibraryAdditions.swift
@@ -557,15 +557,35 @@ package struct Cache3<Key, Value> where Key: Equatable {
 
 extension Dictionary {
     package func optimisticFilter(_ predicate: (Element) -> Bool) -> [Key: Value] {
-        guard count > 64 else {
+        guard count <= 64 else {
             return filter(predicate)
         }
-        // FIXME: Use a more efficient approach for larger dictionaries
+        var matches = BitVector64()
+        var allMatch = true
+        var noMatches = true
+        var index = 0
+        for element in self {
+            if predicate(element) {
+                noMatches = false
+                matches[index] = true
+            } else {
+                allMatch = false
+            }
+            index &+= 1
+        }
+        if noMatches {
+            return [:]
+        }
+        if allMatch {
+            return self
+        }
         var result = [Key: Value]()
+        index = 0
         for (key, value) in self {
-            if predicate((key, value)) {
+            if matches[index] {
                 result[key] = value
             }
+            index &+= 1
         }
         return result
     }

--- a/Tests/OpenSwiftUICoreTests/Util/StandardLibraryAdditionsTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Util/StandardLibraryAdditionsTests.swift
@@ -310,6 +310,104 @@ struct Cache3Tests {
     }
 }
 
+// MARK: - DictionaryOptimisticFilterTests
+
+struct DictionaryOptimisticFilterTests {
+    @Test
+    func empty() {
+        let source: [Int: String] = [:]
+        var predicateCallCount = 0
+
+        let result = source.optimisticFilter { _ in
+            predicateCallCount += 1
+            return true
+        }
+
+        #expect(result == [:])
+        #expect(predicateCallCount == 0)
+    }
+
+    @Test
+    func allRejected() {
+        let source = [1: "one", 2: "two", 3: "three"]
+        var predicateCallCount = 0
+
+        let result = source.optimisticFilter { _ in
+            predicateCallCount += 1
+            return false
+        }
+
+        #expect(result == [:])
+        #expect(predicateCallCount == 3)
+    }
+
+    @Test
+    func allAccepted() {
+        let source = [1: "one", 2: "two", 3: "three"]
+        var predicateCallCount = 0
+
+        let result = source.optimisticFilter { _ in
+            predicateCallCount += 1
+            return true
+        }
+
+        #expect(result == source)
+        #expect(predicateCallCount == 3)
+    }
+
+    @Test
+    func mixedPredicateEvaluatedOncePerElement() {
+        let source = [1: "one", 2: "two", 3: "three", 4: "four"]
+        var callsByKey: [Int: Int] = [:]
+
+        let result = source.optimisticFilter { element in
+            callsByKey[element.key, default: 0] += 1
+            return element.key.isMultiple(of: 2)
+        }
+
+        #expect(result == [2: "two", 4: "four"])
+        #expect(callsByKey == [1: 1, 2: 1, 3: 1, 4: 1])
+    }
+
+    @Test
+    func highestMaskBit() {
+        let source = Dictionary(
+            uniqueKeysWithValues: (0 ..< 64).map { ($0, $0 * 10) }
+        )
+        let last = Array(source).last!
+        var callsByKey: [Int: Int] = [:]
+
+        let result = source.optimisticFilter { element in
+            callsByKey[element.key, default: 0] += 1
+            return element.key == last.key
+        }
+
+        #expect(result == [last.key: last.value])
+        #expect(callsByKey.count == source.count)
+        #expect(callsByKey.values.allSatisfy { $0 == 1 })
+    }
+
+    @Test(arguments: [64, 65])
+    func countBoundary(count: Int) {
+        let source = Dictionary(
+            uniqueKeysWithValues: (0 ..< count).map { ($0, $0 * 10) }
+        )
+        var callsByKey: [Int: Int] = [:]
+
+        let result = source.optimisticFilter { element in
+            callsByKey[element.key, default: 0] += 1
+            return element.key.isMultiple(of: 2)
+        }
+        let expected = Dictionary(
+            uniqueKeysWithValues: stride(from: 0, to: count, by: 2).map { ($0, $0 * 10) }
+        )
+
+        #expect(result == expected)
+        #expect(callsByKey.count == source.count)
+        #expect(callsByKey.values.allSatisfy { $0 == 1 })
+    }
+}
+
 // MARK: - RandomAccessCollection + lowerBound
 
 struct RandomAccessCollectionLowerBoundTests {


### PR DESCRIPTION
## Summary

- Reuse predicate results with a `BitVector64` for dictionaries containing up to 64 entries.
- Return early when every element is accepted or rejected, and delegate larger dictionaries to standard `filter`.
- Cover empty, homogeneous, mixed, highest-bit, and 64/65-element boundary cases with focused tests.