### PR TITLE
docs: require Conventional Commits for commits and PR titles

### DIFF
--- a/.agents/skills/openswiftui-pr-authoring/SKILL.md
+++ b/.agents/skills/openswiftui-pr-authoring/SKILL.md
@@ -6,7 +6,8 @@ description: Draft or review public OpenSwiftUI pull request titles and bodies. 
 # OpenSwiftUI Pull Request Authoring
 
 - Write PR titles and bodies in English and scope them to the committed diff.
-- Use a concise sentence-case title that describes the outcome.
+- Use a concise Conventional Commits title that describes the outcome. Follow
+  the [contributor guide](../../../CONTRIBUTING.md#commit-messages-and-pull-request-titles).
 - Use `## Summary` for the main body. Start the first word of every summary
   bullet with a capital letter, and keep the bullets parallel and
   outcome-focused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,10 @@ swift test --list-tests
 
 Follow `.agents/skills/openswiftui-test-authoring/SKILL.md`.
 
-## Pull Requests
+## Commits and Pull Requests
+
+Use Conventional Commits for all new commit messages and PR titles. Follow the
+[contributor guide](CONTRIBUTING.md#commit-messages-and-pull-request-titles).
 
 Follow `.agents/skills/openswiftui-pr-authoring/SKILL.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,32 @@ A useful issue report includes:
 For crashes or platform-specific behavior, note whether the issue occurs with
 OpenSwiftUI, SwiftUI, or both.
 
+## Commit messages and pull request titles
+
+All new commit messages and pull request titles must follow
+[Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+Use this format for the commit subject or pull request title:
+
+```text
+<type>[optional scope][!]: <description>
+```
+
+Use `feat` for new features and `fix` for bug fixes. Other common types include
+`docs`, `refactor`, `perf`, `test`, `build`, `ci`, `style`, and `chore`.
+Keep the description concise. Add a scope when it helps identify the affected
+component. Commit bodies and footers are optional and follow a blank line.
+
+Mark breaking changes with `!` before `:` in the subject or pull request title.
+A commit message can use a `BREAKING CHANGE: <description>` footer instead.
+
+Examples:
+
+```text
+feat(text): add text alignment support
+fix(layout): preserve child spacing
+docs: require Conventional Commits
+```
+
 ## Pull requests
 
 Pull requests should:


### PR DESCRIPTION
## Summary

- Require Conventional Commits 1.0.0 for new commit messages and pull request titles, with format guidance and examples.
- Link repository and pull request authoring instructions to the contributor guide.
