### PR TITLE
fix(binding): forward projected location writes

### DIFF
--- a/Sources/OpenSwiftUICore/Data/Binding/Location.swift
+++ b/Sources/OpenSwiftUICore/Data/Binding/Location.swift
@@ -390,9 +390,10 @@ private struct ProjectedLocation<L: Location, P: Projection>: Location where P.B
         projection.get(base: location.get())
     }
 
-    func set(_ value: Value, transaction _: Transaction) {
+    func set(_ value: Value, transaction: Transaction) {
         var base = location.get()
         projection.set(base: &base, newValue: value)
+        location.set(base, transaction: transaction)
     }
 
     func update() -> (Value, Bool) {

--- a/Tests/OpenSwiftUICoreTests/Data/Binding/BindingOperationsTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Binding/BindingOperationsTests.swift
@@ -5,8 +5,8 @@
 //  Author: Claude Code with Claude Sonnet 4.5
 
 import Foundation
-import Testing
 @testable import OpenSwiftUICore
+import Testing
 
 struct BindingOperationsTests {
 
@@ -37,10 +37,8 @@ struct BindingOperationsTests {
 
             let optionalBinding: Binding<Int?> = Binding(baseBinding)
             optionalBinding.wrappedValue = 20
-            #expect(optionalBinding.wrappedValue == 10)
-
-            storage = 20
             #expect(optionalBinding.wrappedValue == 20)
+            #expect(storage == 20)
         }
 
         @Test
@@ -86,10 +84,8 @@ struct BindingOperationsTests {
 
             let anyHashableBinding: Binding<AnyHashable> = Binding(baseBinding)
             anyHashableBinding.wrappedValue = AnyHashable(20)
-            #expect(anyHashableBinding.wrappedValue == AnyHashable(10))
-
-            storage = 20
             #expect(anyHashableBinding.wrappedValue == AnyHashable(20))
+            #expect(storage == 20)
         }
 
         @Test
@@ -105,10 +101,8 @@ struct BindingOperationsTests {
             #expect(anyHashableBinding.wrappedValue == AnyHashable("hello"))
 
             anyHashableBinding.wrappedValue = AnyHashable("world")
-            #expect(anyHashableBinding.wrappedValue == AnyHashable("hello"))
-
-            storage = "world"
             #expect(anyHashableBinding.wrappedValue == AnyHashable("world"))
+            #expect(storage == "world")
         }
     }
 
@@ -157,10 +151,8 @@ struct BindingOperationsTests {
             }
 
             unwrappedBinding.wrappedValue = 20
-            #expect(unwrappedBinding.wrappedValue == 10)
-
-            storage = 20
             #expect(unwrappedBinding.wrappedValue == 20)
+            #expect(storage == 20)
         }
     }
 
@@ -218,10 +210,8 @@ struct BindingOperationsTests {
             #expect(nilCoalescingBinding.wrappedValue == 100)
 
             nilCoalescingBinding.wrappedValue = 50
-            #expect(nilCoalescingBinding.wrappedValue == 100)
-
-            storage.value = 50
             #expect(nilCoalescingBinding.wrappedValue == 50)
+            #expect(storage.value == 50)
         }
 
         @Test
@@ -272,10 +262,8 @@ struct BindingOperationsTests {
 
             let doubleBinding: Binding<Double> = Binding(baseBinding)
             doubleBinding.wrappedValue = 2.5
-            #expect(doubleBinding.wrappedValue.isApproximatelyEqual(to: 1.0, absoluteTolerance: 0.001))
-
-            storage = 2.5
             #expect(doubleBinding.wrappedValue.isApproximatelyEqual(to: 2.5, absoluteTolerance: 0.001))
+            #expect(storage == 2.5)
         }
 
         @Test
@@ -302,10 +290,8 @@ struct BindingOperationsTests {
 
             let doubleBinding: Binding<Double> = Binding(baseBinding)
             doubleBinding.wrappedValue = 2.71828
-            #expect(doubleBinding.wrappedValue.isApproximatelyEqual(to: 1.0))
-
-            storage = 2.71828
             #expect(doubleBinding.wrappedValue.isApproximatelyEqual(to: 2.71828))
+            #expect(storage == 2.71828)
         }
     }
 
