### PR TITLE
fix(build): avoid UIKit indexing crashes on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -221,9 +221,9 @@ var sharedSwiftSettings: [SwiftSetting] = [
 
     .define("OPENSWIFTUI_RELEASE_\(releaseVersion)"),
     .unsafeFlags(["-Xfrontend", "-experimental-spi-only-imports"]),
-    // Swift 6.3.3 crashes while indexing AppKit with the private framework shims.
+    // Swift 6.3.3 can crash while indexing UIKit or AppKit with the private framework shims.
     // Keep source indexing enabled while skipping imported system modules.
-    .unsafeFlags(["-index-ignore-system-modules"], .when(platforms: [.macOS])),
+    .unsafeFlags(["-index-ignore-system-modules"], .when(platforms: [.macOS, .iOS])),
 ]
 
 if releaseVersion >= 2021 {


### PR DESCRIPTION
## Summary

- Extend the Swift 6.3.3 system-module indexing workaround to iOS to avoid UIKit deserialization crashes during builds.
- Keep source indexing enabled on iOS and macOS.
