### PR TITLE
fix(event): align gesture debug logging

### DIFF
--- a/Sources/OpenSwiftUICore/Event/Gesture/GestureDebug.swift
+++ b/Sources/OpenSwiftUICore/Event/Gesture/GestureDebug.swift
@@ -3,7 +3,7 @@
 //  OpenSwiftUICore
 //
 //  Audited for 6.5.4
-//  Status: WIP
+//  Status: Complete
 //  ID: 40D5679141F478561068F8E300838A67 (SwiftUICore)
 
 package import Foundation
@@ -259,7 +259,7 @@ extension GesturePhase {
     }
 }
 
-// MARK: - GestureDebug.Data + printTree [TBA]
+// MARK: - GestureDebug.Data + printTree
 
 extension GestureDebug.Data {
     package func printTree() {
@@ -322,7 +322,6 @@ extension GestureDebug.Data {
             line += " [\(items.joined(separator: ", "))]"
         }
         Log.eventDebug(line)
-
         let childIndent = Indent(indent.childText, kind: kind)
         for child in children {
             child.printSubtree(parent: self, indent: childIndent)

--- a/Sources/OpenSwiftUICore/Log/Logging.swift
+++ b/Sources/OpenSwiftUICore/Log/Logging.swift
@@ -141,10 +141,18 @@ package enum Log {
     }
 
     package static func eventDebug(_ message: String) {
+        #if OPENSWIFTUI_SUPPORT_2025_API
+        #if OPENSWIFTUI_SWIFT_LOG
+        events.log("\(message)")
+        #else
+        os_log(log: events, "\(message)")
+        #endif
+        #else
         #if OPENSWIFTUI_SWIFT_LOG
         eventDebuggingLog.log("\(message)")
         #else
         os_log(log: eventDebuggingLog, "\(message)")
+        #endif
         #endif
     }
     
@@ -215,12 +223,19 @@ package enum Log {
 
     @usableFromInline
     package static var eventDebuggingLog: Logger = Logger(subsystem: "org.OpenSwiftUIProject.diagnostics.events", category: "OpenSwiftUI")
+
+    // Added in v7 to replace eventDebuggingLog
+    package static var events: Logger = Logger(subsystem: subsystem, category: "Events")
     #else
     @usableFromInline
     package static var internalErrorsLog: OSLog = OSLog(subsystem: subsystem, category: "OpenSwiftUI")
 
     @usableFromInline
     package static var eventDebuggingLog: OSLog = OSLog(subsystem: "com.apple.diagnostics.events", category: "OpenSwiftUI")
+
+    // Added in v7 to replace eventDebuggingLog
+    @usableFromInline
+    package static var events: OSLog = OSLog(subsystem: subsystem, category: "Events")
     #endif
     
     package static let archiving: Logger = Logger(subsystem: subsystem, category: "Archiving")

--- a/Tests/OpenSwiftUICoreTests/Event/Gesture/GestureDebugTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Event/Gesture/GestureDebugTests.swift
@@ -242,7 +242,11 @@ struct GestureDebugLogTests {
                 $0 as? OSLogEntryLog
             }
             .filter {
+                #if OPENSWIFTUI_SUPPORT_2025_API
+                $0.subsystem == "org.OpenSwiftUIProject.OpenSwiftUI" && $0.category == "Events"
+                #else
                 $0.subsystem == "com.apple.diagnostics.events" && $0.category == "OpenSwiftUI"
+                #endif
             }
             .reversed()
             .prefix(count)

--- a/Tests/OpenSwiftUICoreTests/Event/Gesture/GestureDebugTests.swift
+++ b/Tests/OpenSwiftUICoreTests/Event/Gesture/GestureDebugTests.swift
@@ -5,15 +5,15 @@
 
 import Foundation
 import OpenAttributeGraphShims
-#if !OPENSWIFTUI_SWIFT_LOG
-import OSLog
-#endif
 @_spi(ForOpenSwiftUIOnly)
 @testable
 #if OPENSWIFTUI_ENABLE_PRIVATE_IMPORTS
 @_private(sourceFile: "GestureDebug.swift")
 #endif
 import OpenSwiftUICore
+#if !OPENSWIFTUI_SWIFT_LOG
+import OSLog
+#endif
 import Testing
 
 #if arch(x86_64)
@@ -33,6 +33,8 @@ private let printTreeCases: [PrintTreeCase] = [
     .emptyRoot,
     .combinerWithSameFrameChild,
     .primitiveWithFrameDeltaChildren,
+    .nestedKindsWithSiblings,
+    .heapBackedChildrenAndProperties,
 ]
 
 private extension PrintTreeCase {
@@ -147,6 +149,58 @@ private extension PrintTreeCase {
                 "EmptyGesture<Void> (failed) {(3.0, 4.0)} @(1.0, 2.0)",
                 "EmptyGesture<Void> (active) {(5.0, 6.0)}",
                 ".(EmptyGesture<Void>) (ended) @(7.0, 8.0)",
+            ]
+        )
+    }
+
+    static var nestedKindsWithSiblings: PrintTreeCase {
+        let leaf = makeData(kind: .empty, phase: .possible(nil))
+        let modifier = makeData(
+            kind: .modifier,
+            children: GestureDebug.Data.Children(leaf),
+            phase: .ended(())
+        )
+        let gesture = makeData(
+            kind: .gesture,
+            children: GestureDebug.Data.Children(modifier, makeData(phase: .active(()))),
+            phase: .possible(())
+        )
+        let root = makeData(
+            kind: .combiner,
+            children: GestureDebug.Data.Children(gesture, makeData())
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "+ EmptyGesture<Void> (failed)",
+                "| + EmptyGesture<Void> (possible(some))",
+                "| | * .(EmptyGesture<Void>) (ended)",
+                "| | * (empty) ()",
+                "| | * EmptyGesture<Void> (active)",
+                "| + EmptyGesture<Void> (failed)",
+            ]
+        )
+    }
+
+    static var heapBackedChildrenAndProperties: PrintTreeCase {
+        var children = GestureDebug.Data.Children()
+        children.append(makeData(phase: .possible(nil), resetSeed: 7))
+        children.append(makeData(phase: .active(()), resetSeed: 0))
+        children.append(makeData(phase: .ended(()), resetSeed: .max))
+
+        var properties = GestureDebug.Properties()
+        properties.append(("zeta", "last"))
+        properties.append(("alpha", "first"))
+        properties.append(("middle", "second"))
+
+        let root = makeData(children: children, resetSeed: 7, properties: properties)
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "EmptyGesture<Void> (failed) reset:7 [zeta: last, alpha: first, middle: second]",
+                "EmptyGesture<Void> ()",
+                "EmptyGesture<Void> (active)",
+                "EmptyGesture<Void> (ended) reset:4294967295",
             ]
         )
     }