@@ -336,10 +322,8 @@ struct BindingOperationsTests {
 
             let doubleBinding: Binding<Double> = Binding(baseBinding)
             doubleBinding.wrappedValue = 25.7
-            #expect(doubleBinding.wrappedValue == 10.0)
-
-            storage = 25
             #expect(doubleBinding.wrappedValue == 25.0)
+            #expect(storage == 25)
         }
 
         @Test
@@ -355,10 +339,8 @@ struct BindingOperationsTests {
             #expect(doubleBinding.wrappedValue == 100.0)
 
             doubleBinding.wrappedValue = 200.5
-            #expect(doubleBinding.wrappedValue == 100.0)
-
-            storage = 200
             #expect(doubleBinding.wrappedValue == 200.0)
+            #expect(storage == 200)
         }
     }
 
@@ -404,10 +386,8 @@ struct BindingOperationsTests {
             #expect(resultBinding.wrappedValue == false)
 
             resultBinding.wrappedValue = true
-            #expect(resultBinding.wrappedValue == false)
-
-            storage = 42
             #expect(resultBinding.wrappedValue == true)
+            #expect(storage == 42)
         }
 
         @Test
@@ -443,10 +423,8 @@ struct BindingOperationsTests {
             #expect(resultBinding2.wrappedValue == false)
 
             resultBinding2.wrappedValue = true
-            #expect(resultBinding2.wrappedValue == false)
-
-            storage = "world"
             #expect(resultBinding2.wrappedValue == true)
+            #expect(storage == "world")
 
             resultBinding2.wrappedValue = false
             #expect(resultBinding2.wrappedValue == true)

--- a/Tests/OpenSwiftUICoreTests/Data/Binding/BindingTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Binding/BindingTests.swift
@@ -85,7 +85,8 @@ struct BindingTests {
         #expect(optionalBinding.wrappedValue == 0)
             
         optionalBinding.wrappedValue = 10
-        #expect(optionalBinding.wrappedValue == 0)
+        #expect(optionalBinding.wrappedValue == 10)
+        #expect(storage == 10)
         storage = 20
         #expect(optionalBinding.wrappedValue == 20)
         optionalBinding.wrappedValue = nil
@@ -233,7 +234,8 @@ struct BindingTests {
         let anyHashableBinding: Binding<AnyHashable> = Binding(baseBinding)
         #expect(anyHashableBinding.wrappedValue == AnyHashable(0))
         anyHashableBinding.wrappedValue = 10
-        #expect(anyHashableBinding.wrappedValue == AnyHashable(0))
+        #expect(anyHashableBinding.wrappedValue == AnyHashable(10))
+        #expect(storage == 10)
         storage = 20
         #expect(anyHashableBinding.wrappedValue == AnyHashable(20))
         // #expectCrash(optionalBinding.wrappedValue = 0.0)

--- a/Tests/OpenSwiftUICoreTests/Data/Binding/LocationTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Data/Binding/LocationTests.swift
@@ -110,6 +110,34 @@ struct LocationTests {
     #endif
 
     @Test
+    func projectedWriteForwardsValueAndTransaction() {
+        struct Value: Equatable {
+            var count = 0
+            var name = "value"
+        }
+
+        var value = Value()
+        var receivedTransaction: Transaction?
+        var writes = 0
+        let location = LocationBox(FunctionalLocation {
+            value
+        } setValue: { newValue, transaction in
+            value = newValue
+            receivedTransaction = transaction
+            writes += 1
+        })
+        let projection = location.projecting(\Value.count)
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+
+        projection.set(3, transaction: transaction)
+
+        #expect(value == Value(count: 3))
+        #expect(receivedTransaction?.disablesAnimations == true)
+        #expect(writes == 1)
+    }
+
+    @Test
     func constantLocation() throws {
         let location = ConstantLocation(value: 0)
         #expect(location.wasRead == true)


### PR DESCRIPTION
## Summary

- Write the updated base value through the underlying location with the original transaction.
- Add regression coverage for the stored value, unchanged fields, transaction forwarding, and exactly one underlying write.
- Update binding projection tests to check both the projected value and the underlying storage after writes.

## Stack

Depends on #1048.
