### PR TITLE
refactor: use WeakAttribute.base directly

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "0cec3b3219dd2d99818e861e3dca7598e7554f98"
+        "revision" : "f60ef4da9f8a39c4ae760832593ad5aadce7e51c"
       }
     },
     {
@@ -16,7 +16,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/OpenAttributeGraph",
       "state" : {
         "branch" : "main",
-        "revision" : "7b30d536202535c8e2e235de48764c9d5e6e6f00"
+        "revision" : "b5d71c9e750ce92dbaad44adaae09a08cc689ee9"
       }
     },
     {

--- a/Sources/OpenSwiftUICore/Graph/GraphHost.swift
+++ b/Sources/OpenSwiftUICore/Graph/GraphHost.swift
@@ -498,7 +498,7 @@ extension GraphHost {
         asyncTransaction(
             transaction,
             id: transactionID,
-            mutation: InvalidatingGraphMutation(attribute: .init(attribute)),
+            mutation: InvalidatingGraphMutation(attribute: attribute.base),
             style: style,
             mayDeferUpdate: mayDeferUpdate
         )

--- a/Sources/OpenSwiftUICore/Util/AttributeGraphAdditions.swift
+++ b/Sources/OpenSwiftUICore/Util/AttributeGraphAdditions.swift
@@ -184,7 +184,7 @@ extension Attribute {
 
 extension WeakAttribute {
     package var uncheckedIdentifier: Attribute<Value> {
-        Attribute(identifier: AnyWeakAttribute(self)._details.identifier)
+        Attribute(identifier: base._details.identifier)
     }
 
     package func allowsAsyncUpdate() -> Bool {


### PR DESCRIPTION
## Summary

- Update the OpenAttributeGraph and DarwinPrivateFrameworks revisions to include public `WeakAttribute.base` access.
- Remove redundant weak attribute conversions in `GraphHost.asyncTransaction` and `WeakAttribute.uncheckedIdentifier` by accessing `base` directly.

## Validation

Standalone clients compiled successfully with OpenAttributeGraph and AttributeGraph. The AttributeGraph client also linked successfully.

## Dependency

- [DarwinPrivateFrameworks#71](https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks/pull/71) (merged)
- [OpenAttributeGraph#241](https://github.com/OpenSwiftUIProject/OpenAttributeGraph/pull/241) (merged)
