### PR TITLE
Reuse helpers for numeric operations and object addresses

### DIFF
--- a/Sources/OpenSwiftUI/App/App/AppGraph.swift
+++ b/Sources/OpenSwiftUI/App/App/AppGraph.swift
@@ -105,7 +105,7 @@ package final class AppGraph: GraphHost {
     // MARK: - Override Methods
 
     override package func instantiateOutputs() {
-        data.updateSeed &+= 1
+        data.updateSeed.unsafeIncrement()
         let outputs = rootSubgraph.apply {
             var inputs = _SceneInputs(
                 base: graphInputs,
@@ -187,7 +187,7 @@ extension AppGraph: GraphDelegate {
     }
 
     package func graphDidChange() {
-        data.updateSeed &+= 1
+        data.updateSeed.unsafeIncrement()
         runTransaction()
         let phaseChanged = $rootScenePhase.changedValue().changed
         let commandsChanged = $rootCommandsList?.changedValue().changed ?? false

--- a/Sources/OpenSwiftUI/Event/Platform/UIKit/ScrollEventConverter.swift
+++ b/Sources/OpenSwiftUI/Event/Platform/UIKit/ScrollEventConverter.swift
@@ -39,14 +39,14 @@ struct ScrollEventConverter {
             in: view
         )
         if rawPhase == 4 || rawPhase == 5 {
-            scrollSeed &+= 1
+            scrollSeed.unsafeIncrement()
             accumulatedScrollDelta = .zero
         }
         return [eventID: panEvent]
     }
 
     mutating func reset() {
-        scrollSeed &+= 1
+        scrollSeed.unsafeIncrement()
         accumulatedScrollDelta = .zero
     }
 }

--- a/Sources/OpenSwiftUI/Integration/Hosting/AppKit/View/NSHostingView.swift
+++ b/Sources/OpenSwiftUI/Integration/Hosting/AppKit/View/NSHostingView.swift
@@ -594,8 +594,8 @@ open class NSHostingView<Content>: NSView, XcodeViewDebugDataProvider where Cont
             contentMaxHeight = size.height.rounded(.up, toMultipleOf: pixelLength.height)
         }
 
-        contentMaxWidth = Swift.max(contentMaxWidth, contentMinWidth)
-        contentMaxHeight = Swift.max(contentMaxHeight, contentMinHeight)
+        contentMaxWidth.formMax(contentMinWidth)
+        contentMaxHeight.formMax(contentMinHeight)
 
         let currentMin = window.contentMinSize
         let currentMax = window.contentMaxSize
@@ -615,10 +615,10 @@ open class NSHostingView<Content>: NSView, XcodeViewDebugDataProvider where Cont
             var width = contentRect.width
             var height = contentRect.height
 
-            width = Swift.min(width, window.contentMaxSize.width)
-            width = Swift.max(width, window.contentMinSize.width)
-            height = Swift.min(height, window.contentMaxSize.height)
-            height = Swift.max(height, window.contentMinSize.height)
+            width.formMin(window.contentMaxSize.width)
+            width.formMax(window.contentMinSize.width)
+            height.formMin(window.contentMaxSize.height)
+            height.formMax(window.contentMinSize.height)
 
             if width != contentRect.width || height != contentRect.height {
                 window.setContentSize(CGSize(width: width, height: height))

--- a/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewRepresentable.swift
+++ b/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewRepresentable.swift
@@ -233,7 +233,7 @@ struct PlatformViewChild<Content: PlatformViewRepresentable>: StatefulRule {
             [
                 attribute.graph.graphIdentity(),
                 "\(Content.self)",
-                platformView.map { UInt(bitPattern: Unmanaged.passUnretained($0).toOpaque()) } ?? 0,
+                platformView.map { UInt(bitPattern: address(of: $0)) } ?? 0,
             ]
         ) {
             var (view, viewChanged) = $view.changedValue()

--- a/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewRepresentable.swift
+++ b/Sources/OpenSwiftUI/Integration/Representable/Platform/PlatformViewRepresentable.swift
@@ -804,7 +804,7 @@ private struct PlatformViewLayoutEngine<Content>: LayoutEngine where Content: Pl
         if k == VerticalAlignment.firstTextBaseline.key {
             let baseline = view.platformView._baselineOffsets(at: viewSize.value)
             let firstTextBaseline = baseline.firstTextBaseline
-            return firstTextBaseline.isNaN ? .zero : firstTextBaseline
+            return firstTextBaseline.mappingNaN(to: .zero)
         } else if k == VerticalAlignment.lastTextBaseline.key {
             let baseline = view.platformView._baselineOffsets(at: viewSize.value)
             let lastTextBaseline = baseline.lastTextBaseline

--- a/Sources/OpenSwiftUI/Layout/JindoTripleVStack.swift
+++ b/Sources/OpenSwiftUI/Layout/JindoTripleVStack.swift
@@ -538,7 +538,7 @@ extension JindoTripleVStack {
 
         mutating func updateWithSplit(at index: Int, before: CGFloat) {
             if index == 0 {
-                reserved.before = max(reserved.before, before)
+                reserved.before.formMax(before)
                 let group = groups[0]
                 groups[0] = Group(
                     count: group.count,
@@ -1571,8 +1571,7 @@ extension JindoTripleVStack {
                 let stackHeader = header.stacks[stack]
                 state.currentMajorAxisPosition = stackExtents[stack]
                 if state.range.lowerBound == stackHeader.topPrefix {
-                    sharedTopPrefixPosition = max(
-                        sharedTopPrefixPosition,
+                    sharedTopPrefixPosition.formMax(
                         stackExtents[stack]
                             + distanceToPrevious(state.range.lowerBound, stack: stack)
                     )
@@ -1642,7 +1641,7 @@ extension JindoTripleVStack {
                         states[stateIndex].currentMajorAxisPosition = bottom
                     }
                 }
-                resultHeight = max(resultHeight, bottom)
+                resultHeight.formMax(bottom)
             }
 
             header.stackSize = CGSize(width: proposal.width, height: resultHeight)

--- a/Sources/OpenSwiftUI/Layout/JindoTripleVStack.swift
+++ b/Sources/OpenSwiftUI/Layout/JindoTripleVStack.swift
@@ -1548,7 +1548,7 @@ extension JindoTripleVStack {
                     )
                     children[childIndex] = child
                     let height = child.geometry.dimensions.height
-                    let consumedHeight = height.isNaN ? 0 : height
+                    let consumedHeight = height.mappingNaN(to: 0)
                     for stack in Stack.allCases {
                         if let stateIndex = children[childIndex].majorAxisGroup[stack] {
                             states[stateIndex].consume(consumedHeight)

--- a/Sources/OpenSwiftUI/Modifier/ViewModifier/GeometryActionModifier.swift
+++ b/Sources/OpenSwiftUI/Modifier/ViewModifier/GeometryActionModifier.swift
@@ -203,7 +203,7 @@ private struct GeometryActionBinder<Provider>: StatefulRule, AsyncAttribute wher
         if phase.resetSeed != lastResetSeed {
             reset(seed: phase.resetSeed)
         }
-        proxySeed &+= 1
+        proxySeed.unsafeIncrement()
         let proxy = GeometryProxy(
             owner: attribute.identifier,
             size: $size,

--- a/Sources/OpenSwiftUI/View/Image/AsyncImage.swift
+++ b/Sources/OpenSwiftUI/View/Image/AsyncImage.swift
@@ -509,7 +509,7 @@ extension CGImageSource {
         guard let properties = CGImageSourceCopyPropertiesAtIndex(self, index, nil),
               let orientationResult = CFDictionaryGetValue(
                 properties,
-                Unmanaged.passUnretained(kCGImagePropertyOrientation).toOpaque()
+                address(of: kCGImagePropertyOrientation)
               ),
               let orientation = unsafeBitCast(orientationResult, to: NSNumber.self) as? Int
         else {

--- a/Sources/OpenSwiftUICore/Data/DynamicProperty/DynamicPropertyBuffer.swift
+++ b/Sources/OpenSwiftUICore/Data/DynamicProperty/DynamicPropertyBuffer.swift
@@ -405,7 +405,7 @@ public struct _DynamicPropertyBuffer {
             let itemSize = Int(oldItemPointer.pointee.size)
             newBuffer += itemSize
             oldBuffer += itemSize
-            count &-= 1
+            count.unsafeDecrement()
         }
         oldBuffer = buf
         if size > 0 {

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceKey.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceKey.swift
@@ -160,7 +160,7 @@ package struct HostPreferencesKey: PreferenceKey {
     private static var nodeId = UInt32.zero
     
     package static func makeNodeId() -> UInt32 {
-        nodeId &+= 1
+        nodeId.unsafeIncrement()
         return nodeId
     }
 }

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceTransformModifier.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceTransformModifier.swift
@@ -156,7 +156,7 @@ private struct HostPreferencesTransform<K>: StatefulRule, AsyncAttribute, Custom
         if keyRequested {
             let anyInputsChanged = Graph.anyInputsChanged(excluding: [_keys.identifier, _childValues.base.identifier])
             if anyInputsChanged {
-                delta &+= 1
+                delta.unsafeIncrement()
                 requiresUpdate = true
             }
             if anyInputsChanged || requiresUpdate {

--- a/Sources/OpenSwiftUICore/Data/Preference/PreferenceWritingModifier.swift
+++ b/Sources/OpenSwiftUICore/Data/Preference/PreferenceWritingModifier.swift
@@ -148,7 +148,7 @@ private struct HostPreferencesWriter<K>: StatefulRule, AsyncAttribute, CustomStr
         if keyRequested {
             let (keyValue, keyValueChanged) = $keyValue.changedValue()
             if keyValueChanged {
-                delta &+= 1
+                delta.unsafeIncrement()
                 requiresUpdate = true
             }
             if keyValueChanged || requiresUpdate {

--- a/Sources/OpenSwiftUICore/Data/Update.swift
+++ b/Sources/OpenSwiftUICore/Data/Update.swift
@@ -77,7 +77,7 @@ package enum Update {
                 "ViewHost: (%p) update began PlatformHost [ %p ]",
                 [
                     0,
-                    UInt(bitPattern: Unmanaged.passUnretained(trackHost).toOpaque()),
+                    UInt(bitPattern: address(of: trackHost)),
                 ]
             )
             #endif
@@ -94,7 +94,7 @@ package enum Update {
                 "ViewHost: (%p) update ended PlatformHost [ %p ]",
                 [
                     0,
-                    UInt(bitPattern: Unmanaged.passUnretained(trackHost).toOpaque()),
+                    UInt(bitPattern: address(of: trackHost)),
                 ]
             )
             #endif

--- a/Sources/OpenSwiftUICore/Data/Util/ObjectCache.swift
+++ b/Sources/OpenSwiftUICore/Data/Util/ObjectCache.swift
@@ -58,7 +58,7 @@ final package class ObjectCache<Key, Value> where Key: Hashable {
                 let index = bucket + offset
                 if let itemData = data.table[index].data {
                     if itemData.hash == hash, itemData.key == key {
-                        data.clock &+= 1
+                        data.clock.unsafeIncrement()
                         data.table[index].used = data.clock
                         return itemData.value
                     } else {

--- a/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
+++ b/Sources/OpenSwiftUICore/Data/Util/PropertyList.swift
@@ -428,7 +428,7 @@ private func find1<Key>(
             if let result { return result }
         }
         if currentElement.keyType == Key.self {
-            return .fromOpaque(Unmanaged.passUnretained(currentElement).toOpaque())
+            return .fromOpaque(address(of: currentElement))
         }
         guard let after = currentElement.after else {
             return nil
@@ -467,10 +467,10 @@ private func findValueWithSecondaryLookup<Lookup>(
         }
         let keyType = currentElement.keyType
         if keyType == Lookup.Primary.self {
-            let element: Unmanaged<TypedElement<Lookup.Primary>> = .fromOpaque(Unmanaged.passUnretained(currentElement).toOpaque())
+            let element: Unmanaged<TypedElement<Lookup.Primary>> = .fromOpaque(address(of: currentElement))
             return element.takeUnretainedValue().value
         } else if keyType == Lookup.Secondary.self {
-            let element: Unmanaged<TypedElement<Lookup.Secondary>> = .fromOpaque(Unmanaged.passUnretained(currentElement).toOpaque())
+            let element: Unmanaged<TypedElement<Lookup.Secondary>> = .fromOpaque(address(of: currentElement))
             if let value = Lookup.lookup(in: element.takeUnretainedValue().value) {
                 return value
             }

--- a/Sources/OpenSwiftUICore/Event/Gesture/DelayedGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/DelayedGesture.swift
@@ -100,7 +100,7 @@ private struct DelayedPhase<BodyValue>: ResettableGestureRule {
         let deadline = startTime + delayedModifier.duration
         if useGestureGraph {
             let gestureGraph = GestureGraph.current
-            gestureGraph.nextUpdateTime = min(gestureGraph.nextUpdateTime, deadline)
+            gestureGraph.nextUpdateTime.formMin(deadline)
         } else {
             ViewGraph.current.nextUpdate.gestures.at(deadline)
         }

--- a/Sources/OpenSwiftUICore/Event/Gesture/DistanceGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/DistanceGesture.swift
@@ -25,7 +25,7 @@ package struct DistanceGesture: Gesture {
             let movement: CGFloat
             if let start {
                 movement = distance(start, location)
-                maxDistance = max(maxDistance, movement)
+                maxDistance.formMax(movement)
             } else {
                 start = location
                 movement = .zero

--- a/Sources/OpenSwiftUICore/Event/Gesture/DurationGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/DurationGesture.swift
@@ -130,7 +130,7 @@ private struct DurationPhase<BodyValue>: ResettableGestureRule {
             }
             if useGestureGraph {
                 let gestureGraph = GestureGraph.current
-                gestureGraph.nextUpdateTime = min(gestureGraph.nextUpdateTime, deadline)
+                gestureGraph.nextUpdateTime.formMin(deadline)
             } else {
                 ViewGraph.current.nextUpdate.gestures.at(deadline)
             }

--- a/Sources/OpenSwiftUICore/Event/Gesture/GestureGraph.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/GestureGraph.swift
@@ -140,7 +140,7 @@ final package class GestureGraph: GraphHost, EventGraphHost, CustomStringConvert
         startTransactionUpdate()
         if data.time != time {
             data.time = time
-            data.updateSeed &+= 1 // not setTime due to this
+            data.updateSeed.unsafeIncrement() // not setTime due to this
             timeDidChange()
         }
         gestureEvents = events

--- a/Sources/OpenSwiftUICore/Event/Gesture/RepeatGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/RepeatGesture.swift
@@ -96,7 +96,7 @@ private struct RepeatPhase<V>: ResettableGestureRule {
                 self.value = phase
             }
         case let .ended(wrapped):
-            index &+= 1
+            index.unsafeIncrement()
             if modifier.count > Int(index) {
                 deadline = time + modifier.maximumDelay
                 value = .possible(wrapped)

--- a/Sources/OpenSwiftUICore/Event/Gesture/RepeatGesture.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/RepeatGesture.swift
@@ -115,7 +115,7 @@ private struct RepeatPhase<V>: ResettableGestureRule {
         }
         if useGestureGraph {
             let gestureGraph = GestureGraph.current
-            gestureGraph.nextUpdateTime = min(gestureGraph.nextUpdateTime, deadline)
+            gestureGraph.nextUpdateTime.formMin(deadline)
         } else {
             ViewGraph.current.nextUpdate.gestures.at(deadline)
         }

--- a/Sources/OpenSwiftUICore/Event/Responder/MultiViewResponder.swift
+++ b/Sources/OpenSwiftUICore/Event/Responder/MultiViewResponder.swift
@@ -72,7 +72,7 @@ open class MultiViewResponder: ViewResponder {
                     options: options
                 )
                 mask.formUnion(childResult.mask)
-                priority = max(priority, childResult.priority)
+                priority.formMax(childResult.priority)
             }
             return ContainsPointsResult(mask: mask, priority: priority, children: children)
         }

--- a/Sources/OpenSwiftUICore/Graph/GraphHost.swift
+++ b/Sources/OpenSwiftUICore/Graph/GraphHost.swift
@@ -170,7 +170,7 @@ open class GraphHost: CustomReflectable {
             guard let self else { return }
             graphInvalidation(from: attribute)
         }
-        graph.context = UnsafeRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        graph.context = address(of: self)
     }
     
     deinit {

--- a/Sources/OpenSwiftUICore/Graph/GraphHost.swift
+++ b/Sources/OpenSwiftUICore/Graph/GraphHost.swift
@@ -311,7 +311,7 @@ extension GraphHost {
     
     // TODO: _ArchivedViewHost.reset()
     package final func incrementPhase() {
-        data.phase.resetSeed &+= 1
+        data.phase.resetSeed.unsafeIncrement()
         graphDelegate?.graphDidChange()
     }
     
@@ -492,7 +492,7 @@ extension GraphHost {
     
     package final func startTransactionUpdate() {
         inTransaction = true
-        data.transactionSeed &+= 1
+        data.transactionSeed.unsafeIncrement()
     }
 
     package final func finishTransactionUpdate(in subgraph: Subgraph, postUpdate: (_ again: Bool) -> Void = { _ in }) {

--- a/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
+++ b/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
@@ -665,7 +665,7 @@ struct DynamicContainerInfo<Adapter>: StatefulRule, AsyncAttribute, ObservedAttr
         let phase: TransitionPhase
         switch info.items[index].phase {
         case .willAppear, .identity:
-            info.items[index].resetSeed &-= 1
+            info.items[index].resetSeed.unsafeDecrement()
             phase = .identity
         case .didDisappear:
             info.removedCount &-= 1

--- a/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
+++ b/Sources/OpenSwiftUICore/Layout/Dynamic/DynamicContainer.swift
@@ -452,7 +452,7 @@ struct DynamicContainerInfo<Adapter>: StatefulRule, AsyncAttribute, ObservedAttr
                 return
             }
         }
-        info.seed &+= 1
+        info.seed.unsafeIncrement()
         value = info
     }
 
@@ -576,7 +576,7 @@ struct DynamicContainerInfo<Adapter>: StatefulRule, AsyncAttribute, ObservedAttr
                         info.items.swapAt(target, reusedIndex)
                     }
                 } else {
-                    lastUniqueId &+= 1
+                    lastUniqueId.unsafeIncrement()
                     let createdItem = makeItem(
                         item,
                         uniqueId: lastUniqueId,
@@ -710,7 +710,7 @@ struct DynamicContainerInfo<Adapter>: StatefulRule, AsyncAttribute, ObservedAttr
         if unusedCount < maxUnusedItems {
             info.items.remove(at: index)
             item.removalOrder = 0
-            item.resetSeed &+= 1
+            item.resetSeed.unsafeIncrement()
             item.phase = nil
             item.listener?.viewGraph = nil
             item.listener = nil

--- a/Sources/OpenSwiftUICore/Layout/Edge/EdgeInsets.swift
+++ b/Sources/OpenSwiftUICore/Layout/Edge/EdgeInsets.swift
@@ -266,17 +266,17 @@ extension EdgeInsets {
     }
 
     package mutating func formPointwiseMin(_ other: EdgeInsets) {
-        top = min(top, other.top)
-        leading = min(leading, other.leading)
-        bottom = min(bottom, other.bottom)
-        trailing = min(trailing, other.trailing)
+        top.formMin(other.top)
+        leading.formMin(other.leading)
+        bottom.formMin(other.bottom)
+        trailing.formMin(other.trailing)
     }
 
     package mutating func formPointwiseMax(_ other: EdgeInsets) {
-        top = max(top, other.top)
-        leading = max(leading, other.leading)
-        bottom = max(bottom, other.bottom)
-        trailing = max(trailing, other.trailing)
+        top.formMax(other.top)
+        leading.formMax(other.leading)
+        bottom.formMax(other.bottom)
+        trailing.formMax(other.trailing)
     }
 
     @inline(__always)

--- a/Sources/OpenSwiftUICore/Layout/Geometry/GeometryReader.swift
+++ b/Sources/OpenSwiftUICore/Layout/Geometry/GeometryReader.swift
@@ -78,7 +78,7 @@ public struct GeometryReader<Content>: View, UnaryView, PrimitiveView where Cont
         typealias Value = _VariadicView.Tree<_LayoutRoot<GeometryReaderLayout>, Content>
 
         mutating func updateValue() {
-            seed &+= 1
+            seed.unsafeIncrement()
             let proxy = GeometryProxy(
                 owner: attribute.identifier,
                 size: $size,

--- a/Sources/OpenSwiftUICore/Layout/View/ViewSize.swift
+++ b/Sources/OpenSwiftUICore/Layout/View/ViewSize.swift
@@ -129,8 +129,8 @@ extension ViewSize {
         return ViewSize(
             value: CGSize(width: newWidth, height: newHeight),
             proposal: CGSize(
-                width: newWidth.isNaN ? 0 : newWidth,
-                height: newHeight.isNaN ? 0 : newHeight
+                width: newWidth.mappingNaN(to: 0),
+                height: newHeight.mappingNaN(to: 0)
             )
         )
     }

--- a/Sources/OpenSwiftUICore/Log/CycleDetector.swift
+++ b/Sources/OpenSwiftUICore/Log/CycleDetector.swift
@@ -39,7 +39,7 @@ package struct UpdateCycleDetector {
             return true
         }
         if ttl != 0 {
-            ttl &-= 1
+            ttl.unsafeDecrement()
         }
         guard ttl == 0 else {
             return true

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
@@ -156,7 +156,7 @@ package struct DisplayList: Equatable {
         var nextUpdate = Time.infinity
         if features.contains(.dynamicContent) {
             for item in items {
-                nextUpdate = min(nextUpdate, item.nextUpdate(after: time))
+                nextUpdate.formMin(item.nextUpdate(after: time))
                 if nextUpdate == time {
                     break
                 }
@@ -447,7 +447,7 @@ extension DisplayList {
         package init() { value = .zero }
         
         package init(decodedValue value: Int) {
-            Version.lastValue = max(Version.lastValue, value)
+            Version.lastValue.formMax(value)
             self.value = value
         }
         
@@ -457,7 +457,7 @@ extension DisplayList {
         }
         
         package mutating func combine(with other: Version) {
-            value = max(value, other.value)
+            value.formMax(other.value)
         }
 
         package static func < (lhs: Version, rhs: Version) -> Bool {
@@ -1171,22 +1171,23 @@ extension DisplayList.Item {
         case let .content(content):
             switch content.value {
             case let .text(text, _):
-                nextUpdate = min(nextUpdate, text.text.nextUpdate(after: time, equivalentDate: .now, reduceFrequency: false)
+                nextUpdate.formMin(
+                    text.text.nextUpdate(after: time, equivalentDate: .now, reduceFrequency: false)
                 )
             case let .flattened(list, _, _):
-                nextUpdate = min(nextUpdate, list.nextUpdate(after: time))
+                nextUpdate.formMin(list.nextUpdate(after: time))
             default:
                 break
             }
         case let .effect(effect, list):
-            nextUpdate = min(nextUpdate, list.nextUpdate(after: time))
+            nextUpdate.formMin(list.nextUpdate(after: time))
             switch effect {
             case let .mask(mask, _):
-                nextUpdate = min(nextUpdate, mask.nextUpdate(after: time))
+                nextUpdate.formMin(mask.nextUpdate(after: time))
             case .animation:
                 nextUpdate = time
             case let .interpolatorLayer(group, _):
-                nextUpdate = min(nextUpdate, group.nextUpdate(after: time))
+                nextUpdate.formMin(group.nextUpdate(after: time))
             default:
                 break
             }
@@ -1200,7 +1201,7 @@ extension DisplayList.Item {
                 } else {
                     nestedUpdate = .infinity
                 }
-                nextUpdate = min(nextUpdate, nestedUpdate)
+                nextUpdate.formMin(nestedUpdate)
             }
         case .empty:
             break

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList.swift
@@ -553,7 +553,7 @@ extension DisplayList {
         package init() {}
         package mutating func enter(identity: Identity) -> Index {
             if identity == .none {
-                self.serial &+= 1
+                self.serial.unsafeIncrement()
                 let copy = self
                 self.restored = []
                 return copy

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewCache.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewCache.swift
@@ -120,7 +120,7 @@ extension DisplayList.ViewUpdater {
             }
             removed.removeAll()
             animators = animators.filter { $0.value.deadline >= time }
-            cacheSeed &+= 1
+            cacheSeed.unsafeIncrement()
         }
 
         /// Removes a managed subview from the cache and recursively

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewPlatform.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewPlatform.swift
@@ -502,8 +502,7 @@ extension DisplayList.ViewUpdater.Platform {
                     },
                     sizeChanged: viewInfo.state.size != item.size
                 )
-                viewInfo.nextUpdate = min(
-                    viewInfo.nextUpdate,
+                viewInfo.nextUpdate.formMin(
                     text.text.nextUpdate(
                         after: state.pointee.globals.pointee.time,
                         equivalentDate: .now,
@@ -526,7 +525,7 @@ extension DisplayList.ViewUpdater.Platform {
                     ),
                     sizeChanged: viewInfo.state.size != item.size
                 )
-                viewInfo.nextUpdate = min(viewInfo.nextUpdate, list.nextUpdate(after: time))
+                viewInfo.nextUpdate.formMin(list.nextUpdate(after: time))
             case let .drawing(contents, offset, options):
                 if viewInfo.state.kind != .drawing {
                     viewInfo = _makeItemView(item: item, state: state)
@@ -773,7 +772,7 @@ extension DisplayList.ViewUpdater.Platform {
                 ) else {
                     return false
                 }
-                layer.nextUpdate = min(layer.nextUpdate, newList.nextUpdate(after: time))
+                layer.nextUpdate.formMin(newList.nextUpdate(after: time))
             case let (.drawing(_, _, oldOptions), .drawing(newContents, newOffset, newOptions)):
                 guard updateDrawingViewAsync(
                     &layer,

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewRenderer.swift
@@ -373,7 +373,7 @@ extension DisplayList {
                     printTree = ProcessEnvironment.bool(forKey: "OPENSWIFTUI_PRINT_TREE")
                 }
                 if let printTree, printTree {
-                    print("View \(Unmanaged.passUnretained(self).toOpaque()) at \(time):\n\(list.description)")
+                    print("View \(address(of: self)) at \(time):\n\(list.description)")
                 }
                 renderer.renderDisplayList(list, at: time, in: &ctx)
                 let duration = renderer.nextTime - time

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewUpdater.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewUpdater.swift
@@ -213,7 +213,7 @@ extension DisplayList {
                 let savedIndex = viewCache.index.enter(identity: item.identity)
                 defer { viewCache.index.leave(index: savedIndex) }
                 let nextTime = viewCache.prepare(item: &item, parentState: parentState)
-                container.nextTime = min(container.nextTime, nextTime)
+                container.nextTime.formMin(nextTime)
                 updateInheritedView(
                     container: &container,
                     from: item,
@@ -312,7 +312,7 @@ extension DisplayList {
                     at: container.count
                 )
                 container.count &+= 1
-                container.nextTime = min(container.nextTime, result.nextUpdate)
+                container.nextTime.formMin(result.nextUpdate)
                 guard result.changed || !wasValid else {
                     if case let .effect(effect, list) = item.value {
                         viewCache.index.skip(list: list)
@@ -504,7 +504,7 @@ extension DisplayList {
                 at: container.count
             )
             container.count &+= 1
-            container.nextTime = min(container.nextTime, result.nextUpdate)
+            container.nextTime.formMin(result.nextUpdate)
             guard case let .effect(effect, list) = item.value else {
                 return
             }
@@ -541,7 +541,7 @@ extension DisplayList {
                     parentState: &localState
                 )
                 maskContainer.removeRemaining(viewCache: &viewCache)
-                nextTime = min(nextTime, maskContainer.nextTime)
+                nextTime.formMin(maskContainer.nextTime)
             }
             viewCache.setNextUpdate(nextTime, in: &result)
         }
@@ -606,7 +606,7 @@ extension DisplayList {
                 guard let maskNextTime else {
                     return nil
                 }
-                nextTime = min(nextTime, maskNextTime)
+                nextTime.formMin(maskNextTime)
             }
             viewCache.setNextUpdate(nextTime, in: &result)
             return result.nextUpdate

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewUpdater.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayListViewUpdater.swift
@@ -86,7 +86,7 @@ extension DisplayList {
                 printTree = ProcessEnvironment.bool(forKey: "OPENSWIFTUI_PRINT_TREE")
             }
             if let printTree, printTree {
-                print("View \(Unmanaged.passUnretained(rootView).toOpaque()) at \(time):\n\(list.description)")
+                print("View \(address(of: rootView)) at \(time):\n\(list.description)")
             }
             let globals = Model.State.Globals(
                 updater: self,

--- a/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList_StableIdentity.swift
+++ b/Sources/OpenSwiftUICore/Render/DisplayList/DisplayList_StableIdentity.swift
@@ -79,7 +79,7 @@ package struct _DisplayList_StableIdentityScope: ViewInput, _ViewTraitKey {
     }
     
     package mutating func makeIdentity() -> _DisplayList_StableIdentity {
-        serial &+= 1
+        serial.unsafeIncrement()
         return _DisplayList_StableIdentity(hash: hash, serial: serial)
     }
     

--- a/Sources/OpenSwiftUICore/Render/GeometryEffect/MatchedGeometryEffect.swift
+++ b/Sources/OpenSwiftUICore/Render/GeometryEffect/MatchedGeometryEffect.swift
@@ -348,7 +348,7 @@ private final class MatchedGeometryScope: ViewInput {
         }
         keyedFrames[key] = frameIndex
         frames[frameIndex].views.insert(view, at: 0)
-        frames[frameIndex].viewsSeed &+= 1
+        frames[frameIndex].viewsSeed.unsafeIncrement()
         if needsUpdate {
             let weakFrame = WeakAttribute(frames[frameIndex].$frame)
             GraphHost.currentHost.continueTransaction {
@@ -371,7 +371,7 @@ private final class MatchedGeometryScope: ViewInput {
             keyedFrames.removeValue(forKey: frames[index].key)
             frames[index].key = AnyHashable(EmptyKey())
         } else {
-            frames[index].viewsSeed &+= 1
+            frames[index].viewsSeed.unsafeIncrement()
         }
     }
 
@@ -632,7 +632,7 @@ private struct SharedFrame: StatefulRule, AsyncAttribute, ObservedAttribute {
             if sourceIndex != 0 {
                 let sourceView = scope.frames[frameIndex].views.remove(at: sourceIndex)
                 scope.frames[frameIndex].views.insert(sourceView, at: 0)
-                scope.frames[frameIndex].viewsSeed &+= 1
+                scope.frames[frameIndex].viewsSeed.unsafeIncrement()
             }
         }
         guard let currentView = scope.frames[frameIndex].views.first else {

--- a/Sources/OpenSwiftUICore/Shape/ShapeStyle/ShapeStyleRendering.swift
+++ b/Sources/OpenSwiftUICore/Shape/ShapeStyle/ShapeStyleRendering.swift
@@ -448,7 +448,7 @@ final package class _ShapeStyle_InterpolatorGroup: DisplayList.InterpolatorGroup
     override func nextUpdate(after time: Time) -> Time {
         var nextUpdate = Time.infinity
         for layer in layers {
-            nextUpdate = min(nextUpdate, layer.state.nextUpdate(after: time))
+            nextUpdate.formMin(layer.state.nextUpdate(after: time))
         }
         return nextUpdate
     }

--- a/Sources/OpenSwiftUICore/Shape/ShapeStyle/ShapeStyleResolver.swift
+++ b/Sources/OpenSwiftUICore/Shape/ShapeStyle/ShapeStyleResolver.swift
@@ -75,7 +75,7 @@ package struct _ShapeStyle_ResolverMode: Equatable {
 
     package mutating func formUnion(_ rhs: _ShapeStyle_ResolverMode) {
         bundle = bundle ?? rhs.bundle
-        foregroundLevels = max(foregroundLevels, rhs.foregroundLevels)
+        foregroundLevels.formMax(rhs.foregroundLevels)
         options.formUnion(rhs.options)
     }
 }

--- a/Sources/OpenSwiftUICore/View/DynamicView/IDView.swift
+++ b/Sources/OpenSwiftUICore/View/DynamicView/IDView.swift
@@ -91,7 +91,7 @@ private struct IDPhase<ID>: StatefulRule, AsyncAttribute where ID: Hashable {
     mutating func updateValue() {
         if lastID != id {
             if lastID != nil {
-                delta &+= 1
+                delta.unsafeIncrement()
             }
             lastID = id
         }

--- a/Sources/OpenSwiftUICore/View/DynamicViewContent/ForEach.swift
+++ b/Sources/OpenSwiftUICore/View/DynamicViewContent/ForEach.swift
@@ -345,7 +345,7 @@ private class ForEachState<Data, ID, Content> where Data: RandomAccessCollection
         }
         contentID = UniqueID().value
         let oldSeed = seed
-        seed &+= 1
+        seed.unsafeIncrement()
         invalidateViewCounts()
         if self.view != nil, self.view!.idGenerator.isConstant {
             if self.view!.data.count != view.data.count {
@@ -1561,7 +1561,7 @@ private struct ForEachList<Data, ID, Content>: ViewList where Data: RandomAccess
 
         mutating func updateValue() {
             info.state.invalidateViewCounts()
-            seed &+= 1
+            seed.unsafeIncrement()
             value = ForEachList(state: info.state, seed: seed)
         }
 

--- a/Sources/OpenSwiftUICore/View/Graph/ViewGraph.swift
+++ b/Sources/OpenSwiftUICore/View/Graph/ViewGraph.swift
@@ -431,7 +431,7 @@ extension ViewGraph {
     
     private func beginNextUpdate(at time: Time) {
         setTime(time)
-        data.updateSeed &+= 1
+        data.updateSeed.unsafeIncrement()
         mainUpdates = graph.mainUpdates
     }
 

--- a/Sources/OpenSwiftUICore/View/Graph/ViewRendererHost.swift
+++ b/Sources/OpenSwiftUICore/View/Graph/ViewRendererHost.swift
@@ -62,7 +62,7 @@ extension ViewRendererHost {
             "ViewHost: (%p) initialized PlatformHost [ %p ]",
             [
                 viewGraph.graph.graphIdentity(),
-                UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque()),
+                UInt(bitPattern: address(of: self)),
             ]
         )
         #endif
@@ -77,7 +77,7 @@ extension ViewRendererHost {
             "ViewHost: (%p) invalidated PlatformHost [ %p ]",
             [
                 viewGraph.graph.graphIdentity(),
-                UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque()),
+                UInt(bitPattern: address(of: self)),
             ]
         )
         #endif

--- a/Sources/OpenSwiftUICore/View/Image/NamedImage.swift
+++ b/Sources/OpenSwiftUICore/View/Image/NamedImage.swift
@@ -368,7 +368,7 @@ package enum NamedImage {
                     CGImageSetProperty(
                         cgImage,
                         "org.OpenSwiftUIProject.OpenSwiftUI.ObjectToRetain" as CFString,
-                        Unmanaged.passUnretained(cat).toOpaque()
+                        address(of: cat)
                     )
                 }
                 contents = .cgImage(cgImage)

--- a/Sources/OpenSwiftUICore/View/Input/ViewList.swift
+++ b/Sources/OpenSwiftUICore/View/Input/ViewList.swift
@@ -2279,7 +2279,7 @@ open class _ViewList_Subgraph {
 
     @inline(__always)
     final func invalidate(isInserted: Bool) {
-        refcount &-= 1
+        refcount.unsafeDecrement()
         guard refcount == 0 else {
             return
         }

--- a/Sources/OpenSwiftUICore/View/Input/ViewList.swift
+++ b/Sources/OpenSwiftUICore/View/Input/ViewList.swift
@@ -2274,7 +2274,7 @@ open class _ViewList_Subgraph {
 
     @inline(__always)
     final func retain() {
-        refcount &+= 1
+        refcount.unsafeIncrement()
     }
 
     @inline(__always)

--- a/Sources/OpenSwiftUICore/View/Input/ViewListContent.swift
+++ b/Sources/OpenSwiftUICore/View/Input/ViewListContent.swift
@@ -292,7 +292,7 @@ private struct PlaceholderInfo: StatefulRule, ObservedAttribute, AsyncAttribute 
             as: PlaceholderViewPhase.self,
             invalidating: true
         ) { phase in
-            phase.resetDelta &+= 1
+            phase.resetDelta.unsafeIncrement()
         }
         secondaryRelease = placeholder.elements.retain()
         info.id = placeholder.id

--- a/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
+++ b/Sources/OpenSwiftUICore/View/Text/AttributedString/Text+NSAttributedString.swift
@@ -229,9 +229,9 @@ extension NSAttributedString {
             let font = value as! CTFont
             let fontAscender = font.ascender
             let fontDescender = font.descender
-            capHeight = max(capHeight, font.capHeight)
-            ascender = max(ascender, fontAscender)
-            descender = max(descender, fontDescender)
+            capHeight.formMax(font.capHeight)
+            ascender.formMax(fontAscender)
+            descender.formMax(fontDescender)
             leading = leading.map { max($0, font.leading) } ?? font.leading
             if hasOversizedScalars || font.mayRequireLanguageAwareOutsets {
                 var left: CGFloat = 0
@@ -239,10 +239,10 @@ extension NSAttributedString {
                 var right: CGFloat = 0
                 var bottom: CGFloat = 0
                 if CTFontGetLanguageAwareOutsets(font, &left, &top, &right, &bottom) {
-                    outsets.top = max(outsets.top, top)
-                    outsets.leading = max(outsets.leading, left)
-                    outsets.bottom = max(outsets.bottom, bottom)
-                    outsets.trailing = max(outsets.trailing, right)
+                    outsets.top.formMax(top)
+                    outsets.leading.formMax(left)
+                    outsets.bottom.formMax(bottom)
+                    outsets.trailing.formMax(right)
                     return
                 }
             }
@@ -250,8 +250,8 @@ extension NSAttributedString {
                 var clippingAscender = fontAscender
                 var clippingDescender = fontDescender
                 if CTFontGetClippingMetrics(font, &clippingAscender, &clippingDescender) {
-                    outsets.top = max(outsets.top, max(0, clippingAscender - fontAscender))
-                    outsets.bottom = max(outsets.bottom, max(0, clippingDescender - fontDescender))
+                    outsets.top.formMax(max(0, clippingAscender - fontAscender))
+                    outsets.bottom.formMax(max(0, clippingDescender - fontDescender))
                 }
             }
         }

--- a/Sources/OpenSwiftUICore/View/Text/FormatStyle/UpdateFrequencyDependentFormatStyle.swift
+++ b/Sources/OpenSwiftUICore/View/Text/FormatStyle/UpdateFrequencyDependentFormatStyle.swift
@@ -199,12 +199,8 @@ extension Duration.UnitsFormatStyle: UpdateFrequencyDependentFormatStyle {
             style.fractionalPartDisplay.roundingIncrement = min(roundingIncrement, increment)
         }
         let maximumLength = Int(log10(1.0 / increment))
-        style.fractionalPartDisplay.maximumLength = min(
-            style.fractionalPartDisplay.maximumLength,
-            maximumLength
-        )
-        style.fractionalPartDisplay.minimumLength = min(
-            style.fractionalPartDisplay.minimumLength,
+        style.fractionalPartDisplay.maximumLength.formMin(maximumLength)
+        style.fractionalPartDisplay.minimumLength.formMin(
             style.fractionalPartDisplay.maximumLength
         )
         return style

--- a/Sources/OpenSwiftUICore/View/Text/Resolve/ConfigurationBasedResolvableStringAttribute.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Resolve/ConfigurationBasedResolvableStringAttribute.swift
@@ -48,7 +48,7 @@ package enum ResolvableAttributeConfiguration: Equatable {
         switch (self, other) {
         case let (.interval(lhsDelay), .interval(rhsDelay)):
             let delay: Double? = if let lhsDelay {
-                rhsDelay.map { min(lhsDelay, $0) } ?? lhsDelay
+                min(lhsDelay, ifPresent: rhsDelay)
             } else {
                 rhsDelay
             }

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+LayoutShape.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+LayoutShape.swift
@@ -62,14 +62,14 @@ package struct TextShape: Equatable {
                 if let targetWidth {
                     width = targetWidth
                 }
-                height = max(height, size.height)
+                height.formMax(size.height)
             case .right:
                 if let targetWidth {
                     width = targetWidth
                 } else {
                     width = size.width + width
                 }
-                height = max(height, size.height)
+                height.formMax(size.height)
             default: _openSwiftUIUnreachableCode()
             }
         }

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+StringDrawingContext.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+StringDrawingContext.swift
@@ -215,7 +215,7 @@ extension NSAttributedString {
                     } else {
                         sourceLineCount = components.count
                     }
-                    let limitedSourceLineCount = lineLimit.map { min(sourceLineCount, $0) } ?? sourceLineCount
+                    let limitedSourceLineCount = min(sourceLineCount, ifPresent: lineLimit)
                     matchesSourceLineCount = limitedSourceLineCount == drawingContext.numberOfLineFragments
                 } else {
                     matchesSourceLineCount = true

--- a/Sources/OpenSwiftUICore/View/Text/Text/Text+View.swift
+++ b/Sources/OpenSwiftUICore/View/Text/Text/Text+View.swift
@@ -492,10 +492,10 @@ extension NSAttributedString {
             ) else {
                 return
             }
-            margins.top = max(margins.top, top)
-            margins.leading = max(margins.leading, left)
-            margins.bottom = max(margins.bottom, bottom)
-            margins.trailing = max(margins.trailing, right)
+            margins.top.formMax(top)
+            margins.leading.formMax(left)
+            margins.bottom.formMax(bottom)
+            margins.trailing.formMax(right)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Use `unsafeIncrement()` and `unsafeDecrement()` for supported wrapping arithmetic.
- Use `address(of:)` for object pointers in graph setup, property lookup, image handling, and logging.
- Use `formMin`, `formMax`, `min(_:ifPresent:)`, and `mappingNaN(to:)` for bounds, optional limits, and NaN fallbacks, preserving comparison order and existing behavior.
