### PR TITLE
fix(event): set visionOS hit-testing defaults

### DIFF
--- a/Sources/OpenSwiftUICore/Event/Responder/ViewResponder.swift
+++ b/Sources/OpenSwiftUICore/Event/Responder/ViewResponder.swift
@@ -116,7 +116,13 @@ open class ViewResponder: ResponderNode, CustomStringConvertible, CustomRecursiv
 
         package static let uncached: ContainsPointsOptions = .init(rawValue: 1 << 5)
 
-        public static var platformDefault: ContainsPointsOptions { [] }
+        public static var platformDefault: ContainsPointsOptions {
+            #if os(visionOS)
+            [.useZDistanceAsPriority, .disablePointCloudHitTesting]
+            #else
+            []
+            #endif
+        }
     }
 
     public struct ContainsPointsResult {


### PR DESCRIPTION
## Summary

- Use Z-distance priority and disable point-cloud hit testing by default on visionOS.
- Keep the default options empty on other platforms.

## Stack

Depends on #1059.