--- a/Tests/OpenSwiftUISymbolDualTests/Event/Gesture/GestureDebugDualTests.swift
+++ b/Tests/OpenSwiftUISymbolDualTests/Event/Gesture/GestureDebugDualTests.swift
@@ -4,9 +4,9 @@
 
 #if canImport(SwiftUI, _underlyingVersion: 6.5.4)
 import Foundation
-import OSLog
 @_spi(ForOpenSwiftUIOnly)
 import OpenSwiftUICore
+import OSLog
 import Testing
 
 extension GestureDebug.Data {
@@ -31,6 +31,8 @@ private let printTreeCases: [PrintTreeCase] = [
     .emptyRoot,
     .combinerWithSameFrameChild,
     .primitiveWithFrameDeltaChildren,
+    .nestedKindsWithSiblings,
+    .heapBackedChildrenAndProperties,
 ]
 
 private extension PrintTreeCase {
@@ -148,6 +150,58 @@ private extension PrintTreeCase {
             ]
         )
     }
+
+    static var nestedKindsWithSiblings: PrintTreeCase {
+        let leaf = makeData(kind: .empty, phase: .possible(nil))
+        let modifier = makeData(
+            kind: .modifier,
+            children: GestureDebug.Data.Children(leaf),
+            phase: .ended(())
+        )
+        let gesture = makeData(
+            kind: .gesture,
+            children: GestureDebug.Data.Children(modifier, makeData(phase: .active(()))),
+            phase: .possible(())
+        )
+        let root = makeData(
+            kind: .combiner,
+            children: GestureDebug.Data.Children(gesture, makeData())
+        )
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "+ EmptyGesture<Void> (failed)",
+                "| + EmptyGesture<Void> (possible(some))",
+                "| | * .(EmptyGesture<Void>) (ended)",
+                "| | * (empty) ()",
+                "| | * EmptyGesture<Void> (active)",
+                "| + EmptyGesture<Void> (failed)",
+            ]
+        )
+    }
+
+    static var heapBackedChildrenAndProperties: PrintTreeCase {
+        var children = GestureDebug.Data.Children()
+        children.append(makeData(phase: .possible(nil), resetSeed: 7))
+        children.append(makeData(phase: .active(()), resetSeed: 0))
+        children.append(makeData(phase: .ended(()), resetSeed: .max))
+
+        var properties = GestureDebug.Properties()
+        properties.append(("zeta", "last"))
+        properties.append(("alpha", "first"))
+        properties.append(("middle", "second"))
+
+        let root = makeData(children: children, resetSeed: 7, properties: properties)
+        return PrintTreeCase(
+            root: root,
+            expected: [
+                "EmptyGesture<Void> (failed) reset:7 [zeta: last, alpha: first, middle: second]",
+                "EmptyGesture<Void> ()",
+                "EmptyGesture<Void> (active)",
+                "EmptyGesture<Void> (ended) reset:4294967295",
+            ]
+        )
+    }
 }
 
 private func makeData(
@@ -176,7 +230,7 @@ private func makeData(
 struct GestureDebugDualTests {
     // NOTE: entry.date has some range diff. So we can't use $0.date > date. Use count instead.
     @available(iOS 15, macOS 12, *)
-    private func getLogEntries(count: Int) throws -> [String] {
+    private func getLogEntries(count: Int, isOpenSwiftUI: Bool) throws -> [String] {
         let store = try OSLogStore(scope: .currentProcessIdentifier)
         let entries = try store
             .getEntries() // NOTE: options and position are not respected consistently.
@@ -185,7 +239,13 @@ struct GestureDebugDualTests {
                 $0 as? OSLogEntryLog
             }
             .filter {
-                $0.subsystem == "com.apple.diagnostics.events" && $0.category == "SwiftUI"
+                if isOpenSwiftUI {
+                    ($0.subsystem == "com.apple.diagnostics.events" && $0.category == "OpenSwiftUI")
+                    || ($0.subsystem == "org.OpenSwiftUIProject.OpenSwiftUI" && $0.category == "Events")
+                } else {
+                    ($0.subsystem == "com.apple.diagnostics.events" && $0.category == "SwiftUI")
+                    || ($0.subsystem == "com.apple.SwiftUI" && $0.category == "Events")
+                }
             }
             .reversed()
             .prefix(count)
@@ -196,9 +256,12 @@ struct GestureDebugDualTests {
     @available(iOS 15, macOS 12, *)
     @Test(arguments: printTreeCases)
     func printTreeAcceptsOpenSwiftUIGestureDebugData(_ testCase: PrintTreeCase) throws {
+        testCase.root.printTree()
+        let openSwiftUILogs = try getLogEntries(count: testCase.expected.count, isOpenSwiftUI: true)
         testCase.root.swiftUI_printTree()
-        let logs = try getLogEntries(count: testCase.expected.count)
-        #expect(logs == testCase.expected)
+        let swiftUILogs = try getLogEntries(count: testCase.expected.count, isOpenSwiftUI: false)
+        #expect(openSwiftUILogs == swiftUILogs)
+        #expect(swiftUILogs == testCase.expected)
     }
 }
 #endif

--- a/Tests/OpenSwiftUISymbolDualTests/Event/Gesture/GestureDebugDualTests.swift
+++ b/Tests/OpenSwiftUISymbolDualTests/Event/Gesture/GestureDebugDualTests.swift
@@ -240,11 +240,17 @@ struct GestureDebugDualTests {
             }
             .filter {
                 if isOpenSwiftUI {
-                    ($0.subsystem == "com.apple.diagnostics.events" && $0.category == "OpenSwiftUI")
-                    || ($0.subsystem == "org.OpenSwiftUIProject.OpenSwiftUI" && $0.category == "Events")
+                    #if OPENSWIFTUI_SUPPORT_2025_API
+                    $0.subsystem == "org.OpenSwiftUIProject.OpenSwiftUI" && $0.category == "Events"
+                    #else
+                    $0.subsystem == "com.apple.diagnostics.events" && $0.category == "OpenSwiftUI"
+                    #endif
                 } else {
-                    ($0.subsystem == "com.apple.diagnostics.events" && $0.category == "SwiftUI")
-                    || ($0.subsystem == "com.apple.SwiftUI" && $0.category == "Events")
+                    if #available(iOS 26, macOS 26, *) {
+                        $0.subsystem == "com.apple.SwiftUI" && $0.category == "Events"
+                    } else {
+                        $0.subsystem == "com.apple.diagnostics.events" && $0.category == "SwiftUI"
+                    }
                 }
             }
             .reversed()


### PR DESCRIPTION
## Summary

- Route gesture event logs through the Events category for the 2025 API configuration and preserve legacy routing for earlier configurations.
- Select log filters from the OpenSwiftUI API configuration and SwiftUI runtime version when comparing formatted tree output.
- Expand regression coverage for mixed node kinds, sibling indentation, larger collections, property order, and reset seeds.
