### PR TITLE
feat(event): complete MultiViewResponder implementation

### DIFF
--- a/Sources/OpenSwiftUICore/Event/Responder/MultiViewResponder.swift
+++ b/Sources/OpenSwiftUICore/Event/Responder/MultiViewResponder.swift
@@ -2,18 +2,19 @@
 //  MultiViewResponder.swift
 //  OpenSwiftUICore
 //
-//  Status: Blocked by children.setter
+//  Audited for 6.5.4
+//  Status: Complete
 //  ID: 4A74C6B0E69BD6BC864CC77E33CF2D28 (SwiftUICore)
 
 public import Foundation
 
-// MARK: - MultiViewResponder [6.5.4] [WIP]
+// MARK: - MultiViewResponder
 
 @_spi(ForOpenSwiftUIOnly)
 open class MultiViewResponder: ViewResponder {
-    private var _children: [ViewResponder]
-    private var cache: ContainsPointsCache
-    private var observers: ContentPathObservers
+    private var _children: [ViewResponder] = []
+    private var cache: ContainsPointsCache = .init()
+    private var observers: ContentPathObservers = .init()
 
     override public init() {
         _children = []
@@ -22,7 +23,63 @@ open class MultiViewResponder: ViewResponder {
         super.init()
     }
 
-    // MARK: - MultiViewResponder: ResponderNode
+    override final public var children: [ViewResponder] {
+        get { _children }
+        set {
+            var count = _children.count
+            var index = 0
+            var changed = false
+            for child in newValue {
+                var foundIndex: Int?
+                if child.parent === self {
+                    for candidateIndex in index..<count {
+                        if _children[candidateIndex] === child {
+                            foundIndex = candidateIndex
+                            break
+                        }
+                    }
+                }
+                if let foundIndex {
+                    if foundIndex != index {
+                        _children.swapAt(index, foundIndex)
+                        changed = true
+                    }
+                } else {
+                    child.parent = self
+                    _children.append(child)
+                    if index < count {
+                        _children.swapAt(index, count)
+                    }
+                    count += 1
+                    changed = true
+                }
+                index += 1
+            }
+            if index < count {
+                for removalIndex in index..<count {
+                    let child = _children[removalIndex]
+                    if child.parent === self {
+                        child.parent = nil
+                    }
+                }
+                _children.removeSubrange(index..<count)
+                changed = true
+            }
+            if changed {
+                childrenDidChange()
+            }
+        }
+    }
+
+    final package func updateChildren(_ data: (value: [ViewResponder], changed: Bool)) {
+        if data.changed {
+            children = data.value
+        }
+    }
+
+    open func childrenDidChange() {
+        observers.notifyDidChange(for: self)
+    }
 
     override open func bindEvent(_ event: any EventType) -> ResponderNode? {
         for child in children {
@@ -34,28 +91,11 @@ open class MultiViewResponder: ViewResponder {
         return nil
     }
 
-    @discardableResult
-    override final public func visit(applying visitor: (ResponderNode) -> ResponderVisitorResult) -> ResponderVisitorResult {
-        let result = visitor(self)
-        guard result == .next else {
-            return result
-        }
-        for child in children {
-            let childResult = child.visit(applying: visitor)
-            guard childResult != .cancel else {
-                return .cancel
-            }
-        }
-        return .next
-    }
-
     override open func resetGesture() {
         for child in children {
             child.resetGesture()
         }
     }
-
-    // MARK: - MultiViewResponder: ViewResponder
 
     override open func containsGlobalPoints(
         _ points: [PlatformPoint],
@@ -101,13 +141,21 @@ open class MultiViewResponder: ViewResponder {
         observers.addObserver(observer)
     }
 
-    override final public var children: [ViewResponder] {
-        get { _children }
-        set { _openSwiftUIUnimplementedFailure() }
-    }
-
-    open func childrenDidChange() {
-        observers.notifyDidChange(for: self)
+    @discardableResult
+    override final public func visit(
+        applying visitor: (ResponderNode) -> ResponderVisitorResult
+    ) -> ResponderVisitorResult {
+        let result = visitor(self)
+        guard result == .next else {
+            return result
+        }
+        for child in children {
+            let childResult = child.visit(applying: visitor)
+            guard childResult != .cancel else {
+                return .cancel
+            }
+        }
+        return .next
     }
 }
 

--- a/Sources/OpenSwiftUICore/Event/Responder/ResponderNode.swift
+++ b/Sources/OpenSwiftUICore/Event/Responder/ResponderNode.swift
@@ -10,7 +10,9 @@
 @_spi(ForOpenSwiftUIOnly)
 @available(OpenSwiftUI_v6_0, *)
 open class ResponderNode {
-    public init() {}
+    public init() {
+        _openSwiftUIEmptyStub()
+    }
 
     open var nextResponder: ResponderNode? {
         _openSwiftUIBaseClassAbstractMethod()

--- a/Tests/OpenSwiftUICoreTests/Event/Responder/MultiViewResponderTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Event/Responder/MultiViewResponderTests.swift
@@ -1,0 +1,239 @@
+//
+//  MultiViewResponderTests.swift
+//  OpenSwiftUICoreTests
+//
+//  Author: GPT-6 Astra
+
+import OpenAttributeGraphShims
+@_spi(ForOpenSwiftUIOnly) @testable import OpenSwiftUICore
+import Testing
+
+@MainActor
+@Suite(.disabled(if: attributeGraphVendor == .oag))
+struct MultiViewResponderTests {
+    @Test
+    func unchangedChildrenKeepObserverUntilNextChange() {
+        withViewGraph {
+            let parent = MultiViewResponder()
+            let first = TestResponder("first")
+            let second = TestResponder("second")
+            let observer = TestContentPathObserver()
+
+            parent.addObserver(observer)
+            parent.children = []
+            #expect(observer.changeCount == 0)
+
+            parent.children = [first, second]
+            #expect(observer.changeCount == 1)
+
+            parent.addObserver(observer)
+            parent.children = [first, second]
+            #expect(observer.changeCount == 1)
+
+            parent.children = [second, first]
+            #expect(observer.changeCount == 2)
+            #expect(parent.children.map(ObjectIdentifier.init) == [
+                ObjectIdentifier(second), ObjectIdentifier(first),
+            ])
+            #expect(first.parent === parent)
+            #expect(second.parent === parent)
+            #expect(first.resetCount == 0)
+            #expect(second.resetCount == 0)
+        }
+    }
+
+    @Test
+    func insertingChildrenPreservesExistingParents() {
+        withViewGraph {
+            let parent = MultiViewResponder()
+            let first = TestResponder("first")
+            let second = TestResponder("second")
+            let inserted = TestResponder("inserted")
+            let appended = TestResponder("appended")
+            parent.children = [first, second]
+
+            parent.children = [inserted, second, first, appended]
+
+            #expect(parent.children.map(ObjectIdentifier.init) == [
+                ObjectIdentifier(inserted), ObjectIdentifier(second),
+                ObjectIdentifier(first), ObjectIdentifier(appended),
+            ])
+            #expect(first.parent === parent)
+            #expect(second.parent === parent)
+            #expect(inserted.parent === parent)
+            #expect(appended.parent === parent)
+            #expect(first.resetCount == 0)
+            #expect(second.resetCount == 0)
+        }
+    }
+
+    @Test
+    func removalCallbacksSeeReorderedChildrenBeforeTruncation() {
+        withViewGraph {
+            let parent = MultiViewResponder()
+            let first = TestResponder("first")
+            let second = TestResponder("second")
+            let retained = TestResponder("retained")
+            parent.children = [first, second, retained]
+            let parentID = ObjectIdentifier(parent)
+            let reorderedIDs = [
+                ObjectIdentifier(retained), ObjectIdentifier(second), ObjectIdentifier(first),
+            ]
+            var callbacks: [String] = []
+            for child in [first, second] {
+                child.onReset = { responder in
+                    callbacks.append("reset \(responder.name)")
+                    #expect(responder.parent.map(ObjectIdentifier.init) == parentID)
+                    #expect(responder.parent?.children.map(ObjectIdentifier.init) == reorderedIDs)
+                }
+            }
+            let observer = TestContentPathObserver { updatedParent in
+                callbacks.append("changed")
+                #expect(updatedParent.children.map(ObjectIdentifier.init) == [ObjectIdentifier(retained)])
+                #expect(first.parent == nil)
+                #expect(second.parent == nil)
+            }
+            parent.addObserver(observer)
+
+            parent.children = [retained]
+
+            #expect(callbacks == ["reset second", "reset first", "changed"])
+            #expect(observer.changeCount == 1)
+            #expect(parent.children.map(ObjectIdentifier.init) == [ObjectIdentifier(retained)])
+            #expect(first.parent == nil)
+            #expect(second.parent == nil)
+            #expect(retained.parent === parent)
+            #expect(retained.resetCount == 0)
+        }
+    }
+
+    @Test
+    func removalDoesNotDetachChildFromAnotherParent() {
+        withViewGraph {
+            let parent = MultiViewResponder()
+            let otherParent = MultiViewResponder()
+            let moved = TestResponder("moved")
+            let retained = TestResponder("retained")
+            parent.children = [moved, retained]
+            otherParent.children = [moved]
+
+            parent.children = [retained]
+
+            #expect(parent.children.map(ObjectIdentifier.init) == [ObjectIdentifier(retained)])
+            #expect(otherParent.children.map(ObjectIdentifier.init) == [ObjectIdentifier(moved)])
+            #expect(moved.parent === otherParent)
+            #expect(retained.parent === parent)
+            #expect(moved.resetCount == 0)
+            #expect(retained.resetCount == 0)
+        }
+    }
+
+    @Test
+    func clearingChildrenDetachesEachChildOnce() {
+        withViewGraph {
+            let parent = MultiViewResponder()
+            let first = TestResponder("first")
+            let second = TestResponder("second")
+            parent.children = [first, second]
+            let observer = TestContentPathObserver { updatedParent in
+                #expect(updatedParent.children.isEmpty)
+                #expect(first.parent == nil)
+                #expect(second.parent == nil)
+            }
+            parent.addObserver(observer)
+
+            parent.children = []
+
+            #expect(parent.children.isEmpty)
+            #expect(first.parent == nil)
+            #expect(second.parent == nil)
+            #expect(first.resetCount == 1)
+            #expect(second.resetCount == 1)
+            #expect(observer.changeCount == 1)
+        }
+    }
+
+    private func withViewGraph(_ body: () -> Void) {
+        let graph = ViewGraph(rootViewType: EmptyView.self)
+        let host = TestEventGraphHost(graph: graph)
+        graph.delegate = host
+        withExtendedLifetime(host) {
+            graph.rootSubgraph.apply(body)
+        }
+    }
+}
+
+private final class TestResponder: ViewResponder {
+    let name: String
+    private(set) var resetCount = 0
+    var onReset: ((TestResponder) -> Void)?
+
+    init(_ name: String) {
+        self.name = name
+        super.init()
+    }
+
+    override func resetGesture() {
+        resetCount += 1
+        onReset?(self)
+    }
+}
+
+private final class TestContentPathObserver: ContentPathObserver {
+    private(set) var changeCount = 0
+    let onChange: (ViewResponder) -> Void
+
+    init(onChange: @escaping (ViewResponder) -> Void = { _ in }) {
+        self.onChange = onChange
+    }
+
+    func respondersDidChange(for parent: ViewResponder) {
+        changeCount += 1
+        onChange(parent)
+    }
+
+    func contentPathDidChange(
+        for parent: ViewResponder,
+        changes: ContentPathChanges,
+        transform: (old: ViewTransform, new: ViewTransform),
+        finished: inout Bool
+    ) {}
+}
+
+private final class TestEventGraphHost: ViewGraphDelegate, EventGraphHost {
+    let graph: ViewGraph
+    let eventBindingManager = EventBindingManager()
+
+    init(graph: ViewGraph) {
+        self.graph = graph
+        eventBindingManager.host = self
+    }
+
+    func `as`<T>(_ type: T.Type) -> T? { self as? T }
+
+    func updateViewGraph<T>(body: (ViewGraph) -> T) -> T { body(graph) }
+
+    func requestUpdate(after: Double) {}
+
+    func graphDidChange() {}
+
+    func preferencesDidChange() {}
+
+    var responderNode: ResponderNode? { nil }
+
+    var focusedResponder: ResponderNode? { nil }
+
+    var nextGestureUpdateTime: Time { .infinity }
+
+    func setInheritedPhase(_ phase: _GestureInputs.InheritedPhase) {}
+
+    func sendEvents(
+        _ events: [EventID: any EventType],
+        rootNode: ResponderNode,
+        at time: Time
+    ) -> GesturePhase<Void> { .failed }
+
+    func resetEvents() {}
+
+    func gestureCategory() -> GestureCategory? { nil }
+}


### PR DESCRIPTION
## Summary

- Implement child insertion, reordering, and removal while preserving parent ownership.
- Notify content path observers only when the child list changes.
- Add regression coverage for unchanged assignments, child updates, removal callback order, reparenting, and clearing.

## Stack

Depends on #1058.
